### PR TITLE
[강현구-240806] merge :: 소셜로그인/마이페이지 구현 등

### DIFF
--- a/src/main/java/com/multi/toonGather/config/MybatisConfig.java
+++ b/src/main/java/com/multi/toonGather/config/MybatisConfig.java
@@ -66,6 +66,9 @@ public class MybatisConfig {
         configuration.getTypeAliasRegistry().registerAlias("MyWtCommentDTO", com.multi.toonGather.user.model.dto.MyWtCommentDTO.class);
         configuration.getTypeAliasRegistry().registerAlias("MyRctApplicationDTO", com.multi.toonGather.user.model.dto.MyRctApplicationDTO.class);
         configuration.getTypeAliasRegistry().registerAlias("MyRctFreeDTO", com.multi.toonGather.user.model.dto.MyRctFreeDTO.class);
+        configuration.getTypeAliasRegistry().registerAlias("MyRctCreatorDTO", com.multi.toonGather.user.model.dto.MyRctCreatorDTO.class);
+        configuration.getTypeAliasRegistry().registerAlias("MyRctOrderDTO", com.multi.toonGather.user.model.dto.MyRctOrderDTO.class);
+        configuration.getTypeAliasRegistry().registerAlias("MyInMerchanDTO", com.multi.toonGather.user.model.dto.MyInMerchanDTO.class);
 
         seb.setConfiguration(configuration);
 

--- a/src/main/java/com/multi/toonGather/config/SecurityConfig.java
+++ b/src/main/java/com/multi/toonGather/config/SecurityConfig.java
@@ -3,9 +3,7 @@ package com.multi.toonGather.config;
 import com.multi.toonGather.security.CustomUserDetailsService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.authentication.dao.DaoAuthenticationProvider;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
@@ -25,6 +23,7 @@ public class SecurityConfig {
         this.customUserDetailsService = customUserDetailsService;
     }
 
+
     @Bean
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
@@ -38,12 +37,12 @@ public class SecurityConfig {
         return authProvider;
     }
 
-    @Bean
-    public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
-        AuthenticationManagerBuilder auth = http.getSharedObject(AuthenticationManagerBuilder.class);
-        auth.authenticationProvider(authenticationProvider());
-        return auth.build();
-    }
+//    @Bean
+//    public AuthenticationManager authenticationManager(HttpSecurity http) throws Exception {
+//        AuthenticationManagerBuilder auth = http.getSharedObject(AuthenticationManagerBuilder.class);
+//        auth.authenticationProvider(authenticationProvider());
+//        return auth.build();
+//    }
     ////////////////////////////////////////////////////////////////////////////////////////////////
 
     @Bean

--- a/src/main/java/com/multi/toonGather/user/controller/AuthController.java
+++ b/src/main/java/com/multi/toonGather/user/controller/AuthController.java
@@ -1,0 +1,275 @@
+package com.multi.toonGather.user.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.multi.toonGather.security.CustomUserDetails;
+import com.multi.toonGather.security.CustomUserDetailsService;
+import com.multi.toonGather.user.model.OAuthToken;
+import com.multi.toonGather.user.model.dto.UserDTO;
+import com.multi.toonGather.user.service.UserService;
+import jakarta.servlet.http.HttpSession;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Controller;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.client.RestTemplate;
+
+import java.time.format.DateTimeFormatter;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("/user/auth")
+public class AuthController {
+
+    private final UserService userService;
+    private final CustomUserDetailsService customUserDetailsService;
+//    private final AuthenticationManager authenticationManager;
+
+    @GetMapping("/naver/callback")
+    public String naverCallback(@RequestParam("code") String code, HttpSession session) throws Exception {
+        // step1 ) 코드받기
+//        return "네이버 인증 완료, 코드값: "+code;
+        // step2 ) 토큰받아보기
+        RestTemplate rt = new RestTemplate();
+        // HTTP POST를 요청할 때 보내는 데이터(body)를 설명해주는 헤더도 같이 만들어 보내야 한다??
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // body 데이터를 담은 오브젝트인 MultiValueMap
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", "74obWxfUMfykv5opH_Xw");
+        params.add("client_secret", "6dw_twkFfT");
+        params.add("code", code);
+        params.add("state", "test");
+
+        //요청하기 위해 헤더와 데이터(body)를 합친다.
+        //kakaoTokenRequest는 데이터(body)와 헤더를 entity가 된다(?뭔솔)
+        HttpEntity<MultiValueMap<String, String>> naverTokenRequest = new HttpEntity<>(params, headers);
+
+        //POST방식으로 Http요청, 그리고 response로 응답땡겨받기
+        ResponseEntity<String> response = rt.exchange(
+                "https://nid.naver.com/oauth2.0/token",
+                HttpMethod.POST,
+                naverTokenRequest,
+                String.class
+        );
+//        return "네이버 토큰요청완료 : 토큰요청에 대한 응답: " +response;
+//step 3) Accesstoken 전달하기
+        ObjectMapper objectMapper = new ObjectMapper();
+        OAuthToken oauthToken = null;   //model에 만들어놓은거
+        try {
+            oauthToken = objectMapper.readValue(response.getBody(), OAuthToken.class);
+        } catch(JsonMappingException e) {
+            e.printStackTrace();
+        } catch(JsonProcessingException e) {
+            e.printStackTrace();
+        }
+        System.out.println("네이버 액세스 토큰: "+oauthToken.getAccess_token());
+
+        //HTTP요청 한번더 고고
+        RestTemplate rt2 = new RestTemplate();
+        // HTTP POST를 요청할 때 보내는 데이터(body)를 설명해주는 헤더도 같이 만들어 보내야 한다??
+        HttpHeaders headers2 = new HttpHeaders();
+        headers2.add("authorization", "Bearer "+oauthToken.getAccess_token());
+        headers2.add("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // body 데이터를 담은 오브젝트인 MultiValueMap (생략)
+
+        //요청하기 위해 헤더와 데이터(body)를 합친다.
+        //kakaoTokenRequest는 데이터(body)와 헤더를 entity가 된다(?뭔솔)
+        HttpEntity<MultiValueMap<String, String>> kakaoProfileRequest2 = new HttpEntity<>(headers2);
+
+        //POST방식으로 Http요청, 그리고 response로 응답땡겨받기
+        ResponseEntity<String> response2 = rt2.exchange(
+                "https://openapi.naver.com/v1/nid/me",
+                HttpMethod.POST,
+                kakaoProfileRequest2,
+                String.class
+        );
+
+//        System.out.println("response2.getBody() 내가확인하믄되나?: " +response2);
+//        return response2.getBody();
+
+        //step 4) UserController로 넘기기
+        String naverUserJson = response2.getBody();
+        // 카카오 받아오기 (추후 분리예정)
+        UserDTO userDTO = new UserDTO();
+        if(naverUserJson != null){
+            try {
+                JsonNode naverUserNode = objectMapper.readTree(naverUserJson);
+                String naverId = naverUserNode.path("response").path("id").asText();
+                String naverNickname = naverUserNode.path("response").path("nickname").asText();
+                String naverGender = naverUserNode.path("response").path("gender").asText();
+
+
+                userDTO.setTypeCode('N');
+                userDTO.setAuthCode('B');
+                userDTO.setPassword("BASEDNAVERLOGINAPIS@");  //고민해보기1
+                userDTO.setEmail("BASEDNAVERLOGINAPIS@");     //고민해보기1
+                userDTO.setTermsAgreement(true);            //고민해보기2 추가수집?
+
+                //from naverapi
+                userDTO.setUserId("@"+naverId);
+                userDTO.setNickname("BASEDNAVERLOGINAPIS@" +naverNickname);
+                userDTO.setGender(naverGender.charAt(0));
+
+            } catch(JsonProcessingException e) {
+                e.printStackTrace();
+            }
+
+        } //naverUserJson != null
+        else return "redirect:/user/login";
+
+        // 유저로 등록된 적이 없으면 새로 등록.
+        if(userService.checkUserIdExists(userDTO.getUserId()) == 0) userService.insertUser(userDTO);
+
+        // 스프링 시큐리티 인증
+        System.out.println("[TEST] customUserDetailsService.loadUserByUsername(): "+customUserDetailsService.loadUserByUsername(userDTO.getUserId()).getPassword());
+
+        UserDetails customUserDetails = (CustomUserDetails) customUserDetailsService.loadUserByUsername(userDTO.getUserId());   //이거 왜 CustomUserDetails 안될까? 의문이당..
+
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+
+        System.out.println("[TEST2] authentication: " +authentication);
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        System.out.println("[TEST3] SecurityContextHolder.getContext(): " + SecurityContextHolder.getContext());
+
+        session.setAttribute("SPRING_SECURITY_CONTEXT", SecurityContextHolder.getContext());
+
+        return "redirect:/";
+
+    }
+    @GetMapping("/kakao/callback")
+    public String kakaoCallback(@RequestParam("code") String code, HttpSession session) throws Exception {
+        // step1 ) 코드받기
+//        return "카카오 인증 완료, 코드값: " +code;
+        // step2 ) 토큰받아보기
+        RestTemplate rt = new RestTemplate();
+        // HTTP POST를 요청할 때 보내는 데이터(body)를 설명해주는 헤더도 같이 만들어 보내야 한다??
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // body 데이터를 담은 오브젝트인 MultiValueMap
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", "87b870e71a148436e9f9c4a2aba3801d");
+        params.add("redirect_uri", "http://localhost:8099/user/auth/kakao/callback");
+        params.add("code", code);
+
+        //요청하기 위해 헤더와 데이터(body)를 합친다.
+        //kakaoTokenRequest는 데이터(body)와 헤더를 entity가 된다(?뭔솔)
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(params, headers);
+
+        //POST방식으로 Http요청, 그리고 response로 응답땡겨받기
+        ResponseEntity<String> response = rt.exchange(
+                "https://kauth.kakao.com/oauth/token",
+                HttpMethod.POST,
+                kakaoTokenRequest,
+                String.class
+        );
+//        return "카카오 토근요청완료 : 토큰요청에 대한 응답: " +response;
+
+        //step 3) Accesstoken 전달하기
+        ObjectMapper objectMapper = new ObjectMapper();
+        OAuthToken oauthToken = null;   //model에 만들어놓은거
+        try {
+            oauthToken = objectMapper.readValue(response.getBody(), OAuthToken.class);
+        } catch(JsonMappingException e) {
+            e.printStackTrace();
+        } catch(JsonProcessingException e) {
+            e.printStackTrace();
+        }
+        System.out.println("카카오 액세스 토큰: "+oauthToken.getAccess_token());
+
+        //HTTP요청 한번더 고고
+        RestTemplate rt2 = new RestTemplate();
+        // HTTP POST를 요청할 때 보내는 데이터(body)를 설명해주는 헤더도 같이 만들어 보내야 한다??
+        HttpHeaders headers2 = new HttpHeaders();
+        headers2.add("Authorization", "Bearer "+oauthToken.getAccess_token());
+        headers2.add("Content-Type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        // body 데이터를 담은 오브젝트인 MultiValueMap (생략)
+
+        //요청하기 위해 헤더와 데이터(body)를 합친다.
+        //kakaoTokenRequest는 데이터(body)와 헤더를 entity가 된다(?뭔솔)
+        HttpEntity<MultiValueMap<String, String>> kakaoProfileRequest2 = new HttpEntity<>(headers2);
+
+        //POST방식으로 Http요청, 그리고 response로 응답땡겨받기
+        ResponseEntity<String> response2 = rt2.exchange(
+                "https://kapi.kakao.com/v2/user/me",
+                HttpMethod.POST,
+                kakaoProfileRequest2,
+                String.class
+        );
+
+//        System.out.println("response2.getBody() 내가확인하믄되나?: " +response2.getBody());
+//        return response2.getBody();
+
+        //step 4) UserController로 넘기기
+        String kakaoUserJson = response2.getBody();
+        // 카카오 받아오기 (추후 분리예정)
+        UserDTO userDTO = new UserDTO();
+        if(kakaoUserJson != null){
+            try {
+                JsonNode kakaoUserNode = objectMapper.readTree(kakaoUserJson);
+                String kakaoId = kakaoUserNode.path("id").asText();
+                String kakaoNickname = kakaoUserNode.path("properties").path("nickname").asText();
+//                String kakaoConnectedAt = kakaoUserNode.path("connected_at").asText();
+
+                DateTimeFormatter formatter = DateTimeFormatter.ISO_DATE_TIME;
+//                LocalDateTime kakaoConnectedAtDateTime = LocalDateTime.parse(kakaoConnectedAt, formatter);
+
+                userDTO.setTypeCode('K');
+                userDTO.setAuthCode('B');
+                userDTO.setPassword("BASEDKAKAOLOGINAPIS@");  //고민해보기1
+                userDTO.setEmail("BASEDKAKAOLOGINAPIS@");     //고민해보기1
+                userDTO.setGender('P');                     //고민해보기2 추가수집해볼?
+                userDTO.setTermsAgreement(true);            //고민해보기2
+
+                //from kakaoapi
+                userDTO.setUserId("BASEDKAKAOLOGINAPIS@" +kakaoId);
+                userDTO.setNickname("BASEDKAKAOLOGINAPIS@" +kakaoNickname);
+
+            } catch(JsonProcessingException e) {
+                e.printStackTrace();
+            }
+
+        } //kakaoUserJson != null
+        else return "redirect:/user/login";
+
+        // 유저로 등록된 적이 없으면 새로 등록.
+        if(userService.checkUserIdExists(userDTO.getUserId()) == 0) userService.insertUser(userDTO);
+
+        // 스프링 시큐리티 인증
+        System.out.println("[TEST] customUserDetailsService.loadUserByUsername(): "+customUserDetailsService.loadUserByUsername(userDTO.getUserId()).getPassword());
+
+        UserDetails customUserDetails = (CustomUserDetails) customUserDetailsService.loadUserByUsername(userDTO.getUserId());   //이거 왜 CustomUserDetails 안될까? 의문이당..
+
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
+
+        System.out.println("[TEST2] authentication: " +authentication);
+
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        System.out.println("[TEST3] SecurityContextHolder.getContext(): " + SecurityContextHolder.getContext());
+
+        session.setAttribute("SPRING_SECURITY_CONTEXT", SecurityContextHolder.getContext());
+
+        return "redirect:/";
+    }
+}

--- a/src/main/java/com/multi/toonGather/user/controller/MyController.java
+++ b/src/main/java/com/multi/toonGather/user/controller/MyController.java
@@ -1,14 +1,18 @@
 package com.multi.toonGather.user.controller;
 
 import com.multi.toonGather.security.CustomUserDetails;
+import com.multi.toonGather.security.CustomUserDetailsService;
 import com.multi.toonGather.user.model.dto.*;
 import com.multi.toonGather.user.service.MyService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import java.util.List;
 
@@ -18,6 +22,7 @@ import java.util.List;
 public class MyController {
 
     private final MyService myService;
+    private final CustomUserDetailsService customUserDetailsService;
 
 //    //KHG20
 //    @RequestMapping("")
@@ -25,104 +30,189 @@ public class MyController {
 //        return "/user/mypage";
 //    }
 
-    //KHG20
+    //DEFAULT
     @GetMapping("")
-    public String myWtWebtoon(@AuthenticationPrincipal CustomUserDetails c, Model model) throws Exception {
+    public String redirectToMy() {
+        return "redirect:/user/my/wt/webtoon";
+    }
+
+    //KHG20
+    @GetMapping("/wt/webtoon")
+    public String myWtWebtoon(@RequestParam(value = "orderBy", defaultValue = "recent") String orderBy, @AuthenticationPrincipal CustomUserDetails c, Model model) throws Exception {
         int userNo = c.getUserDTO().getUserNo();
-        List<MyWtWebtoonDTO> myWtWebtoons = myService.getMyWtWebtoons(userNo);
+        List<MyWtWebtoonDTO> myWtWebtoons = myService.getMyWtWebtoons(userNo, orderBy);
 
         model.addAttribute("myWtWebtoons", myWtWebtoons);
+        model.addAttribute("orderBy", orderBy);
         return "/user/mypage_wt_webtoon";
     }
 
     //KHG20
     @GetMapping("/wt/comment")
-    public String myWtComment(@AuthenticationPrincipal CustomUserDetails c, Model model) throws Exception {
+    public String myWtComment(@RequestParam(value = "orderBy", defaultValue = "recent") String orderBy, @AuthenticationPrincipal CustomUserDetails c, Model model) throws Exception {
         int userNo = c.getUserDTO().getUserNo();
-        List<MyWtCommentDTO> myWtComments = myService.getMyWtComments(userNo);
+        List<MyWtCommentDTO> myWtComments = myService.getMyWtComments(userNo, orderBy);
 
         model.addAttribute("myWtComments", myWtComments);
+        model.addAttribute("orderBy", orderBy);
         return "/user/mypage_wt_comment";
     }
 
 
     //KHG30
     @GetMapping("/so/review")
-    public String mySoReview(@AuthenticationPrincipal CustomUserDetails c, Model model) throws Exception{
+    public String mySoReview(@RequestParam(value = "orderBy", defaultValue = "recent") String orderBy, @AuthenticationPrincipal CustomUserDetails c, Model model) throws Exception{
         int userNo = c.getUserDTO().getUserNo();
-        List<MySoReviewDTO> mySoReviews = myService.getMySoReviews(userNo);
+        List<MySoReviewDTO> mySoReviews = myService.getMySoReviews(userNo, orderBy);
 
         model.addAttribute("mySoReviews", mySoReviews);
+        model.addAttribute("orderBy", orderBy);
         return "/user/mypage_so_review";
     }
 
     //KHG31
     @GetMapping("/so/diary")
-    public String mySoDiary(@AuthenticationPrincipal CustomUserDetails c, Model model) throws Exception{
+    public String mySoDiary(@RequestParam(value = "orderBy", defaultValue = "recent") String orderBy, @AuthenticationPrincipal CustomUserDetails c, Model model) throws Exception{
         int userNo = c.getUserDTO().getUserNo();
-        List<MySoDiaryDTO> mySoDiaries = myService.getMySoDiaries(userNo);
+        List<MySoDiaryDTO> mySoDiaries = myService.getMySoDiaries(userNo, orderBy);
 
         model.addAttribute("mySoDiaries", mySoDiaries);
+        model.addAttribute("orderBy", orderBy);
         return "/user/mypage_so_diary";
     }
 
     //KHG40
     @GetMapping("/rct/job")
-    public String myRctJob(@AuthenticationPrincipal CustomUserDetails c, Model model) throws Exception{
+    public String myRctJob(@RequestParam(value = "orderBy", defaultValue = "recent") String orderBy, @RequestParam(value = "isToggled", defaultValue = "N") String toggle, @AuthenticationPrincipal CustomUserDetails c, Model model) throws Exception{
         int userNo = c.getUserDTO().getUserNo();
-        List<MyRctJobDTO> myRctJobs = myService.getMyRctJobs(userNo);
+        List<MyRctJobDTO> myRctJobs = myService.getMyRctJobs(userNo, toggle, orderBy);
 
         model.addAttribute("myRctJobs", myRctJobs);
+        model.addAttribute("isToggled", toggle);
+        model.addAttribute("orderBy", orderBy);
+
         return "/user/mypage_rct_job";
+    }
+
+    //KHG41
+    @GetMapping("/rct/job/apply")
+    public String myRctJobApplication(@RequestParam(value = "orderBy", defaultValue = "recent") String orderBy, @RequestParam(value = "isToggled", defaultValue = "N") String toggle, @RequestParam("boardNo") int boardNo, @AuthenticationPrincipal CustomUserDetails c, Model model) throws Exception{
+            List<MyRctApplicationDTO> myRctApplications = myService.getMyRctJobApplications(boardNo, toggle, orderBy);
+//        int userNo = c.getUserDTO().getUserNo();
+
+        model.addAttribute("myRctJobApplications", myRctApplications);
+        model.addAttribute("boardNo", boardNo);
+        model.addAttribute("isToggled", toggle);
+        model.addAttribute("orderBy", orderBy);
+
+        return "/user/mypage_rct_job_applicationlist";
+    }
+
+    //KHG43
+    @GetMapping("/rct/creator")
+    public String myRctCreator(@AuthenticationPrincipal CustomUserDetails c, Model model) throws Exception{
+
+        // 창작자 등록 후 세션 갱신을 하지 않았기 때문에
+        // 수정된 정보가 바로 반영이 안되었던 것
+        //
+        // 로그아웃하지 않아도 수정된 유저정보를 바로 확인하려면?
+        // [답] 세션을 갱신해야 한다
+        CustomUserDetails c2 = (CustomUserDetails)
+                customUserDetailsService.loadUserByUsername(c.getUserDTO().getUserId());
+
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(c2, null, c2.getAuthorities());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        int userNo = c.getUserDTO().getUserNo();
+        List<MyRctCreatorDTO> myRctCreators = myService.getMyRctCreators(userNo);
+
+        model.addAttribute("myRctCreators", myRctCreators);
+        model.addAttribute("auth_code", Character.toString(c.getUserDTO().getAuthCode()));
+        return "/user/mypage_rct_creator";
     }
 
     //KHG44
     @GetMapping("/rct/apply")
-    public String myRctApply(@AuthenticationPrincipal CustomUserDetails c, Model model) throws Exception{
+    public String myRctApplication(@RequestParam(value = "orderBy", defaultValue = "recent") String orderBy, @RequestParam(value = "isToggled", defaultValue = "N") String toggle, @AuthenticationPrincipal CustomUserDetails c, Model model) throws Exception{
         int userNo = c.getUserDTO().getUserNo();
-        List<MyRctApplicationDTO> myRctApplications = myService.getMyRctApplications(userNo);
+        List<MyRctApplicationDTO> myRctApplications = myService.getMyRctApplications(userNo, toggle, orderBy);
 
         model.addAttribute("myRctApplications", myRctApplications);
+        model.addAttribute("isToggled", toggle);
+        model.addAttribute("orderBy", orderBy);
+
         return "/user/mypage_rct_application";
     }
 
     //KHG45
     @GetMapping("/rct/free")
-    public String myRctFree(@AuthenticationPrincipal CustomUserDetails c, Model model) throws Exception{
+    public String myRctFree(@RequestParam(value = "orderBy", defaultValue = "recent") String orderBy, @AuthenticationPrincipal CustomUserDetails c, Model model) throws Exception{
         int userNo = c.getUserDTO().getUserNo();
-        List<MyRctFreeDTO> myRctFrees = myService.getMyRctFrees(userNo);
+        List<MyRctFreeDTO> myRctFrees = myService.getMyRctFrees(userNo, orderBy);
 
         model.addAttribute("myRctFrees", myRctFrees);
+        model.addAttribute("orderBy", orderBy);
         return "/user/mypage_rct_free";
+    }
+
+    //KHG46
+    @GetMapping("/rct/order")
+    public String myRctOrder(@RequestParam(value = "orderBy", defaultValue = "recent") String orderBy, @RequestParam(value = "isToggled", defaultValue = "N") String toggle, @AuthenticationPrincipal CustomUserDetails c, Model model) throws Exception{
+        int userNo = c.getUserDTO().getUserNo();
+        List<MyRctOrderDTO> myRctOrders = myService.getMyRctOrders(userNo, toggle, orderBy);
+
+        model.addAttribute("myRctOrders", myRctOrders);
+        model.addAttribute("isToggled", toggle);
+        model.addAttribute("orderBy", orderBy);
+
+        return "/user/mypage_rct_order";
     }
 
     //KHG50
     @GetMapping("/in/journal")
-    public String myInJournal(@AuthenticationPrincipal CustomUserDetails c, Model model) throws Exception{
+    public String myInJournal(@RequestParam(value = "orderBy", defaultValue = "recent") String orderBy, @AuthenticationPrincipal CustomUserDetails c, Model model) throws Exception{
         int userNo = c.getUserDTO().getUserNo();
-        List<MyInJournalDTO> myInJournals = myService.getMyInJournals(userNo);
+        List<MyInJournalDTO> myInJournals = myService.getMyInJournals(userNo, orderBy);
 
         model.addAttribute("myInJournals", myInJournals);
+        model.addAttribute("orderBy", orderBy);
         return "/user/mypage_in_journal";
     }
 
     //KHG51
     @GetMapping("/in/event")
-    public String myInEvent(@AuthenticationPrincipal CustomUserDetails c, Model model) throws Exception{
+    public String myInEvent(@RequestParam(value = "orderBy", defaultValue = "recent") String orderBy, @RequestParam(value = "isToggled", defaultValue = "N") String toggle, @AuthenticationPrincipal CustomUserDetails c, Model model) throws Exception{
         int userNo = c.getUserDTO().getUserNo();
-        List<MyInEventDTO> myInEvents = myService.getMyInEvents(userNo);
+        List<MyInEventDTO> myInEvents = myService.getMyInEvents(userNo, toggle, orderBy);
 
         model.addAttribute("myInEvents", myInEvents);
+        model.addAttribute("isToggled", toggle);
+        model.addAttribute("orderBy", orderBy);
+
         return "/user/mypage_in_event";
+    }
+
+    //KHG52
+    @GetMapping("/in/merchan")
+    public String myInMerchan(@RequestParam(value = "orderBy", defaultValue = "recent") String orderBy, @RequestParam(value = "isToggled", defaultValue = "N") String toggle, @AuthenticationPrincipal CustomUserDetails c, Model model) throws Exception{
+        int userNo = c.getUserDTO().getUserNo();
+        List<MyInMerchanDTO> myInMerchans = myService.getMyInMerchans(userNo, toggle, orderBy);
+
+        model.addAttribute("myInMerchans", myInMerchans);
+        model.addAttribute("isToggled", toggle);
+        model.addAttribute("orderBy", orderBy);
+        return "/user/mypage_in_merchan";
     }
 
     //KHG60
     @GetMapping("/cs")
-    public String myCs(@AuthenticationPrincipal CustomUserDetails c, Model model) throws Exception{
+    public String myCs(@RequestParam(value = "orderBy", defaultValue = "recent") String orderBy, @RequestParam(value = "isToggled", defaultValue = "N") String toggle, @AuthenticationPrincipal CustomUserDetails c, Model model) throws Exception{
         int userNo = c.getUserDTO().getUserNo();
-        List<MyCsQuestionDTO> myCsQuestions = myService.getMyCsQuestions(userNo);
+        List<MyCsQuestionDTO> myCsQuestions = myService.getMyCsQuestions(userNo, toggle, orderBy);
 
         model.addAttribute("myCsQuestions", myCsQuestions);
+        model.addAttribute("isToggled", toggle);
+        model.addAttribute("orderBy", orderBy);
         return "/user/mypage_cs";
     }
 }

--- a/src/main/java/com/multi/toonGather/user/model/OAuthToken.java
+++ b/src/main/java/com/multi/toonGather/user/model/OAuthToken.java
@@ -1,0 +1,13 @@
+package com.multi.toonGather.user.model;
+
+import lombok.Data;
+
+@Data
+public class OAuthToken {
+    private String access_token;
+    private String token_type;
+    private String refresh_token;
+    private int expires_in;
+    private String scope;
+    private int refresh_token_expires_in;
+}

--- a/src/main/java/com/multi/toonGather/user/model/dto/MyInMerchanDTO.java
+++ b/src/main/java/com/multi/toonGather/user/model/dto/MyInMerchanDTO.java
@@ -1,0 +1,27 @@
+package com.multi.toonGather.user.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MyInMerchanDTO {
+    private int likedNo;
+    private int merchanNo;
+    private int userNo;
+    private LocalDateTime likedDate;
+
+    private String title;
+    private int regularPrice;
+    private int discountPrice;
+    private int shippingCost;
+    private String merchanInfo;
+    private String content;
+    private LocalDateTime postingDate;
+}

--- a/src/main/java/com/multi/toonGather/user/model/dto/MyRctCreatorDTO.java
+++ b/src/main/java/com/multi/toonGather/user/model/dto/MyRctCreatorDTO.java
@@ -1,0 +1,21 @@
+package com.multi.toonGather.user.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MyRctCreatorDTO {
+    private int creatorNo;
+    private int memberNo;
+    private String content;
+    private String img;
+    private String registNo;
+    private char status;
+    private char typeCode;
+
+}

--- a/src/main/java/com/multi/toonGather/user/model/dto/MyRctFreeDTO.java
+++ b/src/main/java/com/multi/toonGather/user/model/dto/MyRctFreeDTO.java
@@ -20,4 +20,6 @@ public class MyRctFreeDTO {
     private int price;
     private LocalDateTime createdDate;
     private LocalDateTime modifiedDate;
+    private double averageRating;  // 평균 평점 추가
+    private int reviewCount;       // 리뷰 갯수 추가
 }

--- a/src/main/java/com/multi/toonGather/user/model/dto/MyRctOrderDTO.java
+++ b/src/main/java/com/multi/toonGather/user/model/dto/MyRctOrderDTO.java
@@ -1,0 +1,22 @@
+package com.multi.toonGather.user.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class MyRctOrderDTO {
+    private int orderNo;
+    private int memberNo;
+    private int boardNo;
+    private int quantity;
+    private int price;
+    private LocalDateTime orderedDate;
+    private char status;
+}

--- a/src/main/java/com/multi/toonGather/user/model/mapper/MyMapper.java
+++ b/src/main/java/com/multi/toonGather/user/model/mapper/MyMapper.java
@@ -9,14 +9,20 @@ import java.util.List;
 @Mapper
 public interface MyMapper {
 
-    List<MyCsQuestionDTO> selectListMyCsQuestion(@Param("userNo") int userNo) throws Exception;
-    List<MyInJournalDTO> selectListMyInJournal(@Param("userNo") int userNo) throws Exception;
-    List<MyRctJobDTO> selectListMyRctJob(@Param("userNo") int userNo) throws Exception;
-    List<MySoReviewDTO> selectListMySoReview(@Param("userNo") int userNo) throws Exception;
-    List<MySoDiaryDTO> selectListMySoDiary(@Param("userNo") int userNo) throws Exception;
-    List<MyInEventDTO> selectListMyInEvent(@Param("userNo") int userNo) throws Exception;
-    List<MyWtWebtoonDTO> selectListMyWtWebtoon(@Param("userNo") int userNo) throws Exception;
-    List<MyWtCommentDTO> selectListMyWtComment(@Param("userNo") int userNo) throws Exception;
-    List<MyRctApplicationDTO> selectListMyRctApplication(@Param("userNo") int userNo) throws Exception;
-    List<MyRctFreeDTO> selectListMyRctFree(@Param("userNo") int userNo) throws Exception;
+    List<MyCsQuestionDTO> selectListMyCsQuestion(@Param("userNo") int userNo, @Param("toggleValue") char toggleValue, @Param("orderBy") String orderBy) throws Exception;
+    List<MyInJournalDTO> selectListMyInJournal(@Param("userNo") int userNo, @Param("orderBy") String orderBy) throws Exception;
+    List<MyRctJobDTO> selectListMyRctJob(@Param("userNo") int userNo, @Param("toggleValue") char toggleValue, @Param("orderBy") String orderBy) throws Exception;
+    List<MySoReviewDTO> selectListMySoReview(@Param("userNo") int userNo, @Param("orderBy") String orderBy) throws Exception;
+    List<MySoDiaryDTO> selectListMySoDiary(@Param("userNo") int userNo, @Param("orderBy") String orderBy) throws Exception;
+    List<MyInEventDTO> selectListMyInEvent(@Param("userNo") int userNo, @Param("toggleValue") char toggleValue, @Param("orderBy") String orderBy) throws Exception;
+    List<MyWtWebtoonDTO> selectListMyWtWebtoon(@Param("userNo") int userNo, @Param("orderBy") String orderBy) throws Exception;
+    List<MyWtCommentDTO> selectListMyWtComment(@Param("userNo") int userNo, @Param("orderBy") String orderBy) throws Exception;
+    List<MyRctApplicationDTO> selectListMyRctApplication(@Param("userNo") int userNo, @Param("toggleValue") char toggleValue, @Param("orderBy") String orderBy) throws Exception;
+    List<MyRctFreeDTO> selectListMyRctFree(@Param("userNo") int userNo, @Param("orderBy") String orderBy) throws Exception;
+    List<MyRctCreatorDTO> selectListMyRctCreator(@Param("userNo") int userNo) throws Exception;
+    List<MyRctOrderDTO> selectListMyRctOrder(@Param("userNo") int userNo, @Param("toggleValue") char toggleValue, @Param("orderBy") String orderBy) throws Exception;
+
+    List<MyRctApplicationDTO> selectListMyRctJobApplication(@Param("boardNo") int boardNo, @Param("toggleValue") char toggleValue, @Param("orderBy") String orderBy) throws Exception;
+
+    List<MyInMerchanDTO> selectListMyInMerchan(@Param("userNo") int userNo, @Param("toggleValue") char toggleValue, @Param("orderBy") String orderBy) throws Exception;
 }

--- a/src/main/java/com/multi/toonGather/user/model/mapper/UserMapper.java
+++ b/src/main/java/com/multi/toonGather/user/model/mapper/UserMapper.java
@@ -1,8 +1,10 @@
 package com.multi.toonGather.user.model.mapper;
 
+import com.multi.toonGather.common.model.dto.PageDTO;
 import com.multi.toonGather.user.model.dto.UserDTO;
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
+import org.apache.ibatis.annotations.Select;
 
 import java.util.List;
 
@@ -17,10 +19,16 @@ public interface UserMapper {
     UserDTO selectOneByContactNumber(@Param("contactNumber") String contactNumber) throws Exception;
     UserDTO selectOneByUserIdAndEmail(@Param("userId") String userId, @Param("email") String email) throws Exception;
     UserDTO selectOneByUserNo(@Param("userNo") String userNo) throws Exception;
+    UserDTO selectOneByNickname(@Param("nickname") String nickname) throws Exception;
+    UserDTO selectOneByEmail(@Param("email") String email) throws Exception;
 
     int updateUser(@Param("userNo") int userNo, @Param("userDTO") UserDTO userDTO) throws Exception;
 
     int deleteUser(@Param("userNo") int userNo) throws Exception;
-    List<UserDTO> selectList() throws Exception;
+    List<UserDTO> selectList(PageDTO pageDTO) throws Exception;
+
+    //pagination 관련(XML 제외) (추후 옮겨야)
+    @Select("SELECT COUNT(*) FROM users")
+    int selectUserCount() throws Exception;
 
 }

--- a/src/main/java/com/multi/toonGather/user/service/MyService.java
+++ b/src/main/java/com/multi/toonGather/user/service/MyService.java
@@ -6,14 +6,20 @@ import java.util.List;
 
 public interface MyService {
 
-    List<MyCsQuestionDTO> getMyCsQuestions(int userNo) throws Exception;
-    List<MyInJournalDTO> getMyInJournals(int userNo) throws Exception;
-    List<MyRctJobDTO> getMyRctJobs(int userNo) throws Exception;
-    List<MySoReviewDTO> getMySoReviews(int userNo) throws Exception;
-    List<MySoDiaryDTO> getMySoDiaries(int userNo) throws Exception;
-    List<MyInEventDTO> getMyInEvents(int userNo) throws Exception;
-    List<MyWtWebtoonDTO> getMyWtWebtoons(int userNo) throws Exception;
-    List<MyWtCommentDTO> getMyWtComments(int userNo) throws Exception;
-    List<MyRctApplicationDTO> getMyRctApplications(int userNo) throws Exception;
-    List<MyRctFreeDTO> getMyRctFrees(int userNo) throws Exception;
+    List<MyCsQuestionDTO> getMyCsQuestions(int userNo, String toggle, String orderBy) throws Exception;
+    List<MyInJournalDTO> getMyInJournals(int userNo, String orderBy) throws Exception;
+    List<MyRctJobDTO> getMyRctJobs(int userNo, String toggle, String orderBy) throws Exception;
+    List<MySoReviewDTO> getMySoReviews(int userNo, String orderBy) throws Exception;
+    List<MySoDiaryDTO> getMySoDiaries(int userNo, String orderBy) throws Exception;
+    List<MyInEventDTO> getMyInEvents(int userNo, String toggle, String orderBy) throws Exception;
+    List<MyWtWebtoonDTO> getMyWtWebtoons(int userNo, String orderBy) throws Exception;
+    List<MyWtCommentDTO> getMyWtComments(int userNo, String orderBy) throws Exception;
+    List<MyRctApplicationDTO> getMyRctApplications(int userNo, String toggle, String orderBy) throws Exception;
+    List<MyRctFreeDTO> getMyRctFrees(int userNo, String orderBy) throws Exception;
+    List<MyRctCreatorDTO> getMyRctCreators(int userNo) throws Exception;
+    List<MyRctOrderDTO> getMyRctOrders(int userNo, String toggle, String orderBy) throws Exception;
+
+    List<MyRctApplicationDTO> getMyRctJobApplications(int boardNo, String toggle, String orderBy) throws Exception;
+
+    List<MyInMerchanDTO> getMyInMerchans(int userNo, String toggle, String orderBy) throws Exception;
 }

--- a/src/main/java/com/multi/toonGather/user/service/MyServiceImpl.java
+++ b/src/main/java/com/multi/toonGather/user/service/MyServiceImpl.java
@@ -12,52 +12,86 @@ import java.util.List;
 public class MyServiceImpl implements MyService {
     private final MyMapper myMapper;
 
-    public List<MyCsQuestionDTO> getMyCsQuestions(int userNo) throws Exception {
-        List<MyCsQuestionDTO> response = myMapper.selectListMyCsQuestion(userNo);
+    public List<MyCsQuestionDTO> getMyCsQuestions(int userNo, String toggle, String orderBy) throws Exception {
+        char toggleValue = toggle.charAt(0);
+        System.out.println("[MyService.getMyCsQuestions] toggleValue: "+ toggleValue);
+        List<MyCsQuestionDTO> response = myMapper.selectListMyCsQuestion(userNo, toggleValue, orderBy);
         return response;
     }
-    public List<MyInJournalDTO> getMyInJournals(int userNo) throws Exception {
-        List<MyInJournalDTO> response = myMapper.selectListMyInJournal(userNo);
-        return response;
-    }
-
-    public List<MyRctJobDTO> getMyRctJobs(int userNo) throws Exception {
-        List<MyRctJobDTO> response = myMapper.selectListMyRctJob(userNo);
+    public List<MyInJournalDTO> getMyInJournals(int userNo, String orderBy) throws Exception {
+        List<MyInJournalDTO> response = myMapper.selectListMyInJournal(userNo, orderBy);
         return response;
     }
 
-    public List<MySoReviewDTO> getMySoReviews(int userNo) throws Exception {
-        List<MySoReviewDTO> response = myMapper.selectListMySoReview(userNo);
+    public List<MyRctJobDTO> getMyRctJobs(int userNo, String toggle, String orderBy) throws Exception {
+        char toggleValue = toggle.charAt(0);
+        System.out.println("[MyService.getMyRctJobs] toggleValue: "+ toggleValue);
+        List<MyRctJobDTO> response = myMapper.selectListMyRctJob(userNo, toggleValue, orderBy);
         return response;
     }
 
-    public List<MySoDiaryDTO> getMySoDiaries(int userNo) throws Exception {
-        List<MySoDiaryDTO> response = myMapper.selectListMySoDiary(userNo);
+    public List<MySoReviewDTO> getMySoReviews(int userNo, String orderBy) throws Exception {
+        List<MySoReviewDTO> response = myMapper.selectListMySoReview(userNo, orderBy);
         return response;
     }
 
-    public List<MyInEventDTO> getMyInEvents(int userNo) throws Exception {
-        List<MyInEventDTO> response = myMapper.selectListMyInEvent(userNo);
+    public List<MySoDiaryDTO> getMySoDiaries(int userNo, String orderBy) throws Exception {
+        List<MySoDiaryDTO> response = myMapper.selectListMySoDiary(userNo, orderBy);
         return response;
     }
 
-    public List<MyWtWebtoonDTO> getMyWtWebtoons(int userNo) throws Exception {
-        List<MyWtWebtoonDTO> response = myMapper.selectListMyWtWebtoon(userNo);
+    public List<MyInEventDTO> getMyInEvents(int userNo, String toggle, String orderBy) throws Exception {
+        char toggleValue = toggle.charAt(0);
+        System.out.println("[MyService.getMyInEvents] toggleValue: "+ toggleValue);
+        List<MyInEventDTO> response = myMapper.selectListMyInEvent(userNo, toggleValue, orderBy);
         return response;
     }
 
-    public List<MyWtCommentDTO> getMyWtComments(int userNo) throws Exception {
-        List<MyWtCommentDTO> response = myMapper.selectListMyWtComment(userNo);
+    public List<MyWtWebtoonDTO> getMyWtWebtoons(int userNo, String orderBy) throws Exception {
+        List<MyWtWebtoonDTO> response = myMapper.selectListMyWtWebtoon(userNo, orderBy);
         return response;
     }
 
-    public List<MyRctApplicationDTO> getMyRctApplications(int userNo) throws Exception {
-        List<MyRctApplicationDTO> response = myMapper.selectListMyRctApplication(userNo);
+    public List<MyWtCommentDTO> getMyWtComments(int userNo, String orderBy) throws Exception {
+        List<MyWtCommentDTO> response = myMapper.selectListMyWtComment(userNo, orderBy);
         return response;
     }
 
-    public List<MyRctFreeDTO> getMyRctFrees(int userNo) throws Exception {
-        List<MyRctFreeDTO> response = myMapper.selectListMyRctFree(userNo);
+    public List<MyRctApplicationDTO> getMyRctApplications(int userNo, String toggle, String orderBy) throws Exception {
+        char toggleValue = toggle.charAt(0);
+        System.out.println("[MyService.getMyRctApplications] toggleValue: "+ toggleValue);
+        List<MyRctApplicationDTO> response = myMapper.selectListMyRctApplication(userNo, toggleValue, orderBy);
+        return response;
+    }
+
+    public List<MyRctFreeDTO> getMyRctFrees(int userNo, String orderBy) throws Exception {
+        List<MyRctFreeDTO> response = myMapper.selectListMyRctFree(userNo, orderBy);
+        return response;
+    }
+
+    public List<MyRctCreatorDTO> getMyRctCreators(int userNo) throws Exception {
+        List<MyRctCreatorDTO> response = myMapper.selectListMyRctCreator(userNo);
+        return response;
+    }
+
+    public List<MyRctOrderDTO> getMyRctOrders(int userNo, String toggle, String orderBy) throws Exception {
+        char toggleValue = toggle.charAt(0);
+        System.out.println("[MyService.getMyRctOrders] toggleValue: "+ toggleValue);
+        List<MyRctOrderDTO> response = myMapper.selectListMyRctOrder(userNo, toggleValue, orderBy);
+        return response;
+    }
+
+    public List<MyRctApplicationDTO> getMyRctJobApplications(int boardNo, String toggle, String orderBy) throws Exception {
+        char toggleValue = toggle.charAt(0);
+        System.out.println("[MyService.getMyRctJobApplications] toggleValue: "+ toggleValue);
+        List<MyRctApplicationDTO> response = myMapper.selectListMyRctJobApplication(boardNo, toggleValue, orderBy);
+        return response;
+    }
+
+    public List<MyInMerchanDTO> getMyInMerchans(int userNo, String toggle, String orderBy) throws Exception {
+        char toggleValue = toggle.charAt(0);
+        System.out.println("[MyService.getMyInMerchans] toggleValue: "+ toggleValue);
+        List<MyInMerchanDTO> response = myMapper.selectListMyInMerchan(userNo, toggleValue, orderBy);
         return response;
     }
 

--- a/src/main/java/com/multi/toonGather/user/service/UserService.java
+++ b/src/main/java/com/multi/toonGather/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.multi.toonGather.user.service;
 
+import com.multi.toonGather.common.model.dto.PageDTO;
 import com.multi.toonGather.user.model.dto.UserDTO;
 import jakarta.servlet.http.HttpServletRequest;
 import org.springframework.web.multipart.MultipartFile;
@@ -15,5 +16,14 @@ public interface UserService {
     void updateProfile(int userNo, UserDTO userDTO, MultipartFile image, HttpServletRequest request) throws Exception;
     void updateProfileAdmin(int userNo, UserDTO userDTO, MultipartFile image, HttpServletRequest request) throws Exception;
     void deleteProfile(int userNo) throws Exception;
-    List<UserDTO> getUsers() throws Exception;
+    List<UserDTO> getUsers(PageDTO pageDTO) throws Exception;
+
+    int checkUserIdExists(String userId) throws Exception;
+    int checkNicknameExists(String nickname) throws Exception;
+    int checkEmailExists(String email) throws Exception;
+
+
+
+    //pagination 관련(추후 옮겨야)
+    int selectUserCount(PageDTO pageDTO) throws Exception;
 }

--- a/src/main/resources/mappers/user/MyMapper.xml
+++ b/src/main/resources/mappers/user/MyMapper.xml
@@ -26,9 +26,35 @@
         cs_q_view_count AS csQViewCount,
         created_date AS createdDate,
         modified_date AS modifiedDate
-        FROM cs_question
-        WHERE cs_q_writer_no = #{userNo}
+        FROM
+        cs_question
+        WHERE
+        cs_q_writer_no = #{userNo}
+        <if test="toggleValue == 'Y'">
+            AND cs_q_status_code = 'S'
+        </if>
+        <choose>
+            <when test="orderBy == 'recentedited'">
+                ORDER BY modified_date DESC
+            </when>
+            <when test="orderBy == 'recent'">
+                ORDER BY cs_q_no DESC
+            </when>
+            <when test="orderBy == 'oldest'">
+                ORDER BY cs_q_no ASC
+            </when>
+            <when test="orderBy == 'views'">
+                ORDER BY cs_q_view_count DESC
+            </when>
+            <when test="orderBy == 'title'">
+                ORDER BY cs_q_title ASC
+            </when>
+            <otherwise>
+                ORDER BY modified_date DESC
+            </otherwise>
+        </choose>
     </select>
+
 
     <resultMap type="MyInJournalDTO" id="MyInJournalResultMap">
         <!-- in_journal_like 테이블의 컬럼 -->
@@ -52,7 +78,6 @@
         ij.title AS title,
         ij.content AS content,
         ij.posting_date AS postingDate
-
         FROM
         in_journal ij
         INNER JOIN
@@ -61,7 +86,28 @@
         ij.journal_no = ijl.journal_no
         WHERE
         ijl.user_no = #{userNo}
+        <choose>
+            <when test="orderBy == 'recentliked'">
+                ORDER BY ijl.liked_no DESC
+            </when>
+            <when test="orderBy == 'oldestliked'">
+                ORDER BY ijl.liked_no ASC
+            </when>
+            <when test="orderBy == 'recent'">
+                ORDER BY ij.journal_no DESC
+            </when>
+            <when test="orderBy == 'oldest'">
+                ORDER BY ij.journal_no ASC
+            </when>
+            <when test="orderBy == 'title'">
+                ORDER BY ij.title ASC
+            </when>
+            <otherwise>
+                ORDER BY ijl.liked_no DESC
+            </otherwise>
+        </choose>
     </select>
+
 
     <resultMap type="MyRctJobDTO" id="MyRctJobResultMap">
         <id property="boardNo" column="board_no" />
@@ -90,7 +136,31 @@
         rct_job
         WHERE
         writer = #{userNo}
+        <if test="toggleValue == 'Y'">
+            AND dead_line &lt; NOW()
+        </if>
+        <choose>
+            <when test="orderBy == 'recentedited'">
+                ORDER BY modified_date DESC
+            </when>
+            <when test="orderBy == 'recent'">
+                ORDER BY board_no DESC
+            </when>
+            <when test="orderBy == 'oldest'">
+                ORDER BY board_no ASC
+            </when>
+            <when test="orderBy == 'dueSoon'">
+                ORDER BY dead_line ASC
+            </when>
+            <when test="orderBy == 'title'">
+                ORDER BY title ASC
+            </when>
+            <otherwise>
+                ORDER BY modified_date DESC
+            </otherwise>
+        </choose>
     </select>
+
 
     <resultMap type="MySoReviewDTO" id="MySoReviewResultMap">
         <id property="likeNo" column="like_no" />
@@ -129,7 +199,37 @@
         sr.writer_no = srl.liked_user
         WHERE
         srl.liked_user = #{userNo}
+        <choose>
+            <when test="orderBy == 'recentliked'">
+                ORDER BY srl.like_no DESC
+            </when>
+            <when test="orderBy == 'oldestliked'">
+                ORDER BY srl.like_no ASC
+            </when>
+            <when test="orderBy == 'recentadded'">
+                ORDER BY sr.created_date DESC
+            </when>
+            <when test="orderBy == 'oldestadded'">
+                ORDER BY sr.created_date ASC
+            </when>
+            <when test="orderBy == 'highrated'">
+                ORDER BY sr.star_rating DESC
+            </when>
+            <when test="orderBy == 'lowrated'">
+                ORDER BY sr.star_rating ASC
+            </when>
+            <when test="orderBy == 'views'">
+                ORDER BY sr.view_cnt DESC
+            </when>
+            <when test="orderBy == 'title'">
+                ORDER BY sr.title ASC
+            </when>
+            <otherwise>
+                ORDER BY srl.like_no DESC
+            </otherwise>
+        </choose>
     </select>
+
 
     <resultMap type="MySoDiaryDTO" id="MySoDiaryResultMap">
         <id property="commentNo" column="comment_no"/>
@@ -172,7 +272,31 @@
         sd.diary_no = sdc.diary_no
         WHERE
         sdc.commenter_no = #{userNo}
+        <choose>
+            <when test="orderBy == 'recentposted'">
+                ORDER BY sdc.comment_no DESC
+            </when>
+            <when test="orderBy == 'oldestposted'">
+                ORDER BY sdc.comment_no ASC
+            </when>
+            <when test="orderBy == 'recentadded'">
+                ORDER BY sdc.diary_no DESC
+            </when>
+            <when test="orderBy == 'oldestadded'">
+                ORDER BY sdc.diary_no ASC
+            </when>
+            <when test="orderBy == 'views'">
+                ORDER BY sd.view_cnt DESC
+            </when>
+            <when test="orderBy == 'title'">
+                ORDER BY sd.title ASC
+            </when>
+            <otherwise>
+                ORDER BY sdc.comment_no DESC
+            </otherwise>
+        </choose>
     </select>
+
 
     <resultMap type="MyInEventDTO" id="MyInEventResultMap">
         <!-- `in_event_like` 테이블의 컬럼들 -->
@@ -200,7 +324,6 @@
         iel.liked_no AS likedNo,
         iel.user_no AS userNo,
         iel.liked_date AS likedDate,
-
         ie.event_no AS eventNo,
         ie.title AS title,
         ie.event_category_code AS eventCategoryCode,
@@ -216,12 +339,34 @@
         FROM
         in_event ie
         INNER JOIN
-        in_event_like iel
-        ON
-        ie.event_no = iel.event_no
+        in_event_like iel ON ie.event_no = iel.event_no
         WHERE
         iel.user_no = #{userNo}
+        <if test="toggleValue == 'Y'">
+            AND end_date &gt; NOW()
+        </if>
+        <choose>
+            <when test="orderBy == 'recentliked'">
+                ORDER BY iel.liked_no DESC
+            </when>
+            <when test="orderBy == 'oldestliked'">
+                ORDER BY iel.liked_no ASC
+            </when>
+            <when test="orderBy == 'recent'">
+                ORDER BY ie.event_no DESC
+            </when>
+            <when test="orderBy == 'oldest'">
+                ORDER BY ie.event_no ASC
+            </when>
+            <when test="orderBy == 'title'">
+                ORDER BY ie.title ASC
+            </when>
+            <otherwise>
+                ORDER BY iel.liked_no DESC
+            </otherwise>
+        </choose>
     </select>
+
 
     <resultMap type="MyWtWebtoonDTO" id="MyWtWebtoonResultMap">
         <id property="saveNo" column="save_no"/>
@@ -260,6 +405,23 @@
         w.webtoon_no = wu.webtoon_no
         WHERE
         wu.user_no = #{userNo}
+        <choose>
+            <when test="orderBy == 'recent'">
+                ORDER BY wu.save_no DESC
+            </when>
+            <when test="orderBy == 'oldest'">
+                ORDER BY wu.save_no ASC
+            </when>
+            <when test="orderBy == 'views'">
+                ORDER BY w.count DESC
+            </when>
+            <when test="orderBy == 'title'">
+                ORDER BY w.webtoon_name ASC
+            </when>
+            <otherwise>
+                ORDER BY wu.save_no DESC
+            </otherwise>
+        </choose>
     </select>
 
     <resultMap type="MyWtCommentDTO" id="MyWtCommentResultMap">
@@ -304,8 +466,26 @@
         w.webtoon_no = c.webtoon_no
         WHERE
         c.user_no = #{userNo}
+        <choose>
+            <when test="orderBy == 'recent'">
+                ORDER BY c.comment_no DESC
+            </when>
+            <when test="orderBy == 'oldest'">
+                ORDER BY c.comment_no ASC
+            </when>
+            <when test="orderBy == 'views'">
+                ORDER BY w.count DESC
+            </when>
+            <when test="orderBy == 'likes'">
+                ORDER BY c.liked DESC
+            </when>
+            <otherwise>
+                ORDER BY c.comment_no DESC
+            </otherwise>
+        </choose>
     </select>
 
+<!--    MyRctApplicationDTO 클래스를 사용하는 경우가 2가지임을 체크하기 (1)내가지원한목록 (2)내가올린공고_지원서 시작-->
     <resultMap type="MyRctApplicationDTO" id="MyRctApplicationResultMap">
         <id property="applyNo" column="apply_no"/>
         <result property="boardNo" column="board_no"/>
@@ -353,7 +533,82 @@
         rj.board_no = rja.board_no
         WHERE
         rja.writer = #{userNo}
+        <if test="toggleValue == 'Y'">
+            AND rj.dead_line &lt; NOW()
+        </if>
+        <choose>
+            <when test="orderBy == 'recentApplication'">
+                ORDER BY rja.apply_no DESC
+            </when>
+            <when test="orderBy == 'oldestApplication'">
+                ORDER BY rja.apply_no ASC
+            </when>
+            <when test="orderBy == 'recentedited'">
+                ORDER BY rj.modified_date DESC
+            </when>
+            <when test="orderBy == 'recent'">
+                ORDER BY rja.board_no DESC
+            </when>
+            <when test="orderBy == 'oldest'">
+                ORDER BY rja.board_no ASC
+            </when>
+            <when test="orderBy == 'dueSoon'">
+                ORDER BY rj.dead_line ASC
+            </when>
+            <when test="orderBy == 'title'">
+                ORDER BY rj.title ASC
+            </when>
+            <otherwise>
+                ORDER BY rja.apply_no DESC
+            </otherwise>
+        </choose>
     </select>
+
+
+    <select id="selectListMyRctJobApplication" resultType="MyRctApplicationDTO">
+        SELECT
+        rja.apply_no AS applyNo,
+        rja.board_no AS boardNo,
+        rja.writer AS writer,
+        rja.title AS applyTitle,
+        rja.content AS applyContent,
+        rja.img AS applyImg,
+        rja.created_date AS applyCreatedDate,
+        rja.check_status AS applyCheckStatus,
+
+        rj.writer AS jobWriter,
+        rj.title AS jobTitle,
+        rj.content AS jobContent,
+        rj.location AS jobLocation,
+        rj.img AS jobImg,
+        rj.created_date AS jobCreatedDate,
+        rj.modified_date AS jobModifiedDate,
+        rj.dead_line AS jobDeadLine
+        FROM
+        rct_job rj
+        INNER JOIN
+        rct_job_apply rja
+        ON
+        rj.board_no = rja.board_no
+        WHERE
+        rja.board_no = #{boardNo}
+        <if test="toggleValue == 'Y'">
+            AND rja.check_status = false
+        </if>
+        <choose>
+            <when test="orderBy == 'recent'">
+                ORDER BY rja.apply_no DESC
+            </when>
+            <when test="orderBy == 'oldest'">
+                ORDER BY rja.apply_no ASC
+            </when>
+            <otherwise>
+                ORDER BY rja.apply_no DESC
+            </otherwise>
+        </choose>
+    </select>
+
+    <!--    MyRctApplicationDTO 클래스를 사용하는 경우가 2가지임을 체크하기 (1)내가지원한목록 (2)내가올린공고_지원서 끝-->
 
     <resultMap type="MyRctFreeDTO" id="MyRctFreeResultMap">
         <id property="boardNo" column="board_no"/>
@@ -364,21 +619,198 @@
         <result property="price" column="price"/>
         <result property="createdDate" column="created_date"/>
         <result property="modifiedDate" column="modified_date"/>
+
+        <result property="averageRating" column="average_rating"/>
+        <result property="reviewCount" column="review_count"/>
     </resultMap>
 
     <select id="selectListMyRctFree" resultType="MyRctFreeDTO">
         SELECT
-        board_no AS boardNo,
-        writer AS writer,
-        title AS title,
+        rf.board_no AS boardNo,
+        rf.writer,
+        rf.title,
+        rf.content,
+        rf.img,
+        rf.price,
+        rf.created_date AS createdDate,
+        rf.modified_date AS modifiedDate,
+        COALESCE(AVG(rfr.star_rating), 0.0) AS averageRating,
+        COALESCE(COUNT(rfr.review_no), 0) AS reviewCount
+        FROM
+        rct_free rf
+        LEFT JOIN
+        rct_free_review rfr
+        ON
+        rf.board_no = rfr.board_no
+        WHERE
+        rf.writer = #{userNo}
+        GROUP BY
+        rf.board_no, rf.writer, rf.title, rf.content, rf.img, rf.price, rf.created_date, rf.modified_date
+        <choose>
+            <when test="orderBy == 'recentedited'">
+                ORDER BY rf.modified_date DESC
+            </when>
+            <when test="orderBy == 'recent'">
+                ORDER BY rf.board_no DESC
+            </when>
+            <when test="orderBy == 'oldest'">
+                ORDER BY rf.board_no ASC
+            </when>
+            <when test="orderBy == 'topRated'">
+                ORDER BY averageRating DESC
+            </when>
+            <when test="orderBy == 'lowRated'">
+                ORDER BY averageRating ASC
+            </when>
+            <when test="orderBy == 'reviews'">
+                ORDER BY reviewCount DESC
+            </when>
+            <when test="orderBy == 'title'">
+                ORDER BY rf.title ASC
+            </when>
+            <otherwise>
+                ORDER BY rf.modified_date DESC
+            </otherwise>
+        </choose>
+
+    </select>
+
+    <resultMap type="MyRctCreatorDTO" id="MyRctCreatorResultMap">
+        <id property="creatorNo" column="creator_no"/>
+        <result property="memberNo" column="member_no"/>
+        <result property="content" column="content"/>
+        <result property="img" column="img"/>
+        <result property="registNo" column="regist_no"/>
+        <result property="status" column="status"/>
+        <result property="typeCode" column="type_code"/>
+    </resultMap>
+
+    <select id="selectListMyRctCreator" resultType="MyRctCreatorDTO">
+        SELECT
+        creator_no AS creatorNo,
+        member_no AS memberNo,
         content AS content,
         img AS img,
-        price AS price,
-        created_date AS createdDate,
-        modified_date AS modifiedDate
+        regist_no AS registNo,
+        status AS status,
+        type_code AS typeCode
         FROM
-        rct_free
+        rct_creator_regist
         WHERE
-        writer = #{userNo}
+        member_no = #{userNo}
     </select>
+
+    <resultMap type="MyRctOrderDTO" id="MyRctOrderResultMap">
+        <id property="orderNo" column="order_no"/>
+        <result property="memberNo" column="member_no"/>
+        <result property="boardNo" column="board_no"/>
+        <result property="quantity" column="quantity"/>
+        <result property="price" column="price"/>
+        <result property="orderedDate" column="ordered_date"/>
+        <result property="status" column="status"/>
+    </resultMap>
+
+    <select id="selectListMyRctOrder" resultType="MyRctOrderDTO">
+        SELECT
+        order_no AS orderNo,
+        member_no AS memberNo,
+        board_no AS boardNo,
+        quantity AS quantity,
+        price AS price,
+        ordered_date AS orderedDate,
+        status AS status
+        FROM
+        rct_free_pay
+        WHERE
+        member_no = #{userNo}
+        <if test="toggleValue == 'Y'">
+            AND status = 'C'
+        </if>
+        <choose>
+            <when test="orderBy == 'recent'">
+                ORDER BY order_no DESC
+            </when>
+            <when test="orderBy == 'oldest'">
+                ORDER BY order_no ASC
+            </when>
+            <when test="orderBy == 'expensive'">
+                ORDER BY price DESC
+            </when>
+            <when test="orderBy == 'cheap'">
+                ORDER BY price ASC
+            </when>
+            <otherwise>
+                ORDER BY order_no DESC
+            </otherwise>
+        </choose>
+    </select>
+
+
+    <resultMap type="MyInMerchanDTO" id="MyInMerchanResultMap">
+        <id property="likedNo" column="liked_no"/>
+        <result property="merchanNo" column="merchan_no"/>
+        <result property="userNo" column="user_no"/>
+        <result property="likedDate" column="liked_date"/>
+
+        <result property="title" column="title"/>
+        <result property="regularPrice" column="regular_price"/>
+        <result property="discountPrice" column="discount_price"/>
+        <result property="shippingCost" column="shipping_cost"/>
+        <result property="merchanInfo" column="merchan_info"/>
+        <result property="content" column="content"/>
+        <result property="postingDate" column="posting_date"/>
+    </resultMap>
+
+    <select id="selectListMyInMerchan" resultType="MyInMerchanDTO">
+        SELECT
+        iml.liked_no AS likedNo,
+        iml.merchan_no AS merchanNo,
+        iml.user_no AS userNo,
+        iml.liked_date AS likedDate,
+        im.title AS title,
+        im.regular_price AS regularPrice,
+        im.discount_price AS discountPrice,
+        im.shipping_cost AS shippingCost,
+        im.merchan_info AS merchanInfo,
+        im.content AS content,
+        im.posting_date AS postingDate
+        FROM
+        in_merchan im
+        INNER JOIN
+        in_merchan_like iml
+        ON
+        im.merchan_no = iml.merchan_no
+        WHERE
+        iml.user_no = #{userNo}
+        <if test="toggleValue == 'Y'">
+            AND im.discount_price > 1000
+        </if>
+        <choose>
+            <when test="orderBy == 'recentliked'">
+                ORDER BY iml.liked_no DESC
+            </when>
+            <when test="orderBy == 'oldestliked'">
+                ORDER BY iml.liked_no ASC
+            </when>
+            <when test="orderBy == 'recent'">
+                ORDER BY iml.merchan_no DESC
+            </when>
+            <when test="orderBy == 'oldest'">
+                ORDER BY iml.merchan_no ASC
+            </when>
+            <when test="orderBy == 'expensive'">
+                ORDER BY im.regular_price DESC
+            </when>
+            <when test="orderBy == 'cheap'">
+                ORDER BY im.regular_price ASC
+            </when>
+            <when test="orderBy == 'title'">
+                ORDER BY im.title ASC
+            </when>
+            <otherwise>
+                ORDER BY iml.liked_no DESC
+            </otherwise>
+        </choose>
+    </select>
+
 </mapper>

--- a/src/main/resources/mappers/user/UserMapper.xml
+++ b/src/main/resources/mappers/user/UserMapper.xml
@@ -56,6 +56,52 @@
         WHERE user_id = #{userId}
     </select>
 
+    <select id="selectOneByNickname" parameterType="string" resultType="userDTO">
+        SELECT
+        user_no AS userNo,
+        type_code AS typeCode,
+        auth_code AS authCode,
+        user_id AS userId,
+        password,
+        nickname,
+        contact_number AS contactNumber,
+        email,
+        profile_image_path AS profileImagePath,
+        bio,
+        gender,
+        date_of_birth AS dateOfBirth,
+        real_name AS realName,
+        terms_agreement AS termsAgreement,
+        terms_agreement_datetime AS termsAgreementDatetime,
+        registration_datetime AS registrationDatetime,
+        last_modified_datetime AS lastModifiedDatetime
+        FROM users
+        WHERE nickname = #{nickname}
+    </select>
+
+    <select id="selectOneByEmail" parameterType="string" resultType="userDTO">
+        SELECT
+        user_no AS userNo,
+        type_code AS typeCode,
+        auth_code AS authCode,
+        user_id AS userId,
+        password,
+        nickname,
+        contact_number AS contactNumber,
+        email,
+        profile_image_path AS profileImagePath,
+        bio,
+        gender,
+        date_of_birth AS dateOfBirth,
+        real_name AS realName,
+        terms_agreement AS termsAgreement,
+        terms_agreement_datetime AS termsAgreementDatetime,
+        registration_datetime AS registrationDatetime,
+        last_modified_datetime AS lastModifiedDatetime
+        FROM users
+        WHERE email = #{email}
+    </select>
+
     <insert id="insertUser">
         INSERT INTO users (
         type_code,
@@ -78,7 +124,7 @@
         )
 
         VALUES (
-        'G',
+        #{typeCode},
         'B',
         #{userId},
         #{password},
@@ -195,7 +241,7 @@
         WHERE user_no = #{userNo}
     </delete>
 
-    <select id="selectList" resultType="userDTO">
+    <select id="selectList" parameterType="pageDTO" resultType="userDTO">
         SELECT
         user_no AS userNo,
         type_code AS typeCode,
@@ -214,6 +260,10 @@
         registration_datetime AS registrationDatetime,
         last_modified_datetime AS lastModifiedDatetime
         FROM users
+        <if test="page != null">
+            ORDER BY user_no DESC
+            LIMIT #{start}, 10
+        </if>
     </select>
 
 </mapper>

--- a/src/main/resources/templates/user/admin/userdetails.html
+++ b/src/main/resources/templates/user/admin/userdetails.html
@@ -4,6 +4,20 @@
 <head>
     <title>KHG81: 회원관리상세</title>
     <meta charset="UTF-8">
+
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <!-- 폰트: 'Noto Sans KR' 사용 -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap">
+    <!-- 프로젝트 툰게더 전용 css 스타일 시트 -->
+    <link rel="stylesheet" th:href="@{/css/styles.css}">
+
+    <!-- jQuery library -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+
+    <!-- Latest compiled JavaScript -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+
     <style>
         .navbar {
           position: fixed;
@@ -100,48 +114,121 @@
 <body>
 
 <div th:replace="~{common/menubar}"></div>
-<div layout:fragment="content">
-    <nav class="navbar navbar-expand-md">
-        <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-            <li><a th:href="@{/user/admin/userlist}" class="nav-link px-2">회원 관리</a></li>
-            <li><a th:href="@{/user/my}" class="nav-link px-2">마이페이지(테스트용)</a></li>
-        </ul>
-    </nav>
+<style>
+    .jumbotron {
+    position : relative;
+    }
+    .jumbotron .row {
+    position : absolute;
+    width : 100%;
+    bottom: 0%;
+    }
+</style>
+<div class="jumbotron">
+    <div class="row">
+        <div class="col-md-3">
+            <h3>회원 관리</h3>
+        </div>
+        <div class="col-md-9">
+            <nav class="navbar navbar-expand-md">
+                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                    <li><a th:href="@{/user/my}" class="nav-link px-2">마이페이지(테스트용)</a></li>
+                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                </ul>
+            </nav>
+        </div>
+    </div>
 </div>
-<div>
-    <form th:action="@{/user/admin/updateuser(userNo=${user.userNo})}" th:object="${user}" method="post" enctype="multipart/form-data" onsubmit="validateForm(event)">
-        프로필 사진<br>
-        <img th:src="@{/uploadFiles/{fileName}(fileName=${user.profileImagePath})}" style="width: 100px; height: auto;"/><br>
-        <input type="file" name="image"><br>
-        권한 임의설정 :
-        <label>
-            <input type="radio" th:field="*{authCode}" value="A"/> 관리자
-        </label>
-        <label>
-            <input type="radio" th:field="*{authCode}" value="B"/> 일반회원
-        </label>
-        <label>
-            <input type="radio" th:field="*{authCode}" value="C"/> 창작자
-        </label><br>
-        아이디 : <input type="text" th:field="*{userId}" maxlength="20" minlength="4" readonly/> (중복불가)<br>
+<div class="row">
+    <aside class="col-md-3">
+        <div class="panel">
+            <ul class="list-group">
+                <li><a th:href="@{/user/admin/userlist}" class="nav-link px-2">회원 관리</a></li>
+            </ul>
+        </div>
+    </aside>
+    <script>
+        // nickname available check
+        function checkNicknameDuplicate() {
+            const nickname = document.getElementById('nickname').value;
 
-        닉네임 : <input type="text" th:field="*{nickname}" maxlength="20" minlength="4"/> (중복불가)<br>
-        연락처 : <input type="text" th:field="*{contactNumber}" oninput="autoFormatPhoneNumber(this)" placeholder="000-0000-0000"/><br>
-<!--        연락처 : <input type="text" th:field="*{contactNumber}"/><br>-->
-        성별 : <select th:field="*{gender}">
-        <option value="P">성별을 공개하지 않습니다
-        <option value="F">여
-        <option value="M">남</select><br>
-        생년월일 : <input type="text" th:field="*{dateOfBirth}" oninput="autoFormatDate(this)" placeholder="yyyy-mm-dd"/><br>
-        이메일 : <input type="text" th:field="*{email}"/> (중복불가)<br>
-        자기소개(선택사항) : <input type="text" th:field="*{bio}"/><br>
+            if(!nickname) {
+                alert('닉네임을 입력해 주세요.');
+                return;
+            }
 
-        <input type="submit">수정확인<br>
-    </form>
+            fetch(`/user/checkNicknameDuplicate?nickname=${encodeURIComponent(nickname)}`)
+                .then(response => response.json())
+                .then(data => {
+                    if (data.isDuplicate) alert('이미 사용 중인 닉네임입니다.');
+                    else alert('사용 가능한 닉네임입니다.');
+                })
+                .catch(error => {
+                    console.error('Error: ', error);
+                });
+        } //checkNicknameDuplicate()
 
-    <form th:action="@{/user/admin/deleteuser(userNo=${user.userNo})}" method="post">
-        <button type="submit">탈퇴하기(누르면 바로 삭제되니 조심!)</button>
-    </form>
+        // email available check
+        function checkEmailDuplicate() {
+            const email = document.getElementById('email').value;
+
+            if(!email) {
+                alert('이메일을 입력해 주세요.');
+                return;
+            }
+
+            fetch(`/user/checkEmailDuplicate?email=${encodeURIComponent(email)}`)
+                .then(response => response.json())
+                .then(data => {
+                    if (data.isDuplicate) alert('이미 등록된 이메일입니다.');
+                    else alert('등록 가능한 이메일입니다.');
+                })
+                .catch(error => {
+                    console.error('Error: ', error);
+                });
+        } //checkEmailDuplicate()
+    </script>
+    <div class="col-md-9">
+        <form th:action="@{/user/admin/updateuser(userNo=${user.userNo})}" th:object="${user}" method="post" enctype="multipart/form-data" onsubmit="validateForm(event)">
+            프로필 사진<br>
+            <img th:src="@{/uploadFiles/{fileName}(fileName=${user.profileImagePath})}" style="width: 100px; height: auto;"/><br>
+            <input type="file" name="image"><br>
+            권한 임의설정 :
+            <label>
+                <input type="radio" th:field="*{authCode}" value="A"/> 관리자
+            </label>
+            <label>
+                <input type="radio" th:field="*{authCode}" value="B"/> 일반회원
+            </label>
+            <label>
+                <input type="radio" th:field="*{authCode}" value="C"/> 창작자
+            </label><br>
+            아이디 : <input type="text" th:field="*{userId}" maxlength="20" minlength="4" readonly/><br>
+
+            닉네임 : <input type="text" th:field="*{nickname}" maxlength="20" minlength="4"/>
+            <button type="button" onclick="checkNicknameDuplicate()">중복확인</button>
+            <br>
+            연락처 : <input type="text" th:field="*{contactNumber}" oninput="autoFormatPhoneNumber(this)" placeholder="000-0000-0000"/><br>
+    <!--        연락처 : <input type="text" th:field="*{contactNumber}"/><br>-->
+            성별 : <select th:field="*{gender}">
+            <option value="P">성별을 공개하지 않습니다
+            <option value="F">여
+            <option value="M">남</select><br>
+            생년월일 : <input type="text" th:field="*{dateOfBirth}" oninput="autoFormatDate(this)" placeholder="yyyy-mm-dd"/><br>
+            이메일 : <input type="text" th:field="*{email}"/>
+            <button type="button" onclick="checkEmailDuplicate()">중복확인</button>
+            <br>
+            자기소개(선택사항) : <input type="text" th:field="*{bio}"/><br>
+
+            <input type="submit">수정확인<br>
+        </form>
+
+        <form th:action="@{/user/admin/deleteuser(userNo=${user.userNo})}" method="post">
+            <button type="submit">탈퇴하기(누르면 바로 삭제되니 조심!)</button>
+        </form>
+    </div>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/user/admin/userlist.html
+++ b/src/main/resources/templates/user/admin/userlist.html
@@ -4,6 +4,20 @@
 <head>
     <title>KHG80: 회원관리</title>
     <meta charset="UTF-8">
+
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <!-- 폰트: 'Noto Sans KR' 사용 -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap">
+    <!-- 프로젝트 툰게더 전용 css 스타일 시트 -->
+    <link rel="stylesheet" th:href="@{/css/styles.css}">
+
+    <!-- jQuery library -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+
+    <!-- Latest compiled JavaScript -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script>
         $(document).ready(function($) {
@@ -71,59 +85,136 @@
 <body>
 
 <div th:replace="~{common/menubar}"></div>
-<div layout:fragment="content">
-    <nav class="navbar navbar-expand-md">
-        <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-            <li><a th:href="@{/user/admin/userlist}" class="nav-link px-2">회원 관리</a></li>
-            <li><a th:href="@{/user/my}" class="nav-link px-2">마이페이지(테스트용)</a></li>
-        </ul>
-    </nav>
+<style>
+    .jumbotron {
+    position : relative;
+    }
+    .jumbotron .row {
+    position : absolute;
+    width : 100%;
+    bottom: 0%;
+    }
+</style>
+<div class="jumbotron">
+    <div class="row">
+        <div class="col-md-3">
+            <h3>회원 관리</h3>
+        </div>
+        <div class="col-md-9">
+            <nav class="navbar navbar-expand-md">
+                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                    <li><a th:href="@{/user/my}" class="nav-link px-2">마이페이지(테스트용)</a></li>
+                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                </ul>
+            </nav>
+        </div>
+    </div>
 </div>
-<div class="container">
-    <div class="review-list">
-        <h2>회원 목록</h2>
-        <table>
-            <thead>
-            <tr>
-                <th>회원번호</th>
-                <th>유형 코드</th>
-                <th>권한 코드</th>
-                <th>사용자 ID</th>
-                <th>닉네임</th>
-                <th>연락처</th>
-                <th>이메일</th>
-                <th>프로필 이미지 경로</th>
-                <th>소개</th>
-                <th>성별</th>
-                <th>생년월일</th>
-                <th>실명</th>
-                <th>약관 동의</th>
-                <th>약관 동의 시간</th>
-                <th>등록 시간</th>
-                <th>마지막 수정 시간</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr th:each="user : ${users}" class="clickable-row" th:attr="data-href=@{/user/admin/userdetails(userNo=${user.userNo})}">
-                <td th:text="${user.userNo}">회원번호</td>
-                <td th:text="${user.typeCode}">유형 코드</td>
-                <td th:text="${user.authCode}">권한 코드</td>
-                <td th:text="${user.userId}">사용자 ID</td>
-                <td th:text="${user.nickname}">닉네임</td>
-                <td th:text="${user.contactNumber}">연락처</td>
-                <td th:text="${user.email}">이메일</td>
-                <td th:text="${user.profileImagePath}">프로필 이미지 경로</td>
-                <td th:text="${user.bio}">소개</td>
-                <td th:text="${user.gender}">성별</td>
-                <td th:text="${user.dateOfBirth}">생년월일</td>
-                <td th:text="${user.realName}">실명</td>
-                <td th:text="${user.termsAgreement}">약관 동의</td>
-                <td th:text="${user.termsAgreementDatetime}">약관 동의 시간</td>
-                <td th:text="${user.registrationDatetime}">등록 시간</td>
-                <td th:text="${user.lastModifiedDatetime}">마지막 수정 시간</td>
-            </tr>
-            </tbody>
-        </table>
+<div class="row">
+    <aside class="col-md-3">
+        <div class="panel">
+            <ul class="list-group">
+                <li><a th:href="@{/user/admin/userlist}" class="nav-link px-2">회원 관리</a></li>
+            </ul>
+        </div>
+    </aside>
+    <script> // toggle + sorting
+        function updateCheckboxValueAndSubmit() {
+            const checkbox = document.getElementById('isToggledCheckbox');
+            const form = document.getElementById('filter-and-sort-form');
+            // 체크박스가 체크된 상태를 확인
+            checkbox.value = checkbox.checked ? 'Y' : 'N';
+            // 폼 제출
+            form.submit();
+        }
+
+        function submitForm() {
+            document.getElementById('filter-and-sort-form').submit();
+        }
+    </script>
+    <div class="col-md-9">
+        <div class="review-list">
+            <h2>회원 목록</h2>
+<!--            <form id="filter-and-sort-form" th:action="@{/user/admin/userlist(page=${page})}" method="get">-->
+<!--                <label>-->
+<!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">창작자-->
+<!--                </label>-->
+<!--                &lt;!&ndash; Hidden field for boardNo &ndash;&gt;-->
+<!--                <input type="hidden" name="page" th:value="${page}" />-->
+<!--                <label>-->
+<!--                    <select name="orderBy" onchange="submitForm()">-->
+<!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최근가입순</option>-->
+<!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
+<!--                        <option value="title" th:selected="${orderBy == 'title'}">닉네임가나다순</option>-->
+<!--                    </select>-->
+<!--                </label>-->
+<!--            </form>-->
+            <table>
+                <thead>
+                <tr>
+                    <th>회원번호</th>
+                    <th>유형 코드</th>
+                    <th>권한 코드</th>
+                    <th>사용자 ID</th>
+                    <th>닉네임</th>
+                    <th>연락처</th>
+                    <th>이메일</th>
+                    <th>프로필 이미지 경로</th>
+                    <th>소개</th>
+                    <th>성별</th>
+                    <th>생년월일</th>
+                    <th>실명</th>
+                    <th>약관 동의</th>
+                    <th>약관 동의 시간</th>
+                    <th>등록 시간</th>
+                    <th>마지막 수정 시간</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="user : ${users}" class="clickable-row" th:attr="data-href=@{/user/admin/userdetails(userNo=${user.userNo})}">
+                    <td th:text="${user.userNo}">회원번호</td>
+                    <td th:text="${user.typeCode}">유형 코드</td>
+                    <td th:text="${user.authCode}">권한 코드</td>
+                    <td th:text="${user.userId}">사용자 ID</td>
+                    <td th:text="${user.nickname}">닉네임</td>
+                    <td th:text="${user.contactNumber}">연락처</td>
+                    <td th:text="${user.email}">이메일</td>
+                    <td th:text="${user.profileImagePath}">프로필 이미지 경로</td>
+                    <td th:text="${user.bio}">소개</td>
+                    <td th:text="${user.gender}">성별</td>
+                    <td th:text="${user.dateOfBirth}">생년월일</td>
+                    <td th:text="${user.realName}">실명</td>
+                    <td th:text="${user.termsAgreement}">약관 동의</td>
+                    <td th:text="${user.termsAgreementDatetime}">약관 동의 시간</td>
+                    <td th:text="${user.registrationDatetime}">등록 시간</td>
+                    <td th:text="${user.lastModifiedDatetime}">마지막 수정 시간</td>
+                </tr>
+                </tbody>
+            </table>
+
+            <th:block th:if="${pages != null}">
+                <div class="d-flex justify-content-center">
+                    <div class="btn-group">
+                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/admin/userlist(page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                            </svg>
+                        </button>
+                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">
+                            <button type="button" class="btn btn-sm me-2 pages"
+                                    th:text="${p}" th:onclick="|location.href='@{/user/admin/userlist(page=${p})}'|"></button>
+                        </th:block>
+                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/admin/userlist(page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">
+                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                            </svg>
+                        </button>
+                    </div>
+                </div>
+            </th:block>
+        </div>
     </div>
 </div>
 </body>

--- a/src/main/resources/templates/user/findid.html
+++ b/src/main/resources/templates/user/findid.html
@@ -4,6 +4,20 @@
 <head>
     <title>KHG10: 아이디찾기</title>
     <meta charset="UTF-8">
+
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <!-- 폰트: 'Noto Sans KR' 사용 -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap">
+    <!-- 프로젝트 툰게더 전용 css 스타일 시트 -->
+    <link rel="stylesheet" th:href="@{/css/styles.css}">
+
+    <!-- jQuery library -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+
+    <!-- Latest compiled JavaScript -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+
     <style>
         .navbar {
           position: fixed;
@@ -56,36 +70,75 @@
 <body>
 
 <div th:replace="~{common/menubar}"></div>
-<div>
-    아이디 찾기<br>
+<style>
+    .jumbotron {
+    position : relative;
+    }
+    .jumbotron .row {
+    position : absolute;
+    width : 100%;
+    bottom: 0%;
+    }
+</style>
+<div class="jumbotron">
+    <div class="row">
+        <div class="col-md-3">
+            <h3>로그인</h3>
+        </div>
+        <div class="col-md-9">
+            <nav class="navbar navbar-expand-md">
+                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                    <li>-</li>
+                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                </ul>
+            </nav>
+        </div>
+    </div>
+</div>
+<div class="row">
+    <aside class="col-md-3">
+        <div class="panel">
+            <ul class="list-group">
+                <li><a th:href="@{/user/login}" class="nav-link px-2">로그인</a></li>
+                <li><a th:href="@{/user/signup}" class="nav-link px-2">회원가입</a></li>
+            </ul>
+        </div>
+    </aside>
+    <div class="col-md-9">
+        <div>
+            아이디 찾기<br>
 
-    <a href="#">아이디 찾기</a><br>
-    <a href="/user/findpw">비밀번호 찾기</a><br>
+            <a href="/user/findid">아이디 찾기</a><br>
+            <a href="/user/findpw">비밀번호 찾기</a><br>
 
 
-    <form th:action="@{/user/findid}" th:object="${user}" method="post" onsubmit="validateForm(event)">
-        이름*(닉네임으로 대체) : <input type="text" th:field="*{nickname}" maxlength="20" minlength="4"/> (중복불가)<br>
-        전화번호 : <input type="text" th:field="*{contactNumber}" oninput="autoFormatPhoneNumber(this)" placeholder="000-0000-0000"/><br>
+            <form th:action="@{/user/findid}" th:object="${user}" method="post" onsubmit="validateForm(event)">
+                이름*(닉네임으로 대체) : <input type="text" th:field="*{nickname}" maxlength="20" minlength="4"/> (중복불가)<br>
+                전화번호 : <input type="text" th:field="*{contactNumber}" oninput="autoFormatPhoneNumber(this)" placeholder="000-0000-0000"/><br>
 
-        <input type="submit">아이디 찾기
-    </form>
-    <!--    <form th:action="@{/user/signup}" th:object="${user}" method="post">-->
-    <!--        아이디 : <input type="text" name="userId"><br>-->
-    <!--        비밀번호 : <input type="password" name="password"><br>-->
-    <!--        비밀번호 확인 : <br>-->
-    <!--        닉네임 : <input type="text" name="nickname"><br>-->
-    <!--        연락처 : <input type="text" name="contactNumber"><br>-->
-    <!--        성별 : <select name="gender">-->
-    <!--        <option>성별을 공개하지 않습니다-->
-    <!--        <option>여-->
-    <!--        <option>남</select><br>-->
-    <!--        생년월일 : <input type="text" name="dateOfBirth"><br>-->
-    <!--        이메일 : <input type="text" name="email"><br>-->
-    <!--        자기소개(선택사항) : <input type="text" name="bio"><br>-->
-    <!--        <input type="checkbox" name="termsAgreement">본인은 툰게더 회원 약관에 동의합니다.<br>-->
+                <input type="submit">아이디 찾기
+            </form>
+            <!--    <form th:action="@{/user/signup}" th:object="${user}" method="post">-->
+            <!--        아이디 : <input type="text" name="userId"><br>-->
+            <!--        비밀번호 : <input type="password" name="password"><br>-->
+            <!--        비밀번호 확인 : <br>-->
+            <!--        닉네임 : <input type="text" name="nickname"><br>-->
+            <!--        연락처 : <input type="text" name="contactNumber"><br>-->
+            <!--        성별 : <select name="gender">-->
+            <!--        <option>성별을 공개하지 않습니다-->
+            <!--        <option>여-->
+            <!--        <option>남</select><br>-->
+            <!--        생년월일 : <input type="text" name="dateOfBirth"><br>-->
+            <!--        이메일 : <input type="text" name="email"><br>-->
+            <!--        자기소개(선택사항) : <input type="text" name="bio"><br>-->
+            <!--        <input type="checkbox" name="termsAgreement">본인은 툰게더 회원 약관에 동의합니다.<br>-->
 
-    <!--        <input type="submit">가입하기-->
-    <!--    </form>-->
+            <!--        <input type="submit">가입하기-->
+            <!--    </form>-->
+        </div>
+    </div>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/user/findpw.html
+++ b/src/main/resources/templates/user/findpw.html
@@ -1,9 +1,23 @@
 <!DOCTYPE html>
-        <html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.w3.org/1999/xhtml">
-        <html layout:decorate="~{layout}">
-        <head>
-        <title>KHG12: 비밀번호찾기</title>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.w3.org/1999/xhtml">
+<html layout:decorate="~{layout}">
+<head>
+    <title>KHG12: 비밀번호찾기</title>
     <meta charset="UTF-8">
+
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <!-- 폰트: 'Noto Sans KR' 사용 -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap">
+    <!-- 프로젝트 툰게더 전용 css 스타일 시트 -->
+    <link rel="stylesheet" th:href="@{/css/styles.css}">
+
+    <!-- jQuery library -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+
+    <!-- Latest compiled JavaScript -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+
     <style>
         .navbar {
           position: fixed;
@@ -38,36 +52,75 @@
 <body>
 
 <div th:replace="~{common/menubar}"></div>
-<div>
-    비밀번호 찾기<br>
+<style>
+    .jumbotron {
+    position : relative;
+    }
+    .jumbotron .row {
+    position : absolute;
+    width : 100%;
+    bottom: 0%;
+    }
+</style>
+<div class="jumbotron">
+    <div class="row">
+        <div class="col-md-3">
+            <h3>로그인</h3>
+        </div>
+        <div class="col-md-9">
+            <nav class="navbar navbar-expand-md">
+                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                    <li>-</li>
+                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                </ul>
+            </nav>
+        </div>
+    </div>
+</div>
+<div class="row">
+    <aside class="col-md-3">
+        <div class="panel">
+            <ul class="list-group">
+                <li><a th:href="@{/user/login}" class="nav-link px-2">로그인</a></li>
+                <li><a th:href="@{/user/signup}" class="nav-link px-2">회원가입</a></li>
+            </ul>
+        </div>
+    </aside>
+    <div class="col-md-9">
+        <div>
+            비밀번호 찾기<br>
 
-    <a href="/user/findid">아이디 찾기</a><br>
-    <a href="#">비밀번호 찾기</a><br>
+            <a href="/user/findid">아이디 찾기</a><br>
+            <a href="/user/findpw">비밀번호 찾기</a><br>
 
 
-    <form th:action="@{/user/findpw}" th:object="${user}" method="post" onsubmit="validateForm(event)">
-        아이디 : <input type="text" th:field="*{userId}" maxlength="20" minlength="4"/> (중복불가)<br>
-        이메일 : <input type="text" th:field="*{email}"/> (중복불가)<br>
+            <form th:action="@{/user/findpw}" th:object="${user}" method="post" onsubmit="validateForm(event)">
+                아이디 : <input type="text" th:field="*{userId}" maxlength="20" minlength="4"/> (중복불가)<br>
+                이메일 : <input type="text" th:field="*{email}"/> (중복불가)<br>
 
-        <input type="submit">비밀번호 찾기
-    </form>
-    <!--    <form th:action="@{/user/signup}" th:object="${user}" method="post">-->
-    <!--        아이디 : <input type="text" name="userId"><br>-->
-    <!--        비밀번호 : <input type="password" name="password"><br>-->
-    <!--        비밀번호 확인 : <br>-->
-    <!--        닉네임 : <input type="text" name="nickname"><br>-->
-    <!--        연락처 : <input type="text" name="contactNumber"><br>-->
-    <!--        성별 : <select name="gender">-->
-    <!--        <option>성별을 공개하지 않습니다-->
-    <!--        <option>여-->
-    <!--        <option>남</select><br>-->
-    <!--        생년월일 : <input type="text" name="dateOfBirth"><br>-->
-    <!--        이메일 : <input type="text" name="email"><br>-->
-    <!--        자기소개(선택사항) : <input type="text" name="bio"><br>-->
-    <!--        <input type="checkbox" name="termsAgreement">본인은 툰게더 회원 약관에 동의합니다.<br>-->
+                <input type="submit">비밀번호 찾기
+            </form>
+            <!--    <form th:action="@{/user/signup}" th:object="${user}" method="post">-->
+            <!--        아이디 : <input type="text" name="userId"><br>-->
+            <!--        비밀번호 : <input type="password" name="password"><br>-->
+            <!--        비밀번호 확인 : <br>-->
+            <!--        닉네임 : <input type="text" name="nickname"><br>-->
+            <!--        연락처 : <input type="text" name="contactNumber"><br>-->
+            <!--        성별 : <select name="gender">-->
+            <!--        <option>성별을 공개하지 않습니다-->
+            <!--        <option>여-->
+            <!--        <option>남</select><br>-->
+            <!--        생년월일 : <input type="text" name="dateOfBirth"><br>-->
+            <!--        이메일 : <input type="text" name="email"><br>-->
+            <!--        자기소개(선택사항) : <input type="text" name="bio"><br>-->
+            <!--        <input type="checkbox" name="termsAgreement">본인은 툰게더 회원 약관에 동의합니다.<br>-->
 
-    <!--        <input type="submit">가입하기-->
-    <!--    </form>-->
+            <!--        <input type="submit">가입하기-->
+            <!--    </form>-->
+        </div>
+    </div>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/user/idfound.html
+++ b/src/main/resources/templates/user/idfound.html
@@ -4,6 +4,20 @@
 <head>
     <title>KHG11: 아이디찾기 성공</title>
     <meta charset="UTF-8">
+
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <!-- 폰트: 'Noto Sans KR' 사용 -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap">
+    <!-- 프로젝트 툰게더 전용 css 스타일 시트 -->
+    <link rel="stylesheet" th:href="@{/css/styles.css}">
+
+    <!-- jQuery library -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+
+    <!-- Latest compiled JavaScript -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+
     <style>
         .navbar {
           position: fixed;
@@ -14,39 +28,78 @@
 <body>
 
 <div th:replace="~{common/menubar}"></div>
-<div>
-    아이디 찾기<br>
-
-    <a href="#">아이디 찾기</a><br>
-    <a href="/user/findpw">비밀번호 찾기</a><br>
-
-    <div th:if="${userId != null}">
-        찾으시는 아이디는<br>
-        <span th:text="${userId}"></span><br>
-        입니다.<br>
+<style>
+    .jumbotron {
+    position : relative;
+    }
+    .jumbotron .row {
+    position : absolute;
+    width : 100%;
+    bottom: 0%;
+    }
+</style>
+<div class="jumbotron">
+    <div class="row">
+        <div class="col-md-3">
+            <h3>로그인</h3>
+        </div>
+        <div class="col-md-9">
+            <nav class="navbar navbar-expand-md">
+                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                    <li>-</li>
+                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                </ul>
+            </nav>
+        </div>
     </div>
-    <div th:if="${userId == null}">
-        찾으시는 아이디가 존재하지 않습니다.<br>
+</div>
+<div class="row">
+    <aside class="col-md-3">
+        <div class="panel">
+            <ul class="list-group">
+                <li><a th:href="@{/user/login}" class="nav-link px-2">로그인</a></li>
+                <li><a th:href="@{/user/signup}" class="nav-link px-2">회원가입</a></li>
+            </ul>
+        </div>
+    </aside>
+    <div class="col-md-9">
+        <div>
+            아이디 찾기<br>
+
+            <a href="/user/findid">아이디 찾기</a><br>
+            <a href="/user/findpw">비밀번호 찾기</a><br>
+
+            <div th:if="${userId != null}">
+                찾으시는 아이디는<br>
+                <span th:text="${userId}"></span><br>
+                입니다.<br>
+            </div>
+            <div th:if="${userId == null}">
+                찾으시는 아이디가 존재하지 않습니다.<br>
+            </div>
+
+            <a href="/user/login">로그인</a>
+            <!--    <form th:action="@{/user/signup}" th:object="${user}" method="post">-->
+            <!--        아이디 : <input type="text" name="userId"><br>-->
+            <!--        비밀번호 : <input type="password" name="password"><br>-->
+            <!--        비밀번호 확인 : <br>-->
+            <!--        닉네임 : <input type="text" name="nickname"><br>-->
+            <!--        연락처 : <input type="text" name="contactNumber"><br>-->
+            <!--        성별 : <select name="gender">-->
+            <!--        <option>성별을 공개하지 않습니다-->
+            <!--        <option>여-->
+            <!--        <option>남</select><br>-->
+            <!--        생년월일 : <input type="text" name="dateOfBirth"><br>-->
+            <!--        이메일 : <input type="text" name="email"><br>-->
+            <!--        자기소개(선택사항) : <input type="text" name="bio"><br>-->
+            <!--        <input type="checkbox" name="termsAgreement">본인은 툰게더 회원 약관에 동의합니다.<br>-->
+
+            <!--        <input type="submit">가입하기-->
+            <!--    </form>-->
+        </div>
     </div>
-
-    <a href="/user/login">로그인</a>
-    <!--    <form th:action="@{/user/signup}" th:object="${user}" method="post">-->
-    <!--        아이디 : <input type="text" name="userId"><br>-->
-    <!--        비밀번호 : <input type="password" name="password"><br>-->
-    <!--        비밀번호 확인 : <br>-->
-    <!--        닉네임 : <input type="text" name="nickname"><br>-->
-    <!--        연락처 : <input type="text" name="contactNumber"><br>-->
-    <!--        성별 : <select name="gender">-->
-    <!--        <option>성별을 공개하지 않습니다-->
-    <!--        <option>여-->
-    <!--        <option>남</select><br>-->
-    <!--        생년월일 : <input type="text" name="dateOfBirth"><br>-->
-    <!--        이메일 : <input type="text" name="email"><br>-->
-    <!--        자기소개(선택사항) : <input type="text" name="bio"><br>-->
-    <!--        <input type="checkbox" name="termsAgreement">본인은 툰게더 회원 약관에 동의합니다.<br>-->
-
-    <!--        <input type="submit">가입하기-->
-    <!--    </form>-->
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/user/insert.html
+++ b/src/main/resources/templates/user/insert.html
@@ -4,6 +4,20 @@
 <head>
     <title>KHG02: 회원가입 완료</title>
     <meta charset="UTF-8">
+
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <!-- 폰트: 'Noto Sans KR' 사용 -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap">
+    <!-- 프로젝트 툰게더 전용 css 스타일 시트 -->
+    <link rel="stylesheet" th:href="@{/css/styles.css}">
+
+    <!-- jQuery library -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+
+    <!-- Latest compiled JavaScript -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+
     <style>
         .navbar {
           position: fixed;
@@ -13,11 +27,50 @@
 </head>
 <body>
 <div th:replace="~{common/menubar}"></div>
-<div layout:fragment="content">
-    회원가입 완료<br>
-    성공적으로 가입이 완료되었습니다.<br>
-    로그인하여 다양한 플랫폼을 누려 보세요!<br>
-    <a href="/user/login">툰게더 로그인하기</a>
+<style>
+    .jumbotron {
+    position : relative;
+    }
+    .jumbotron .row {
+    position : absolute;
+    width : 100%;
+    bottom: 0%;
+    }
+</style>
+<div class="jumbotron">
+    <div class="row">
+        <div class="col-md-3">
+            <h3>회원 가입</h3>
+        </div>
+        <div class="col-md-9">
+            <nav class="navbar navbar-expand-md">
+                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                    <li>-</li>
+                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                </ul>
+            </nav>
+        </div>
+    </div>
+</div>
+<div class="row">
+    <aside class="col-md-3">
+        <div class="panel">
+            <ul class="list-group">
+                <li><a th:href="@{/user/login}" class="nav-link px-2">로그인</a></li>
+                <li><a th:href="@{/user/signup}" class="nav-link px-2">회원가입</a></li>
+            </ul>
+        </div>
+    </aside>
+    <div class="col-md-9">
+        <div layout:fragment="content">
+            회원가입 완료<br>
+            성공적으로 가입이 완료되었습니다.<br>
+            로그인하여 다양한 플랫폼을 누려 보세요!<br>
+            <a href="/user/login">툰게더 로그인하기</a>
+        </div>
+    </div>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/user/login.html
+++ b/src/main/resources/templates/user/login.html
@@ -4,6 +4,20 @@
 <head>
     <title>KHG00: 로그인</title>
     <meta charset="UTF-8">
+
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <!-- 폰트: 'Noto Sans KR' 사용 -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap">
+    <!-- 프로젝트 툰게더 전용 css 스타일 시트 -->
+    <link rel="stylesheet" th:href="@{/css/styles.css}">
+
+    <!-- jQuery library -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+
+    <!-- Latest compiled JavaScript -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+
     <style>
         .navbar {
           position: fixed;
@@ -14,41 +28,80 @@
 <body>
 
 <div th:replace="~{common/menubar}"></div>
-<div>
-    로그인<br>
+<style>
+    .jumbotron {
+    position : relative;
+    }
+    .jumbotron .row {
+    position : absolute;
+    width : 100%;
+    bottom: 0%;
+    }
+</style>
+<div class="jumbotron">
+    <div class="row">
+        <div class="col-md-3">
+            <h3>로그인</h3>
+        </div>
+        <div class="col-md-9">
+            <nav class="navbar navbar-expand-md">
+                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                    <li>-</li>
+                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                </ul>
+            </nav>
+        </div>
+    </div>
+</div>
+<div class="row">
+    <aside class="col-md-3">
+        <div class="panel">
+            <ul class="list-group">
+                <li><a th:href="@{/user/login}" class="nav-link px-2">로그인</a></li>
+                <li><a th:href="@{/user/signup}" class="nav-link px-2">회원가입</a></li>
+            </ul>
+        </div>
+    </aside>
+    <div class="col-md-9">
+        <div>
+            로그인<br>
+            <a href="https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=74obWxfUMfykv5opH_Xw&redirect_uri=http://localhost:8099/user/auth/naver/callback&state=test">네이버로 시작하기</a><br>
+            <a href="https://kauth.kakao.com/oauth/authorize?client_id=87b870e71a148436e9f9c4a2aba3801d&redirect_uri=http://localhost:8099/user/auth/kakao/callback&response_type=code">카카오로 시작하기</a><br>
+            또는<br>
 
-    <a href="#">카카오로 시작하기</a><br>
-    또는<br>
+            <form th:action="@{/user/login}" method="post">
+                아이디 : <input type="text" name="username" maxlength="20" minlength="4"/> (중복불가)<br>
+                비밀번호 : <input type="password" name="password" maxlength="30" minlength="8"/><br>
+                <input type="submit">로그인<br>
+            </form>
+        <!--    <form th:action="@{/user/login}" th:object="${user}" method="post">-->
+        <!--        아이디 : <input type="text" th:field="*{userId}"/> (중복불가)<br>-->
+        <!--        비밀번호 : <input type="password" th:field="*{password}"/><br>-->
 
-    <form th:action="@{/user/login}" method="post">
-        아이디 : <input type="text" name="username" maxlength="20" minlength="4"/> (중복불가)<br>
-        비밀번호 : <input type="password" name="password" maxlength="30" minlength="8"/><br>
-        <input type="submit">로그인<br>
-    </form>
-<!--    <form th:action="@{/user/login}" th:object="${user}" method="post">-->
-<!--        아이디 : <input type="text" th:field="*{userId}"/> (중복불가)<br>-->
-<!--        비밀번호 : <input type="password" th:field="*{password}"/><br>-->
+        <!--        <input type="submit">로그인<br>-->
+        <!--    </form>-->
+            <a href="/user/signup">회원가입</a> | <a href="/user/findid">ID/PW 찾기</a>
+            <!--    <form th:action="@{/user/signup}" th:object="${user}" method="post">-->
+            <!--        아이디 : <input type="text" name="userId"><br>-->
+            <!--        비밀번호 : <input type="password" name="password"><br>-->
+            <!--        비밀번호 확인 : <br>-->
+            <!--        닉네임 : <input type="text" name="nickname"><br>-->
+            <!--        연락처 : <input type="text" name="contactNumber"><br>-->
+            <!--        성별 : <select name="gender">-->
+            <!--        <option>성별을 공개하지 않습니다-->
+            <!--        <option>여-->
+            <!--        <option>남</select><br>-->
+            <!--        생년월일 : <input type="text" name="dateOfBirth"><br>-->
+            <!--        이메일 : <input type="text" name="email"><br>-->
+            <!--        자기소개(선택사항) : <input type="text" name="bio"><br>-->
+            <!--        <input type="checkbox" name="termsAgreement">본인은 툰게더 회원 약관에 동의합니다.<br>-->
 
-<!--        <input type="submit">로그인<br>-->
-<!--    </form>-->
-    <a href="/user/signup">회원가입</a> | <a href="/user/findid">ID/PW 찾기</a>
-    <!--    <form th:action="@{/user/signup}" th:object="${user}" method="post">-->
-    <!--        아이디 : <input type="text" name="userId"><br>-->
-    <!--        비밀번호 : <input type="password" name="password"><br>-->
-    <!--        비밀번호 확인 : <br>-->
-    <!--        닉네임 : <input type="text" name="nickname"><br>-->
-    <!--        연락처 : <input type="text" name="contactNumber"><br>-->
-    <!--        성별 : <select name="gender">-->
-    <!--        <option>성별을 공개하지 않습니다-->
-    <!--        <option>여-->
-    <!--        <option>남</select><br>-->
-    <!--        생년월일 : <input type="text" name="dateOfBirth"><br>-->
-    <!--        이메일 : <input type="text" name="email"><br>-->
-    <!--        자기소개(선택사항) : <input type="text" name="bio"><br>-->
-    <!--        <input type="checkbox" name="termsAgreement">본인은 툰게더 회원 약관에 동의합니다.<br>-->
-
-    <!--        <input type="submit">가입하기-->
-    <!--    </form>-->
+            <!--        <input type="submit">가입하기-->
+            <!--    </form>-->
+        </div>
+    </div>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/user/mypage.html
+++ b/src/main/resources/templates/user/mypage.html
@@ -4,6 +4,21 @@
 <head>
     <title>마이페이지</title>
     <meta charset="UTF-8">
+
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <!-- 폰트: 'Noto Sans KR' 사용 -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap">
+    <!-- 프로젝트 툰게더 전용 css 스타일 시트 -->
+    <link rel="stylesheet" th:href="@{/css/styles.css}">
+
+    <!-- jQuery library -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+
+    <!-- Latest compiled JavaScript -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+
+
     <style>
         .navbar {
           position: fixed;
@@ -13,6 +28,10 @@
 </head>
 <body>
 <div th:replace="~{common/menubar}"></div>
+<div class="jumbotron">
+    <div class="container">
+    </div>
+</div>
 <div layout:fragment="content">
     <nav class="navbar navbar-expand-md">
         <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">

--- a/src/main/resources/templates/user/mypage_cs.html
+++ b/src/main/resources/templates/user/mypage_cs.html
@@ -4,6 +4,20 @@
 <head>
     <title>KHG60: 마이페이지-나의문의</title>
     <meta charset="UTF-8">
+
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <!-- 폰트: 'Noto Sans KR' 사용 -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap">
+    <!-- 프로젝트 툰게더 전용 css 스타일 시트 -->
+    <link rel="stylesheet" th:href="@{/css/styles.css}">
+
+    <!-- jQuery library -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+
+    <!-- Latest compiled JavaScript -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script>
         $(document).ready(function($) {
@@ -67,53 +81,127 @@
           z-index: 1000;
         }
     </style>
+
+
+
 </head>
 <body>
-
 <div th:replace="~{common/menubar}"></div>
-<div layout:fragment="content">
-    <nav class="navbar navbar-expand-md">
-        <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-            <li><a th:href="@{/user/my}" class="nav-link px-2">나의 웹툰</a></li>
-            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
-            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-        </ul>
-    </nav>
+<style>
+    .jumbotron {
+    position : relative;
+    }
+    .jumbotron .row {
+    position : absolute;
+    width : 100%;
+    bottom: 0%;
+    }
+</style>
+<div class="jumbotron">
+    <div class="row">
+        <div class="col-md-3">
+            <h3>나의 문의</h3>
+        </div>
+        <div class="col-md-9">
+            <nav class="navbar navbar-expand-md">
+                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                    <li>-</li>
+                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                </ul>
+            </nav>
+        </div>
+    </div>
 </div>
-<div class="container">
-    <div class="review-list">
-        <h2>나의 문의</h2>
-        <table>
-            <thead>
-            <tr>
-                <th>문의글 번호</th>
-                <th>문의글 제목</th>
-                <th>문의글 내용</th>
-                <th>문의글 작성자</th>
-                <th>문의 카테고리 코드</th>
-                <th>문의 상태 코드</th>
-                <th>문의글 조회수</th>
-                <th>문의 작성일자</th>
-                <th>문의 수정일자</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr th:each="myCsQuestion : ${myCsQuestions}" class="clickable-row" th:attr="data-href=@{/cs/questionDetail/{id}(id=${myCsQuestion.csQNo})}">
-                <td th:text="${myCsQuestion.csQNo}">문의글 번호</td>
-                <td th:text="${myCsQuestion.csQTitle}">문의글 제목</td>
-                <td th:text="${myCsQuestion.csQContent}">문의글 내용</td>
-                <td th:text="${myCsQuestion.csQWriterNo}">문의글 작성자</td>
-                <td th:text="${myCsQuestion.csQCategoryCode}">문의 카테고리 코드</td>
-                <td th:text="${myCsQuestion.csQStatusCode}">문의 상태 코드</td>
-                <td th:text="${myCsQuestion.csQViewCount}">문의글 조회수</td>
-                <td th:text="${myCsQuestion.createdDate}">문의 작성일자</td>
-                <td th:text="${myCsQuestion.modifiedDate}">문의 수정일자</td>
-            </tr>
-            </tbody>
-        </table>
+<div class="row">
+    <aside class="col-md-3">
+        <div class="panel">
+            <ul class="list-group">
+                <li><a th:href="@{/user/my}" class="nav-link px-2">나의 웹툰</a></li>
+                <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
+                <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+            </ul>
+        </div>
+    </aside>
+<!--    <script>-->
+<!--        function toggleCheckboxValue() {-->
+<!--            const checkbox = document.getElementById('isToggledCheckbox');-->
+<!--            if(!checkbox.checked) checkbox.value = 'N';-->
+<!--            else checkbox.value = 'Y';-->
+<!--            document.getElementById('filter-form').submit();-->
+<!--        }-->
+<!--    </script>-->
+    <script> // toggle + sorting
+        function updateCheckboxValueAndSubmit() {
+            const checkbox = document.getElementById('isToggledCheckbox');
+            const form = document.getElementById('filter-and-sort-form');
+            // 체크박스가 체크된 상태를 확인
+            checkbox.value = checkbox.checked ? 'Y' : 'N';
+            // 폼 제출
+            form.submit();
+        }
+
+        function submitForm() {
+            document.getElementById('filter-and-sort-form').submit();
+        }
+    </script>
+    <div class="col-md-9">
+        <div class="review-list">
+            <h2>나의 문의</h2>
+            <form id="filter-and-sort-form" th:action="@{/user/my/cs}" method="get">
+                <label>
+                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">답변완료
+                </label>
+                <label>
+                    <select name="orderBy" onchange="submitForm()">
+                        <option value="recentedited" th:selected="${orderBy == 'recentedited'}">최근수정순</option>
+
+                        <option value="recent" th:selected="${orderBy == 'recent'}">최근작성순</option>
+                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>
+
+                        <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>
+                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>
+                    </select>
+                </label>
+            </form>
+<!--            <form id="filter-form" th:action="@{/user/my/cs}" method="get">-->
+<!--                <label>-->
+<!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="toggleCheckboxValue()">답변완료-->
+<!--                </label>-->
+<!--            </form>-->
+            <table>
+                <thead>
+                <tr>
+                    <th>문의글 번호</th>
+                    <th>문의글 제목</th>
+                    <th>문의글 내용</th>
+                    <th>문의글 작성자</th>
+                    <th>문의 카테고리 코드</th>
+                    <th>문의 상태 코드</th>
+                    <th>문의글 조회수</th>
+                    <th>문의 작성일자</th>
+                    <th>문의 수정일자</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="myCsQuestion : ${myCsQuestions}" class="clickable-row" th:attr="data-href=@{/cs/questionDetail/{id}(id=${myCsQuestion.csQNo})}">
+                    <td th:text="${myCsQuestion.csQNo}">문의글 번호</td>
+                    <td th:text="${myCsQuestion.csQTitle}">문의글 제목</td>
+                    <td th:text="${myCsQuestion.csQContent}">문의글 내용</td>
+                    <td th:text="${myCsQuestion.csQWriterNo}">문의글 작성자</td>
+                    <td th:text="${myCsQuestion.csQCategoryCode}">문의 카테고리 코드</td>
+                    <td th:text="${myCsQuestion.csQStatusCode}">문의 상태 코드</td>
+                    <td th:text="${myCsQuestion.csQViewCount}">문의글 조회수</td>
+                    <td th:text="${myCsQuestion.createdDate}">문의 작성일자</td>
+                    <td th:text="${myCsQuestion.modifiedDate}">문의 수정일자</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
     </div>
 </div>
 </body>

--- a/src/main/resources/templates/user/mypage_editprofile.html
+++ b/src/main/resources/templates/user/mypage_editprofile.html
@@ -4,6 +4,21 @@
 <head>
   <title>KHG70: 프로필수정</title>
   <meta charset="UTF-8">
+
+  <!-- Latest compiled and minified CSS -->
+  <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+  <!-- 폰트: 'Noto Sans KR' 사용 -->
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap">
+  <!-- 프로젝트 툰게더 전용 css 스타일 시트 -->
+  <link rel="stylesheet" th:href="@{/css/styles.css}">
+
+  <!-- jQuery library -->
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+
+  <!-- Latest compiled JavaScript -->
+  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+
+
   <style>
     .navbar {
       position: fixed;
@@ -98,42 +113,115 @@
 <body>
 
 <div th:replace="~{common/menubar}"></div>
-<div layout:fragment="content">
-  <nav class="navbar navbar-expand-md">
-    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-      <li><a th:href="@{/user/my}" class="nav-link px-2">나의 웹툰</a></li>
-      <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-      <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
-      <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-      <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-      <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-    </ul>
-  </nav>
+<style>
+  .jumbotron {
+  position : relative;
+  }
+  .jumbotron .row {
+  position : absolute;
+  width : 100%;
+  bottom: 0%;
+  }
+</style>
+<div class="jumbotron">
+  <div class="row">
+    <div class="col-md-3">
+      <h3>프로필 수정</h3>
+    </div>
+    <div class="col-md-9">
+      <nav class="navbar navbar-expand-md">
+        <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+          <li>-</li>
+<!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+<!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+<!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+        </ul>
+      </nav>
+    </div>
+  </div>
 </div>
-<div>
-  <form th:action="@{/user/my/editprofile}" th:object="${user}" method="post" enctype="multipart/form-data" onsubmit="validateForm(event)">
-    프로필 사진<br>
-    <img th:src="@{/uploadFiles/{fileName}(fileName=${user.profileImagePath})}" style="width: 100px; height: auto;"/><br>
-    <input type="file" name="image"><br>
-    아이디 : <input type="text" th:field="*{userId}" maxlength="20" minlength="4" readonly/> (중복불가)<br>
-    비밀번호 : <input type="password" th:field="*{password}" maxlength="30" minlength="8"/><br>
-    비밀번호 확인 : <br>
-    닉네임 : <input type="text" th:field="*{nickname}" maxlength="20" minlength="4"/> (중복불가)<br>
-    연락처 : <input type="text" th:field="*{contactNumber}" oninput="autoFormatPhoneNumber(this)" placeholder="000-0000-0000"/><br>
-    성별 : <select th:field="*{gender}">
-    <option value="P">성별을 공개하지 않습니다
-    <option value="F">여
-    <option value="M">남</select><br>
-    생년월일 : <input type="text" th:field="*{dateOfBirth}" oninput="autoFormatDate(this)" placeholder="yyyy-mm-dd"/><br>
-    이메일 : <input type="text" th:field="*{email}"/> (중복불가)<br>
-    자기소개(선택사항) : <input type="text" th:field="*{bio}"/><br>
+<div class="row">
+  <aside class="col-md-3">
+    <div class="panel">
+      <ul class="list-group">
+        <li><a th:href="@{/user/my}" class="nav-link px-2">나의 웹툰</a></li>
+        <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+        <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
+        <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+        <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+        <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+      </ul>
+    </div>
+  </aside>
+  <script>
+    // nickname available check
+        function checkNicknameDuplicate() {
+            const nickname = document.getElementById('nickname').value;
 
-    <input type="submit">수정확인<br>
-  </form>
+            if(!nickname) {
+                alert('닉네임을 입력해 주세요.');
+                return;
+            }
 
-  <form th:action="@{/user/my/deleteprofile}" method="post">
-    <button type="submit">탈퇴하기(누르면 바로 삭제되니 조심!)</button>
-  </form>
+            fetch(`/user/checkNicknameDuplicate?nickname=${encodeURIComponent(nickname)}`)
+                .then(response => response.json())
+                .then(data => {
+                    if (data.isDuplicate) alert('이미 사용 중인 닉네임입니다.');
+                    else alert('사용 가능한 닉네임입니다.');
+                })
+                .catch(error => {
+                    console.error('Error: ', error);
+                });
+        } //checkNicknameDuplicate()
+
+        // email available check
+        function checkEmailDuplicate() {
+            const email = document.getElementById('email').value;
+
+            if(!email) {
+                alert('이메일을 입력해 주세요.');
+                return;
+            }
+
+            fetch(`/user/checkEmailDuplicate?email=${encodeURIComponent(email)}`)
+                .then(response => response.json())
+                .then(data => {
+                    if (data.isDuplicate) alert('이미 등록된 이메일입니다.');
+                    else alert('등록 가능한 이메일입니다.');
+                })
+                .catch(error => {
+                    console.error('Error: ', error);
+                });
+        } //checkEmailDuplicate()
+  </script>
+  <div class="col-md-9">
+    <form th:action="@{/user/my/editprofile}" th:object="${user}" method="post" enctype="multipart/form-data" onsubmit="validateForm(event)">
+      프로필 사진<br>
+      <img th:src="@{/uploadFiles/{fileName}(fileName=${user.profileImagePath})}" style="width: 100px; height: auto;"/><br>
+      <input type="file" name="image"><br>
+      아이디 : <input type="text" th:field="*{userId}" maxlength="20" minlength="4" readonly/><br>
+      비밀번호 : <input type="password" th:field="*{password}" maxlength="30" minlength="8"/><br>
+      비밀번호 확인 : <br>
+      닉네임 : <input type="text" th:field="*{nickname}" maxlength="20" minlength="4"/>
+      <button type="button" onclick="checkNicknameDuplicate()">중복확인</button>
+      <br>
+      연락처 : <input type="text" th:field="*{contactNumber}" oninput="autoFormatPhoneNumber(this)" placeholder="000-0000-0000"/><br>
+      성별 : <select th:field="*{gender}">
+      <option value="P">성별을 공개하지 않습니다
+      <option value="F">여
+      <option value="M">남</select><br>
+      생년월일 : <input type="text" th:field="*{dateOfBirth}" oninput="autoFormatDate(this)" placeholder="yyyy-mm-dd"/><br>
+      이메일 : <input type="text" th:field="*{email}"/>
+      <button type="button" onclick="checkEmailDuplicate()">중복확인</button>
+      <br>
+      자기소개(선택사항) : <input type="text" th:field="*{bio}"/><br>
+
+      <input type="submit">수정확인<br>
+    </form>
+
+    <form th:action="@{/user/my/deleteprofile}" method="post">
+      <button type="submit">탈퇴하기(누르면 바로 삭제되니 조심!)</button>
+    </form>
   <!--    <form th:action="@{/user/signup}" th:object="${user}" method="post">-->
   <!--        아이디 : <input type="text" name="userId"><br>-->
   <!--        비밀번호 : <input type="password" name="password"><br>-->
@@ -151,6 +239,7 @@
 
   <!--        <input type="submit">가입하기-->
   <!--    </form>-->
+  </div>
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/user/mypage_in_event.html
+++ b/src/main/resources/templates/user/mypage_in_event.html
@@ -4,6 +4,20 @@
 <head>
     <title>KHG51: 마이페이지-나의소식-좋아요한행사</title>
     <meta charset="UTF-8">
+
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <!-- 폰트: 'Noto Sans KR' 사용 -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap">
+    <!-- 프로젝트 툰게더 전용 css 스타일 시트 -->
+    <link rel="stylesheet" th:href="@{/css/styles.css}">
+
+    <!-- jQuery library -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+
+    <!-- Latest compiled JavaScript -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script>
         $(document).ready(function($) {
@@ -71,70 +85,133 @@
 <body>
 
 <div th:replace="~{common/menubar}"></div>
-<div layout:fragment="content">
-    <nav class="navbar navbar-expand-md">
-        <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-            <li><a th:href="@{/user/my}" class="nav-link px-2">나의 웹툰</a></li>
-            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
-            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-        </ul>
-    </nav>
+<style>
+    .jumbotron {
+    position : relative;
+    }
+    .jumbotron .row {
+    position : absolute;
+    width : 100%;
+    bottom: 0%;
+    }
+</style>
+<div class="jumbotron">
+    <div class="row">
+        <div class="col-md-3">
+            <h3>나의 소식</h3>
+        </div>
+        <div class="col-md-9">
+            <nav class="navbar navbar-expand-md">
+                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                    <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>
+                    <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>
+                    <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>
+                </ul>
+            </nav>
+        </div>
+    </div>
 </div>
-<div layout:fragment="content">
-    <nav class="navbar navbar-expand-md">
-        <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>
-            <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>
-        </ul>
-    </nav>
-</div>
-<div class="container">
-    <div class="review-list">
-        <h2>좋아요한 행사</h2>
-        <table>
-            <thead>
-            <tr>
-                <th>좋아요 번호</th>
-                <th>행사 게시글 번호</th>
-                <th>회원번호</th>
-                <th>좋아요 날짜</th>
-                <th>행사 제목</th>
-                <th>행사 카테고리 코드</th>
-                <th>행사 시작일</th>
-                <th>행사 종료일</th>
-                <th>행사 비용</th>
-                <th>관련사이트URL</th>
-                <th>장소명</th>
-                <th>주소명</th>
-                <th>좌표</th>
-                <th>행사 내용</th>
-                <th>게시 일시</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr th:each="myInEvent : ${myInEvents}" class="clickable-row" th:attr="data-href=@{/introduction/eventDetail(id=${myInEvent.eventNo})}">
-                <td th:text="${myInEvent.likedNo}">좋아요 번호</td>
-                <td th:text="${myInEvent.eventNo}">행사 게시글 번호</td>
-                <td th:text="${myInEvent.userNo}">회원번호</td>
-                <td th:text="${myInEvent.likedDate}">좋아요 날짜</td>
-                <td th:text="${myInEvent.title}">행사 제목</td>
-                <td th:text="${myInEvent.eventCategoryCode}">행사 카테고리 코드</td>
-                <td th:text="${myInEvent.startDate}">행사 시작일</td>
-                <td th:text="${myInEvent.endDate}">행사 종료일</td>
-                <td th:text="${myInEvent.cost}">행사 비용</td>
-                <td th:text="${myInEvent.site}">관련사이트URL</td>
-                <td th:text="${myInEvent.place}">장소명</td>
-                <td th:text="${myInEvent.address}">주소명</td>
-                <td th:text="${myInEvent.coordinates}">좌표</td>
-                <td th:text="${myInEvent.content}">행사 내용</td>
-                <td th:text="${myInEvent.postingDate}">게시 일시</td>
-            </tr>
-            </tbody>
-        </table>
+<div class="row">
+    <aside class="col-md-3">
+        <div class="panel">
+            <ul class="list-group">
+                <li><a th:href="@{/user/my}" class="nav-link px-2">나의 웹툰</a></li>
+                <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
+                <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+            </ul>
+        </div>
+    </aside>
+<!--    <script>-->
+<!--        function toggleCheckboxValue() {-->
+<!--            const checkbox = document.getElementById('isToggledCheckbox');-->
+<!--            if(!checkbox.checked) checkbox.value = 'N';-->
+<!--            else checkbox.value = 'Y';-->
+<!--            document.getElementById('filter-form').submit();-->
+<!--        }-->
+<!--    </script>-->
+    <script> // toggle + sorting
+        function updateCheckboxValueAndSubmit() {
+            const checkbox = document.getElementById('isToggledCheckbox');
+            const form = document.getElementById('filter-and-sort-form');
+            // 체크박스가 체크된 상태를 확인
+            checkbox.value = checkbox.checked ? 'Y' : 'N';
+            // 폼 제출
+            form.submit();
+        }
 
+        function submitForm() {
+            document.getElementById('filter-and-sort-form').submit();
+        }
+    </script>
+    <div class="col-md-9">
+        <div class="review-list">
+            <h2>좋아요한 행사</h2>
+            <form id="filter-and-sort-form" th:action="@{/user/my/in/event}" method="get">
+                <label>
+                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">진행중인 행사
+                </label>
+
+                <label>
+                    <select name="orderBy" onchange="submitForm()">
+                        <option value="recentliked" th:selected="${orderBy == 'recentliked'}">최근좋아요순</option>
+                        <option value="oldestliked" th:selected="${orderBy == 'oldestliked'}">오래된순</option>
+
+                        <option value="recent" th:selected="${orderBy == 'recent'}">최신행사순</option>
+                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된행사순</option>
+
+                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>
+                    </select>
+                </label>
+            </form>
+<!--            <form id="filter-form" th:action="@{/user/my/in/event}" method="get">-->
+<!--                <label>-->
+<!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="toggleCheckboxValue()">진행중인 행사-->
+<!--                </label>-->
+<!--            </form>-->
+            <table>
+                <thead>
+                <tr>
+                    <th>좋아요 번호</th>
+                    <th>행사 게시글 번호</th>
+                    <th>회원번호</th>
+                    <th>좋아요 날짜</th>
+                    <th>행사 제목</th>
+                    <th>행사 카테고리 코드</th>
+                    <th>행사 시작일</th>
+                    <th>행사 종료일</th>
+                    <th>행사 비용</th>
+                    <th>관련사이트URL</th>
+                    <th>장소명</th>
+                    <th>주소명</th>
+                    <th>좌표</th>
+                    <th>행사 내용</th>
+                    <th>게시 일시</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="myInEvent : ${myInEvents}" class="clickable-row" th:attr="data-href=@{/introduction/eventDetail(id=${myInEvent.eventNo})}">
+                    <td th:text="${myInEvent.likedNo}">좋아요 번호</td>
+                    <td th:text="${myInEvent.eventNo}">행사 게시글 번호</td>
+                    <td th:text="${myInEvent.userNo}">회원번호</td>
+                    <td th:text="${myInEvent.likedDate}">좋아요 날짜</td>
+                    <td th:text="${myInEvent.title}">행사 제목</td>
+                    <td th:text="${myInEvent.eventCategoryCode}">행사 카테고리 코드</td>
+                    <td th:text="${myInEvent.startDate}">행사 시작일</td>
+                    <td th:text="${myInEvent.endDate}">행사 종료일</td>
+                    <td th:text="${myInEvent.cost}">행사 비용</td>
+                    <td th:text="${myInEvent.site}">관련사이트URL</td>
+                    <td th:text="${myInEvent.place}">장소명</td>
+                    <td th:text="${myInEvent.address}">주소명</td>
+                    <td th:text="${myInEvent.coordinates}">좌표</td>
+                    <td th:text="${myInEvent.content}">행사 내용</td>
+                    <td th:text="${myInEvent.postingDate}">게시 일시</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
     </div>
 </div>
 </body>

--- a/src/main/resources/templates/user/mypage_in_journal.html
+++ b/src/main/resources/templates/user/mypage_in_journal.html
@@ -4,6 +4,20 @@
 <head>
     <title>KHG50: 마이페이지-나의소식-좋아요한웹툰소식</title>
     <meta charset="UTF-8">
+
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <!-- 폰트: 'Noto Sans KR' 사용 -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap">
+    <!-- 프로젝트 툰게더 전용 css 스타일 시트 -->
+    <link rel="stylesheet" th:href="@{/css/styles.css}">
+
+    <!-- jQuery library -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+
+    <!-- Latest compiled JavaScript -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script>
         $(document).ready(function($) {
@@ -71,62 +85,95 @@
 <body>
 
 <div th:replace="~{common/menubar}"></div>
-<div layout:fragment="content">
-    <nav class="navbar navbar-expand-md">
-        <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-            <li><a th:href="@{/user/my}" class="nav-link px-2">나의 웹툰</a></li>
-            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
-            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-        </ul>
-    </nav>
+<style>
+    .jumbotron {
+    position : relative;
+    }
+    .jumbotron .row {
+    position : absolute;
+    width : 100%;
+    bottom: 0%;
+    }
+</style>
+<div class="jumbotron">
+    <div class="row">
+        <div class="col-md-3">
+            <h3>나의 소식</h3>
+        </div>
+        <div class="col-md-9">
+            <nav class="navbar navbar-expand-md">
+                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                    <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>
+                    <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>
+                    <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>
+                </ul>
+            </nav>
+        </div>
+    </div>
 </div>
-<div layout:fragment="content">
-    <nav class="navbar navbar-expand-md">
-        <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>
-            <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>
-        </ul>
-    </nav>
-</div>
-<div class="container">
-    <div class="review-list">
-        <h2>좋아요한 웹툰 소식</h2>
-        <table>
-            <thead>
-            <tr>
-                <th>좋아요 번호</th>
-                <th>회원번호</th>
-                <th>좋아요 날짜</th>
-                <th>소식 게시글 번호</th>
-                <th>소식 제목</th>
-                <th>소식 내용</th>
-                <th>게시 일시</th>
+<div class="row">
+    <aside class="col-md-3">
+        <div class="panel">
+            <ul class="list-group">
+                <li><a th:href="@{/user/my}" class="nav-link px-2">나의 웹툰</a></li>
+                <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
+                <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+            </ul>
+        </div>
+    </aside>
+    <div class="col-md-9">
+        <div class="review-list">
+            <h2>좋아요한 웹툰 소식</h2>
+            <form id="sort-form" th:action="@{/user/my/in/journal}" method="get">
+                <label>
+                    <select name="orderBy" onchange="this.form.submit()">
+                        <option value="recentliked" th:selected="${orderBy == 'recentliked'}">최근좋아요순</option>
+                        <option value="oldestliked" th:selected="${orderBy == 'oldestliked'}">오래된순</option>
 
-<!--                <th>ijl.liked_no</th>-->
-<!--                <th>ijl.user_no</th>-->
-<!--                <th>ijl.liked_date</th>-->
-<!--                <th>ij.journal_no</th>-->
-<!--                <th>ij.title</th>-->
-<!--                <th>ij.content</th>-->
-<!--                <th>ij.posting_date</th>-->
+                        <option value="recent" th:selected="${orderBy == 'recent'}">최신소식순</option>
+                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된소식순</option>
 
-            </tr>
-            </thead>
-            <tbody>
-            <tr th:each="myInJournal : ${myInJournals}" class="clickable-row" th:attr="data-href=@{/introduction/journalDetail(id=${myInJournal.journalNo})}">
-                <td th:text="${myInJournal.likedNo}">좋아요 번호</td>
-                <td th:text="${myInJournal.userNo}">회원번호</td>
-                <td th:text="${myInJournal.likedDate}">좋아요 날짜</td>
-                <td th:text="${myInJournal.journalNo}">소식 게시글 번호</td>
-                <td th:text="${myInJournal.title}">소식 제목</td>
-                <td th:text="${myInJournal.content}">소식 내용</td>
-                <td th:text="${myInJournal.postingDate}">게시 일시</td>
-            </tr>
-            </tbody>
-        </table>
+                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>
+                    </select>
+                </label>
+            </form>
+            <table>
+                <thead>
+                <tr>
+                    <th>좋아요 번호</th>
+                    <th>회원번호</th>
+                    <th>좋아요 날짜</th>
+                    <th>소식 게시글 번호</th>
+                    <th>소식 제목</th>
+                    <th>소식 내용</th>
+                    <th>게시 일시</th>
+
+    <!--                <th>ijl.liked_no</th>-->
+    <!--                <th>ijl.user_no</th>-->
+    <!--                <th>ijl.liked_date</th>-->
+    <!--                <th>ij.journal_no</th>-->
+    <!--                <th>ij.title</th>-->
+    <!--                <th>ij.content</th>-->
+    <!--                <th>ij.posting_date</th>-->
+
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="myInJournal : ${myInJournals}" class="clickable-row" th:attr="data-href=@{/introduction/journalDetail(title=${myInJournal.title})}">
+                    <td th:text="${myInJournal.likedNo}">좋아요 번호</td>
+                    <td th:text="${myInJournal.userNo}">회원번호</td>
+                    <td th:text="${myInJournal.likedDate}">좋아요 날짜</td>
+                    <td th:text="${myInJournal.journalNo}">소식 게시글 번호</td>
+                    <td th:text="${myInJournal.title}">소식 제목</td>
+                    <td th:text="${myInJournal.content}">소식 내용</td>
+                    <td th:text="${myInJournal.postingDate}">게시 일시</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
     </div>
 </div>
 </body>

--- a/src/main/resources/templates/user/mypage_in_merchan.html
+++ b/src/main/resources/templates/user/mypage_in_merchan.html
@@ -2,7 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.w3.org/1999/xhtml">
 <html layout:decorate="~{layout}">
 <head>
-    <title>KHG20: 마이페이지-나의웹툰-북마크한웹툰</title>
+    <title>KHG52: 마이페이지-나의소식-좋아요한굿즈</title>
     <meta charset="UTF-8">
 
     <!-- Latest compiled and minified CSS -->
@@ -17,7 +17,6 @@
 
     <!-- Latest compiled JavaScript -->
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
-
 
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script>
@@ -82,31 +81,31 @@
           z-index: 1000;
         }
     </style>
-
 </head>
 <body>
 
 <div th:replace="~{common/menubar}"></div>
 <style>
-        .jumbotron {
-        position : relative;
-        }
-        .jumbotron .row {
-        position : absolute;
-        width : 100%;
-        bottom: 0%;
-        }
+    .jumbotron {
+    position : relative;
+    }
+    .jumbotron .row {
+    position : absolute;
+    width : 100%;
+    bottom: 0%;
+    }
 </style>
 <div class="jumbotron">
     <div class="row">
         <div class="col-md-3">
-            <h3>나의 웹툰</h3>
+            <h3>나의 소식</h3>
         </div>
         <div class="col-md-9">
             <nav class="navbar navbar-expand-md">
                 <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                    <li><a th:href="@{/user/my}" class="nav-link px-2">북마크한 웹툰</a></li>
-                    <li><a th:href="@{/user/my/wt/comment}" class="nav-link px-2">내가 남긴 코멘트</a></li>
+                    <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>
+                    <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>
+                    <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>
                 </ul>
             </nav>
         </div>
@@ -125,60 +124,76 @@
             </ul>
         </div>
     </aside>
+    <script> // toggle + sorting
+        function updateCheckboxValueAndSubmit() {
+            const checkbox = document.getElementById('isToggledCheckbox');
+            const form = document.getElementById('filter-and-sort-form');
+            // 체크박스가 체크된 상태를 확인
+            checkbox.value = checkbox.checked ? 'Y' : 'N';
+            // 폼 제출
+            form.submit();
+        }
+
+        function submitForm() {
+            document.getElementById('filter-and-sort-form').submit();
+        }
+    </script>
     <div class="col-md-9">
         <div class="review-list">
-            <h2>북마크한 웹툰</h2>
-            <form id="sort-form" th:action="@{/user/my/wt/webtoon}" method="get">
+            <h2>좋아요한 굿즈</h2>
+            <form id="filter-and-sort-form" th:action="@{/user/my/in/merchan}" method="get">
                 <label>
-                    <select name="orderBy" onchange="this.form.submit()">
-                        <option value="recent" th:selected="${orderBy == 'recent'}">최근저장순</option>
-                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>
-                        <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>
+                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">품절됨
+                </label>
+                <label>
+                    <select name="orderBy" onchange="submitForm()">
+                        <option value="recentliked" th:selected="${orderBy == 'recentliked'}">최근좋아요순</option>
+                        <option value="oldestliked" th:selected="${orderBy == 'oldestliked'}">오래된순</option>
+
+                        <option value="recent" th:selected="${orderBy == 'recent'}">최신상품순</option>
+                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된상품순</option>
+
+                        <option value="expensive" th:selected="${orderBy == 'expensive'}">금액높은순</option>
+                        <option value="cheap" th:selected="${orderBy == 'cheap'}">금액낮은순</option>
+
                         <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>
                     </select>
                 </label>
             </form>
-
             <table>
                 <thead>
                 <tr>
-                    <th>저장번호</th>
-                    <th>웹툰 번호</th>
-                    <th>유저넘버</th>
-                    <th>웹툰아이디</th>
-                    <th>플렛폼</th>
-                    <th>제목</th>
-                    <th>작가</th>
-                    <th>이미지URL</th>
-                    <th>장르</th>
-                    <th>태그</th>
-                    <th>조회수</th>
+                    <th>좋아요 번호</th>
+                    <th>상품 게시글 번호</th>
+                    <th>회원번호</th>
+                    <th>좋아요 날짜</th>
+                    <th>상품 제목</th>
+                    <th>정가</th>
+                    <th>할인가</th>
+                    <th>배송비</th>
+                    <th>상품 정보</th>
+                    <th>상품내용</th>
+                    <th>게시 일시</th>
                 </tr>
                 </thead>
                 <tbody>
-                <tr th:each="myWtWebtoon : ${myWtWebtoons}" class="clickable-row"
-                    th:attr="data-href=@{/webtoon/one(
-                webtoon_id=${(myWtWebtoon.platform == 1 ? 'naver_' : myWtWebtoon.platform == 2 ? 'kakao_' : '') + myWtWebtoon.webtoonId},
-                webtoon_name=${myWtWebtoon.webtoonName},
-                author=${myWtWebtoon.author}
-                )}">
-                    <td th:text="${myWtWebtoon.saveNo}">저장번호</td>
-                    <td th:text="${myWtWebtoon.webtoonNo}">웹툰 번호</td>
-                    <td th:text="${myWtWebtoon.userNo}">유저넘버</td>
-                    <td th:text="${myWtWebtoon.webtoonId}">웹툰아이디</td>
-                    <td th:text="${myWtWebtoon.platform}">플렛폼</td>
-                    <td th:text="${myWtWebtoon.webtoonName}">제목</td>
-                    <td th:text="${myWtWebtoon.author}">작가</td>
-                    <td th:text="${myWtWebtoon.thumbnailUrl}">이미지URL</td>
-                    <td th:text="${myWtWebtoon.genre}">장르</td>
-                    <td th:text="${myWtWebtoon.tags}">태그</td>
-                    <td th:text="${myWtWebtoon.count}">조회수</td>
+                <tr th:each="myInMerchan : ${myInMerchans}" class="clickable-row" th:attr="data-href=@{/introduction/merchanDetail(no=${myInMerchan.merchanNo})}">
+                    <td th:text="${myInMerchan.likedNo}">좋아요 번호</td>
+                    <td th:text="${myInMerchan.merchanNo}">상품 게시글 번호</td>
+                    <td th:text="${myInMerchan.userNo}">회원번호</td>
+                    <td th:text="${myInMerchan.likedDate}">좋아요 날짜</td>
+                    <td th:text="${myInMerchan.title}">상품 제목</td>
+                    <td th:text="${myInMerchan.regularPrice}">정가</td>
+                    <td th:text="${myInMerchan.discountPrice}">할인가</td>
+                    <td th:text="${myInMerchan.shippingCost}">배송비</td>
+                    <td th:text="${myInMerchan.merchanInfo}">상품 정보</td>
+                    <td th:text="${myInMerchan.content}">상품내용</td>
+                    <td th:text="${myInMerchan.postingDate}">게시 일시</td>
                 </tr>
                 </tbody>
             </table>
         </div>
     </div>
 </div>
-
 </body>
 </html>

--- a/src/main/resources/templates/user/mypage_rct_application.html
+++ b/src/main/resources/templates/user/mypage_rct_application.html
@@ -4,6 +4,20 @@
 <head>
     <title>KHG44: 마이페이지-나의채용-나의지원서관리</title>
     <meta charset="UTF-8">
+
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <!-- 폰트: 'Noto Sans KR' 사용 -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap">
+    <!-- 프로젝트 툰게더 전용 css 스타일 시트 -->
+    <link rel="stylesheet" th:href="@{/css/styles.css}">
+
+    <!-- jQuery library -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+
+    <!-- Latest compiled JavaScript -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script>
         $(document).ready(function($) {
@@ -71,77 +85,141 @@
 <body>
 
 <div th:replace="~{common/menubar}"></div>
-<div layout:fragment="content">
-    <nav class="navbar navbar-expand-md">
-        <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-            <li><a th:href="@{/user/my}" class="nav-link px-2">나의 웹툰</a></li>
-            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
-            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-        </ul>
-    </nav>
+<style>
+    .jumbotron {
+    position : relative;
+    }
+    .jumbotron .row {
+    position : absolute;
+    width : 100%;
+    bottom: 0%;
+    }
+</style>
+<div class="jumbotron">
+    <div class="row">
+        <div class="col-md-3">
+            <h3>나의 채용</h3>
+        </div>
+        <div class="col-md-9">
+            <nav class="navbar navbar-expand-md">
+                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                    <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
+                    <li><a th:href="@{/user/my/rct/creator}" class="nav-link px-2">창작자 등록 현황</a></li>
+                    <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a></li>
+                    <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
+                    <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
+                </ul>
+            </nav>
+        </div>
+    </div>
 </div>
-<div layout:fragment="content">
-    <nav class="navbar navbar-expand-md">
-        <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
-            <li><a th:href="@{/user/my/rct/creator}" class="nav-link px-2">창작자 등록 현황</a></li>
-            <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a></li>
-            <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
-            <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
-        </ul>
-    </nav>
-</div>
-<div class="container">
-    <div class="review-list">
-        <h2>나의 지원서 관리</h2>
-        <table>
-            <thead>
-            <tr>
-                <th>지원글 번호</th>
-                <th>게시글 번호</th>
-                <th>지원자</th>
-                <th>제목</th>
-                <th>내용</th>
-                <th>이미지</th>
-                <th>작성 일자</th>
-                <th>조회 여부</th>
+<div class="row">
+    <aside class="col-md-3">
+        <div class="panel">
+            <ul class="list-group">
+                <li><a th:href="@{/user/my}" class="nav-link px-2">나의 웹툰</a></li>
+                <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
+                <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+            </ul>
+        </div>
+    </aside>
+<!--    <script>-->
+<!--        function toggleCheckboxValue() {-->
+<!--            const checkbox = document.getElementById('isToggledCheckbox');-->
+<!--            if(!checkbox.checked) checkbox.value = 'N';-->
+<!--            else checkbox.value = 'Y';-->
+<!--            document.getElementById('filter-form').submit();-->
+<!--        }-->
+<!--    </script>-->
+    <script> // toggle + sorting
+        function updateCheckboxValueAndSubmit() {
+            const checkbox = document.getElementById('isToggledCheckbox');
+            const form = document.getElementById('filter-and-sort-form');
+            // 체크박스가 체크된 상태를 확인
+            checkbox.value = checkbox.checked ? 'Y' : 'N';
+            // 폼 제출
+            form.submit();
+        }
 
-                <th>작성자</th>
-                <th>제목</th>
-                <th>내용</th>
-                <th>근무지</th>
-                <th>이미지</th>
-                <th>작성 일자</th>
-                <th>수정 일자</th>
-                <th>마감 일자</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr th:each="myRctApplication : ${myRctApplications}" class="clickable-row" th:attr="data-href=@{/recruit/job/applyView(no=${myRctApplication.applyNo})}">
-                <td th:text="${myRctApplication.applyNo}">지원글 번호</td>
-                <td th:text="${myRctApplication.boardNo}">게시글 번호</td>
-                <td th:text="${myRctApplication.writer}">지원자</td>
-                <td th:text="${myRctApplication.applyTitle}">제목</td>
-                <td th:text="${myRctApplication.applyContent}">내용</td>
-                <td th:text="${myRctApplication.applyImg}">이미지</td>
-                <td th:text="${myRctApplication.applyCreatedDate}">작성 일자</td>
-                <td th:text="${myRctApplication.applyCheckStatus}">조회 여부</td>
+        function submitForm() {
+            document.getElementById('filter-and-sort-form').submit();
+        }
+    </script>
+    <div class="col-md-9">
+        <div class="review-list">
+            <h2>나의 지원서 관리</h2>
+            <form id="filter-and-sort-form" th:action="@{/user/my/rct/apply}" method="get">
+                <label>
+                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">마감된 공고
+                </label>
 
-                <td th:text="${myRctApplication.jobWriter}">작성자</td>
-                <td th:text="${myRctApplication.jobTitle}">제목</td>
-                <td th:text="${myRctApplication.jobContent}">내용</td>
-                <td th:text="${myRctApplication.jobLocation}">근무지</td>
-                <td th:text="${myRctApplication.jobImg}">이미지</td>
-                <td th:text="${myRctApplication.jobCreatedDate}">작성 일자</td>
-                <td th:text="${myRctApplication.jobModifiedDate}">수정 일자</td>
-                <td th:text="${myRctApplication.jobDeadLine}">마감 일자</td>
-            </tr>
-            </tbody>
-        </table>
+                <label>
+                    <select name="orderBy" onchange="submitForm()">
+                        <option value="recentApplication" th:selected="${orderBy == 'recentApplication'}">지원최근순</option>
+                        <option value="oldestApplication" th:selected="${orderBy == 'oldestApplication'}">오래된순</option>
 
+                        <option value="recentedited" th:selected="${orderBy == 'recentedited'}">공고최근수정순</option>
+                        <option value="recent" th:selected="${orderBy == 'recent'}">공고최근작성순</option>
+                        <option value="oldest" th:selected="${orderBy == 'oldest'}">공고오래된순</option>
+                        <option value="dueSoon" th:selected="${orderBy == 'dueSoon'}">마감임박순</option>
+                        <option value="title" th:selected="${orderBy == 'title'}">공고제목가나다순</option>
+                    </select>
+                </label>
+            </form>
+<!--            <form id="filter-form" th:action="@{/user/my/rct/apply}" method="get">-->
+<!--                <label>-->
+<!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="toggleCheckboxValue()">마감된 공고-->
+<!--                </label>-->
+<!--            </form>-->
+            <table>
+                <thead>
+                <tr>
+                    <th>지원글 번호</th>
+                    <th>게시글 번호</th>
+                    <th>지원자</th>
+                    <th>제목</th>
+                    <th>내용</th>
+                    <th>이미지</th>
+                    <th>작성 일자</th>
+                    <th>조회 여부</th>
+
+                    <th>작성자</th>
+                    <th>제목</th>
+                    <th>내용</th>
+                    <th>근무지</th>
+                    <th>이미지</th>
+                    <th>작성 일자</th>
+                    <th>수정 일자</th>
+                    <th>마감 일자</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="myRctApplication : ${myRctApplications}" class="clickable-row" th:attr="data-href=@{/recruit/job/applyView(no=${myRctApplication.applyNo})}">
+                    <td th:text="${myRctApplication.applyNo}">지원글 번호</td>
+                    <td th:text="${myRctApplication.boardNo}">게시글 번호</td>
+                    <td th:text="${myRctApplication.writer}">지원자</td>
+                    <td th:text="${myRctApplication.applyTitle}">제목</td>
+                    <td th:text="${myRctApplication.applyContent}">내용</td>
+                    <td th:text="${myRctApplication.applyImg}">이미지</td>
+                    <td th:text="${myRctApplication.applyCreatedDate}">작성 일자</td>
+                    <td th:text="${myRctApplication.applyCheckStatus}">조회 여부</td>
+
+                    <td th:text="${myRctApplication.jobWriter}">작성자</td>
+                    <td th:text="${myRctApplication.jobTitle}">제목</td>
+                    <td th:text="${myRctApplication.jobContent}">내용</td>
+                    <td th:text="${myRctApplication.jobLocation}">근무지</td>
+                    <td th:text="${myRctApplication.jobImg}">이미지</td>
+                    <td th:text="${myRctApplication.jobCreatedDate}">작성 일자</td>
+                    <td th:text="${myRctApplication.jobModifiedDate}">수정 일자</td>
+                    <td th:text="${myRctApplication.jobDeadLine}">마감 일자</td>
+                </tr>
+                </tbody>
+            </table>
+
+        </div>
     </div>
 </div>
 </body>

--- a/src/main/resources/templates/user/mypage_rct_creator.html
+++ b/src/main/resources/templates/user/mypage_rct_creator.html
@@ -2,7 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.w3.org/1999/xhtml">
 <html layout:decorate="~{layout}">
 <head>
-    <title>KHG20: 마이페이지-나의웹툰-북마크한웹툰</title>
+    <title>KHG43: 마이페이지-나의채용-창작자등록관리</title>
     <meta charset="UTF-8">
 
     <!-- Latest compiled and minified CSS -->
@@ -17,7 +17,6 @@
 
     <!-- Latest compiled JavaScript -->
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
-
 
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script>
@@ -82,31 +81,33 @@
           z-index: 1000;
         }
     </style>
-
 </head>
 <body>
 
 <div th:replace="~{common/menubar}"></div>
 <style>
-        .jumbotron {
-        position : relative;
-        }
-        .jumbotron .row {
-        position : absolute;
-        width : 100%;
-        bottom: 0%;
-        }
+    .jumbotron {
+    position : relative;
+    }
+    .jumbotron .row {
+    position : absolute;
+    width : 100%;
+    bottom: 0%;
+    }
 </style>
 <div class="jumbotron">
     <div class="row">
         <div class="col-md-3">
-            <h3>나의 웹툰</h3>
+            <h3>나의 채용</h3>
         </div>
         <div class="col-md-9">
             <nav class="navbar navbar-expand-md">
                 <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                    <li><a th:href="@{/user/my}" class="nav-link px-2">북마크한 웹툰</a></li>
-                    <li><a th:href="@{/user/my/wt/comment}" class="nav-link px-2">내가 남긴 코멘트</a></li>
+                    <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
+                    <li><a th:href="@{/user/my/rct/creator}" class="nav-link px-2">창작자 등록 현황</a></li>
+                    <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a></li>
+                    <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
+                    <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
                 </ul>
             </nav>
         </div>
@@ -127,58 +128,39 @@
     </aside>
     <div class="col-md-9">
         <div class="review-list">
-            <h2>북마크한 웹툰</h2>
-            <form id="sort-form" th:action="@{/user/my/wt/webtoon}" method="get">
-                <label>
-                    <select name="orderBy" onchange="this.form.submit()">
-                        <option value="recent" th:selected="${orderBy == 'recent'}">최근저장순</option>
-                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>
-                        <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>
-                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>
-                    </select>
-                </label>
-            </form>
-
+            <h2>창작자 등록 현황</h2>
+            <th:block th:if="${!auth_code.equals('C')}">
+                <a th:href="@{/recruit/creator/choice}">창작자 등록 신청</a>
+            </th:block>
+            <th:block th:if="${auth_code.equals('C')}">
+                <button type="button" onclick="">등록증 확인(미구현)</button>
+            </th:block><br>
             <table>
                 <thead>
                 <tr>
-                    <th>저장번호</th>
-                    <th>웹툰 번호</th>
-                    <th>유저넘버</th>
-                    <th>웹툰아이디</th>
-                    <th>플렛폼</th>
-                    <th>제목</th>
-                    <th>작가</th>
-                    <th>이미지URL</th>
-                    <th>장르</th>
-                    <th>태그</th>
-                    <th>조회수</th>
+                    <th>창작자 번호</th>
+                    <th>회원 번호</th>
+                    <th>내용</th>
+                    <th>이미지</th>
+                    <th>사업자 등록번호</th>
+                    <th>심사 현황</th>
+                    <th>등록 유형 코드</th>
                 </tr>
                 </thead>
                 <tbody>
-                <tr th:each="myWtWebtoon : ${myWtWebtoons}" class="clickable-row"
-                    th:attr="data-href=@{/webtoon/one(
-                webtoon_id=${(myWtWebtoon.platform == 1 ? 'naver_' : myWtWebtoon.platform == 2 ? 'kakao_' : '') + myWtWebtoon.webtoonId},
-                webtoon_name=${myWtWebtoon.webtoonName},
-                author=${myWtWebtoon.author}
-                )}">
-                    <td th:text="${myWtWebtoon.saveNo}">저장번호</td>
-                    <td th:text="${myWtWebtoon.webtoonNo}">웹툰 번호</td>
-                    <td th:text="${myWtWebtoon.userNo}">유저넘버</td>
-                    <td th:text="${myWtWebtoon.webtoonId}">웹툰아이디</td>
-                    <td th:text="${myWtWebtoon.platform}">플렛폼</td>
-                    <td th:text="${myWtWebtoon.webtoonName}">제목</td>
-                    <td th:text="${myWtWebtoon.author}">작가</td>
-                    <td th:text="${myWtWebtoon.thumbnailUrl}">이미지URL</td>
-                    <td th:text="${myWtWebtoon.genre}">장르</td>
-                    <td th:text="${myWtWebtoon.tags}">태그</td>
-                    <td th:text="${myWtWebtoon.count}">조회수</td>
+                <tr th:each="myRctCreator : ${myRctCreators}" class="clickable-row">
+                    <td th:text="${myRctCreator.creatorNo}">창작자 번호</td>
+                    <td th:text="${myRctCreator.memberNo}">회원 번호</td>
+                    <td th:text="${myRctCreator.content}">내용</td>
+                    <td th:text="${myRctCreator.img}">이미지</td>
+                    <td th:text="${myRctCreator.registNo}">사업자 등록번호</td>
+                    <td th:text="${myRctCreator.status}">심사 현황</td>
+                    <td th:text="${myRctCreator.typeCode}">등록 유형 코드</td>
                 </tr>
                 </tbody>
             </table>
         </div>
     </div>
 </div>
-
 </body>
 </html>

--- a/src/main/resources/templates/user/mypage_rct_job.html
+++ b/src/main/resources/templates/user/mypage_rct_job.html
@@ -4,6 +4,21 @@
 <head>
     <title>KHG40: 마이페이지-나의채용-내가올린공고</title>
     <meta charset="UTF-8">
+
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <!-- 폰트: 'Noto Sans KR' 사용 -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap">
+    <!-- 프로젝트 툰게더 전용 css 스타일 시트 -->
+    <link rel="stylesheet" th:href="@{/css/styles.css}">
+
+    <!-- jQuery library -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+
+    <!-- Latest compiled JavaScript -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+
+
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script>
         $(document).ready(function($) {
@@ -71,61 +86,137 @@
 <body>
 
 <div th:replace="~{common/menubar}"></div>
-<div layout:fragment="content">
-    <nav class="navbar navbar-expand-md">
-        <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-            <li><a th:href="@{/user/my}" class="nav-link px-2">나의 웹툰</a></li>
-            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
-            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-        </ul>
-    </nav>
-</div>
-<div layout:fragment="content">
-    <nav class="navbar navbar-expand-md">
-        <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
-            <li><a th:href="@{/user/my/rct/creator}" class="nav-link px-2">창작자 등록 현황</a></li>
-            <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a></li>
-            <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
-            <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
-        </ul>
-    </nav>
-</div>
-<div class="container">
-    <div class="review-list">
-        <h2>내가 올린 공고</h2>
-        <table>
-            <thead>
-            <tr>
-                <th>게시글 번호</th>
-                <th>작성자</th>
-                <th>제목</th>
-                <th>내용</th>
-                <th>근무지</th>
-                <th>이미지</th>
-                <th>작성 일자</th>
-                <th>수정 일자</th>
-                <th>마감 일자</th>
+<style>
+    .jumbotron {
+    position : relative;
+    }
+    .jumbotron .row {
+    position : absolute;
+    width : 100%;
+    bottom: 0%;
+    }
+</style>
 
-            </tr>
-            </thead>
-            <tbody>
-            <tr th:each="myRctJob : ${myRctJobs}" class="clickable-row" th:attr="data-href=@{/recruit/job/view(no=${myRctJob.boardNo})}">
-                <td th:text="${myRctJob.boardNo}">게시글 번호</td>
-                <td th:text="${myRctJob.writer}">작성자</td>
-                <td th:text="${myRctJob.title}">제목</td>
-                <td th:text="${myRctJob.content}">내용</td>
-                <td th:text="${myRctJob.location}">근무지</td>
-                <td th:text="${myRctJob.img}">이미지</td>
-                <td th:text="${myRctJob.createdDate}">작성 일자</td>
-                <td th:text="${myRctJob.modifiedDate}">수정 일자</td>
-                <td th:text="${myRctJob.deadLine}">마감 일자</td>
-            </tr>
-            </tbody>
-        </table>
+<div class="jumbotron">
+    <div class="row">
+        <div class="col-md-3">
+            <h3>나의 채용</h3>
+        </div>
+        <div class="col-md-9">
+            <nav class="navbar navbar-expand-md">
+                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                    <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
+                    <li><a th:href="@{/user/my/rct/creator}" class="nav-link px-2">창작자 등록 현황</a></li>
+                    <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a></li>
+                    <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
+                    <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
+                </ul>
+            </nav>
+        </div>
+    </div>
+</div>
+<div class="row">
+    <aside class="col-md-3">
+        <div class="panel">
+            <ul class="list-group">
+                <li><a th:href="@{/user/my}" class="nav-link px-2">나의 웹툰</a></li>
+                <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
+                <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+            </ul>
+        </div>
+    </aside>
+<!--    <script>-->
+<!--        function toggleCheckboxValue() {-->
+<!--            const checkbox = document.getElementById('isToggledCheckbox');-->
+<!--            if(!checkbox.checked) checkbox.value = 'N';-->
+<!--            else checkbox.value = 'Y';-->
+<!--            document.getElementById('filter-form').submit();-->
+<!--        }-->
+<!--    </script>-->
+    <script> // toggle + sorting
+        function updateCheckboxValueAndSubmit() {
+            const checkbox = document.getElementById('isToggledCheckbox');
+            const form = document.getElementById('filter-and-sort-form');
+            // 체크박스가 체크된 상태를 확인
+            checkbox.value = checkbox.checked ? 'Y' : 'N';
+            // 폼 제출
+            form.submit();
+        }
+
+        function submitForm() {
+            document.getElementById('filter-and-sort-form').submit();
+        }
+    </script>
+    <div class="col-md-9">
+        <div class="review-list">
+            <h2>내가 올린 공고</h2>
+            <form id="filter-and-sort-form" th:action="@{/user/my/rct/job}" method="get">
+                <label>
+                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">마감된 공고
+                </label>
+                <label>
+                    <select name="orderBy" onchange="submitForm()">
+                        <option value="recentedited" th:selected="${orderBy == 'recentedited'}">최근수정순</option>
+                        <option value="recent" th:selected="${orderBy == 'recent'}">최근작성순</option>
+                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>
+                        <option value="dueSoon" th:selected="${orderBy == 'dueSoon'}">마감임박순</option>
+                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>
+                    </select>
+                </label>
+            </form>
+
+
+            <!--            <form id="filter-form" th:action="@{/user/my/rct/job}" method="get">-->
+<!--                <label>-->
+<!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="toggleCheckboxValue()">마감된 공고-->
+<!--                </label>-->
+<!--            </form>-->
+<!--            <form id="sort-form" th:action="@{/user/my/rct/job}" method="get">-->
+<!--                <label>-->
+<!--                    <select name="orderBy" onchange="this.form.submit()">-->
+<!--                        <option value="recentedited" th:selected="${orderBy == 'recentedited'}">최근수정순</option>-->
+
+<!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최근작성순</option>-->
+<!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
+
+<!--                        <option value="dueSoon" th:selected="${orderBy == 'dueSoon'}">마감임박순</option>-->
+<!--                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
+<!--                    </select>-->
+<!--                </label>-->
+<!--            </form>-->
+            <table>
+                <thead>
+                <tr>
+                    <th>게시글 번호</th>
+                    <th>작성자</th>
+                    <th>제목</th>
+                    <th>내용</th>
+                    <th>근무지</th>
+                    <th>이미지</th>
+                    <th>작성 일자</th>
+                    <th>수정 일자</th>
+                    <th>마감 일자</th>
+
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="myRctJob : ${myRctJobs}" class="clickable-row" th:attr="data-href=@{/user/my/rct/job/apply(boardNo=${myRctJob.boardNo})}">
+                    <td th:text="${myRctJob.boardNo}">게시글 번호</td>
+                    <td th:text="${myRctJob.writer}">작성자</td>
+                    <td th:text="${myRctJob.title}">제목</td>
+                    <td th:text="${myRctJob.content}">내용</td>
+                    <td th:text="${myRctJob.location}">근무지</td>
+                    <td th:text="${myRctJob.img}">이미지</td>
+                    <td th:text="${myRctJob.createdDate}">작성 일자</td>
+                    <td th:text="${myRctJob.modifiedDate}">수정 일자</td>
+                    <td th:text="${myRctJob.deadLine}">마감 일자</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
     </div>
 </div>
 </body>

--- a/src/main/resources/templates/user/mypage_rct_job_applicationlist.html
+++ b/src/main/resources/templates/user/mypage_rct_job_applicationlist.html
@@ -2,7 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.w3.org/1999/xhtml">
 <html layout:decorate="~{layout}">
 <head>
-    <title>KHG45: 마이페이지-나의채용-내가 올린 프리랜서게시글관리</title>
+    <title>KHG41: 마이페이지-나의채용-내가올린공고-지원서목록</title>
     <meta charset="UTF-8">
 
     <!-- Latest compiled and minified CSS -->
@@ -126,52 +126,95 @@
             </ul>
         </div>
     </aside>
+<!--    <script>-->
+<!--        function toggleCheckboxValue() {-->
+<!--            const checkbox = document.getElementById('isToggledCheckbox');-->
+<!--            if(!checkbox.checked) checkbox.value = 'N';-->
+<!--            else checkbox.value = 'Y';-->
+<!--            document.getElementById('filter-form').submit();-->
+<!--        }-->
+<!--    </script>-->
+    <script> // toggle + sorting
+        function updateCheckboxValueAndSubmit() {
+            const checkbox = document.getElementById('isToggledCheckbox');
+            const form = document.getElementById('filter-and-sort-form');
+            // 체크박스가 체크된 상태를 확인
+            checkbox.value = checkbox.checked ? 'Y' : 'N';
+            // 폼 제출
+            form.submit();
+        }
+
+        function submitForm() {
+            document.getElementById('filter-and-sort-form').submit();
+        }
+    </script>
     <div class="col-md-9">
         <div class="review-list">
-            <h2>프리랜서 게시글 관리</h2>
-            <form id="sort-form" th:action="@{/user/my/rct/free}" method="get">
+            <h3><a th:href="@{/user/my/rct/job}">뒤로가기(페이지번호미반영)</a></h3>
+            <h2>내가 올린 공고-지원서목록</h2>
+            <h3><a th:href="@{/recruit/job/view(no=${boardNo})}">공고 확인</a></h3>
+            <form id="filter-and-sort-form" th:action="@{/user/my/rct/job/apply(boardNo=${boardNo})}" method="get">
                 <label>
-                    <select name="orderBy" onchange="this.form.submit()">
-                        <option value="recentedited" th:selected="${orderBy == 'recentedited'}">최근수정순</option>
+                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">미열람
+                </label>
+                <!-- Hidden field for boardNo -->
+                <input type="hidden" name="boardNo" th:value="${boardNo}" />
 
+                <label>
+                    <select name="orderBy" onchange="submitForm()">
                         <option value="recent" th:selected="${orderBy == 'recent'}">최근작성순</option>
                         <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>
-
-                        <option value="topRated" th:selected="${orderBy == 'topRated'}">평점높은순</option>
-                        <option value="lowRated" th:selected="${orderBy == 'lowRated'}">평점낮은순</option>
-                        <option value="reviews" th:selected="${orderBy == 'reviews'}">리뷰많은순</option>
-
-                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>
                     </select>
                 </label>
             </form>
+<!--            <form id="filter-form" th:action="@{/user/my/rct/job/apply(boardNo=${boardNo})}" method="get">-->
+<!--                <label>-->
+<!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="toggleCheckboxValue()">미열람-->
+<!--                </label>-->
+<!--                &lt;!&ndash; Hidden field for boardNo &ndash;&gt;-->
+<!--                <input type="hidden" name="boardNo" th:value="${boardNo}" />-->
+<!--            </form>-->
             <table>
                 <thead>
                 <tr>
+                    <th>지원글 번호</th>
                     <th>게시글 번호</th>
-                    <th>작성자</th>
+                    <th>지원자</th>
                     <th>제목</th>
                     <th>내용</th>
                     <th>이미지</th>
-                    <th>가격</th>
+                    <th>작성 일자</th>
+                    <th>조회 여부</th>
+
+                    <th>작성자</th>
+                    <th>제목</th>
+                    <th>내용</th>
+                    <th>근무지</th>
+                    <th>이미지</th>
                     <th>작성 일자</th>
                     <th>수정 일자</th>
-                    <th>평점</th>
-                    <th>리뷰 개수</th>
+                    <th>마감 일자</th>
                 </tr>
                 </thead>
                 <tbody>
-                <tr th:each="myRctFree : ${myRctFrees}" class="clickable-row" th:attr="data-href=@{/recruit/free/view(no=${myRctFree.boardNo})}">
-                    <td th:text="${myRctFree.boardNo}">게시글 번호</td>
-                    <td th:text="${myRctFree.writer}">작성자</td>
-                    <td th:text="${myRctFree.title}">제목</td>
-                    <td th:text="${myRctFree.content}">내용</td>
-                    <td th:text="${myRctFree.img}">이미지</td>
-                    <td th:text="${myRctFree.price}">가격</td>
-                    <td th:text="${myRctFree.createdDate}">작성 일자</td>
-                    <td th:text="${myRctFree.modifiedDate}">수정 일자</td>
-                    <td th:text="${myRctFree.averageRating}">평점</td>
-                    <td th:text="${myRctFree.reviewCount}">리뷰 개수</td>
+                <tr th:each="myRctJobApplication : ${myRctJobApplications}" class="clickable-row" th:attr="data-href=@{/recruit/job/applyView(no=${myRctJobApplication.applyNo})}">
+                    <td th:text="${myRctJobApplication.applyNo}">지원글 번호</td>
+                    <td th:text="${myRctJobApplication.boardNo}">게시글 번호</td>
+                    <td th:text="${myRctJobApplication.writer}">지원자</td>
+                    <td th:text="${myRctJobApplication.applyTitle}">제목</td>
+                    <td th:text="${myRctJobApplication.applyContent}">내용</td>
+                    <td th:text="${myRctJobApplication.applyImg}">이미지</td>
+                    <td th:text="${myRctJobApplication.applyCreatedDate}">작성 일자</td>
+                    <td th:text="${myRctJobApplication.applyCheckStatus}">조회 여부</td>
+
+                    <td th:text="${myRctJobApplication.jobWriter}">작성자</td>
+                    <td th:text="${myRctJobApplication.jobTitle}">제목</td>
+                    <td th:text="${myRctJobApplication.jobContent}">내용</td>
+                    <td th:text="${myRctJobApplication.jobLocation}">근무지</td>
+                    <td th:text="${myRctJobApplication.jobImg}">이미지</td>
+                    <td th:text="${myRctJobApplication.jobCreatedDate}">작성 일자</td>
+                    <td th:text="${myRctJobApplication.jobModifiedDate}">수정 일자</td>
+                    <td th:text="${myRctJobApplication.jobDeadLine}">마감 일자</td>
                 </tr>
                 </tbody>
             </table>

--- a/src/main/resources/templates/user/mypage_rct_order.html
+++ b/src/main/resources/templates/user/mypage_rct_order.html
@@ -2,7 +2,7 @@
 <html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.w3.org/1999/xhtml">
 <html layout:decorate="~{layout}">
 <head>
-    <title>KHG20: 마이페이지-나의웹툰-북마크한웹툰</title>
+    <title>KHG46: 마이페이지-나의채용-프리랜서구매목록</title>
     <meta charset="UTF-8">
 
     <!-- Latest compiled and minified CSS -->
@@ -17,7 +17,6 @@
 
     <!-- Latest compiled JavaScript -->
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
-
 
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script>
@@ -82,31 +81,33 @@
           z-index: 1000;
         }
     </style>
-
 </head>
 <body>
 
 <div th:replace="~{common/menubar}"></div>
 <style>
-        .jumbotron {
-        position : relative;
-        }
-        .jumbotron .row {
-        position : absolute;
-        width : 100%;
-        bottom: 0%;
-        }
+    .jumbotron {
+    position : relative;
+    }
+    .jumbotron .row {
+    position : absolute;
+    width : 100%;
+    bottom: 0%;
+    }
 </style>
 <div class="jumbotron">
     <div class="row">
         <div class="col-md-3">
-            <h3>나의 웹툰</h3>
+            <h3>나의 채용</h3>
         </div>
         <div class="col-md-9">
             <nav class="navbar navbar-expand-md">
                 <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                    <li><a th:href="@{/user/my}" class="nav-link px-2">북마크한 웹툰</a></li>
-                    <li><a th:href="@{/user/my/wt/comment}" class="nav-link px-2">내가 남긴 코멘트</a></li>
+                    <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
+                    <li><a th:href="@{/user/my/rct/creator}" class="nav-link px-2">창작자 등록 현황</a></li>
+                    <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a></li>
+                    <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
+                    <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
                 </ul>
             </nav>
         </div>
@@ -125,60 +126,80 @@
             </ul>
         </div>
     </aside>
+<!--    <script>-->
+<!--        function toggleCheckboxValue() {-->
+<!--            const checkbox = document.getElementById('isToggledCheckbox');-->
+<!--            if(!checkbox.checked) checkbox.value = 'N';-->
+<!--            else checkbox.value = 'Y';-->
+<!--            document.getElementById('filter-form').submit();-->
+<!--        }-->
+<!--    </script>-->
+    <script> // toggle + sorting
+        function updateCheckboxValueAndSubmit() {
+            const checkbox = document.getElementById('isToggledCheckbox');
+            const form = document.getElementById('filter-and-sort-form');
+            // 체크박스가 체크된 상태를 확인
+            checkbox.value = checkbox.checked ? 'Y' : 'N';
+            // 폼 제출
+            form.submit();
+        }
+
+        function submitForm() {
+            document.getElementById('filter-and-sort-form').submit();
+        }
+    </script>
     <div class="col-md-9">
         <div class="review-list">
-            <h2>북마크한 웹툰</h2>
-            <form id="sort-form" th:action="@{/user/my/wt/webtoon}" method="get">
+            <h2>프리랜서 구매 목록</h2>
+            <form id="filter-and-sort-form" th:action="@{/user/my/rct/order}" method="get">
                 <label>
-                    <select name="orderBy" onchange="this.form.submit()">
-                        <option value="recent" th:selected="${orderBy == 'recent'}">최근저장순</option>
+                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">마감된 작업
+                </label>
+
+                <label>
+                    <select name="orderBy" onchange="submitForm()">
+                        <option value="recent" th:selected="${orderBy == 'recent'}">최근주문순</option>
                         <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>
-                        <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>
-                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>
+                        <option value="expensive" th:selected="${orderBy == 'expensive'}">결제금액높은순</option>
+                        <option value="cheap" th:selected="${orderBy == 'cheap'}">결제금액낮은순</option>
                     </select>
                 </label>
             </form>
 
+
+
+
+<!--            <form id="filter-form" th:action="@{/user/my/rct/order}" method="get">-->
+<!--                <label>-->
+<!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="toggleCheckboxValue()">마감된 작업-->
+<!--                </label>-->
+<!--            </form>-->
             <table>
                 <thead>
                 <tr>
-                    <th>저장번호</th>
-                    <th>웹툰 번호</th>
-                    <th>유저넘버</th>
-                    <th>웹툰아이디</th>
-                    <th>플렛폼</th>
-                    <th>제목</th>
-                    <th>작가</th>
-                    <th>이미지URL</th>
-                    <th>장르</th>
-                    <th>태그</th>
-                    <th>조회수</th>
+                    <th>주문 번호</th>
+                    <th>구매자</th>
+                    <th>구매상품</th>
+                    <th>구매 갯수</th>
+                    <th>결제 금액</th>
+                    <th>구매 일자</th>
+                    <th>작업 상태</th>
                 </tr>
                 </thead>
                 <tbody>
-                <tr th:each="myWtWebtoon : ${myWtWebtoons}" class="clickable-row"
-                    th:attr="data-href=@{/webtoon/one(
-                webtoon_id=${(myWtWebtoon.platform == 1 ? 'naver_' : myWtWebtoon.platform == 2 ? 'kakao_' : '') + myWtWebtoon.webtoonId},
-                webtoon_name=${myWtWebtoon.webtoonName},
-                author=${myWtWebtoon.author}
-                )}">
-                    <td th:text="${myWtWebtoon.saveNo}">저장번호</td>
-                    <td th:text="${myWtWebtoon.webtoonNo}">웹툰 번호</td>
-                    <td th:text="${myWtWebtoon.userNo}">유저넘버</td>
-                    <td th:text="${myWtWebtoon.webtoonId}">웹툰아이디</td>
-                    <td th:text="${myWtWebtoon.platform}">플렛폼</td>
-                    <td th:text="${myWtWebtoon.webtoonName}">제목</td>
-                    <td th:text="${myWtWebtoon.author}">작가</td>
-                    <td th:text="${myWtWebtoon.thumbnailUrl}">이미지URL</td>
-                    <td th:text="${myWtWebtoon.genre}">장르</td>
-                    <td th:text="${myWtWebtoon.tags}">태그</td>
-                    <td th:text="${myWtWebtoon.count}">조회수</td>
+                <tr th:each="myRctOrder : ${myRctOrders}" class="clickable-row" th:attr="data-href=@{/recruit/free/view(no=${myRctOrder.boardNo})}">
+                    <td th:text="${myRctOrder.orderNo}">주문 번호</td>
+                    <td th:text="${myRctOrder.memberNo}">구매자</td>
+                    <td th:text="${myRctOrder.boardNo}">구매상품</td>
+                    <td th:text="${myRctOrder.quantity}">구매 갯수</td>
+                    <td th:text="${myRctOrder.price}">결제 금액</td>
+                    <td th:text="${myRctOrder.orderedDate}">구매 일자</td>
+                    <td th:text="${myRctOrder.status}">작업 상태</td>
                 </tr>
                 </tbody>
             </table>
         </div>
     </div>
 </div>
-
 </body>
 </html>

--- a/src/main/resources/templates/user/mypage_so_diary.html
+++ b/src/main/resources/templates/user/mypage_so_diary.html
@@ -4,6 +4,21 @@
 <head>
     <title>KHG31: 마이페이지-나의소셜-내가남긴다이어리댓글</title>
     <meta charset="UTF-8">
+
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <!-- 폰트: 'Noto Sans KR' 사용 -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap">
+    <!-- 프로젝트 툰게더 전용 css 스타일 시트 -->
+    <link rel="stylesheet" th:href="@{/css/styles.css}">
+
+    <!-- jQuery library -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+
+    <!-- Latest compiled JavaScript -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+
+
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script>
         $(document).ready(function($) {
@@ -71,65 +86,98 @@
 <body>
 
 <div th:replace="~{common/menubar}"></div>
-<div layout:fragment="content">
-    <nav class="navbar navbar-expand-md">
-        <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-            <li><a th:href="@{/user/my}" class="nav-link px-2">나의 웹툰</a></li>
-            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
-            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-        </ul>
-    </nav>
+<style>
+    .jumbotron {
+    position : relative;
+    }
+    .jumbotron .row {
+    position : absolute;
+    width : 100%;
+    bottom: 0%;
+    }
+</style>
+<div class="jumbotron">
+    <div class="row">
+        <div class="col-md-3">
+            <h3>나의 소셜</h3>
+        </div>
+        <div class="col-md-9">
+            <nav class="navbar navbar-expand-md">
+                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                    <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">좋아요한 리뷰</a></li>
+                    <li><a th:href="@{/user/my/so/diary}" class="nav-link px-2">내가 남긴 다이어리 댓글</a></li>
+                </ul>
+            </nav>
+        </div>
+    </div>
 </div>
-<div layout:fragment="content">
-    <nav class="navbar navbar-expand-md">
-        <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">좋아요한 리뷰</a></li>
-            <li><a th:href="@{/user/my/so/diary}" class="nav-link px-2">내가 남긴 다이어리 댓글</a></li>
-        </ul>
-    </nav>
-</div>
-<div class="container">
-    <div class="review-list">
-        <h2>내가 남긴 다이어리 댓글</h2>
-        <table>
-            <thead>
-            <tr>
-                <th>댓글 번호</th>
-                <th>다이어리 번호</th>
-                <th>댓글 작성자</th>
-                <th>댓글 내용</th>
-                <th>댓글 작성일시</th>
-                <th>웹툰 번호</th>
-                <th>작성자</th>
-                <th>제목</th>
-                <th>다이어리 내용</th>
-                <th>상태 코드</th>
-                <th>다이어리 작성일시</th>
-                <th>다이어리 수정일시</th>
-                <th>조회수</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr th:each="mySoDiary : ${mySoDiaries}" class="clickable-row" th:attr="data-href=@{/social/diaries/{diaryNo}(diaryNo=${mySoDiary.diaryNo})}">
-                <td th:text="${mySoDiary.commentNo}">댓글 번호</td>
-                <td th:text="${mySoDiary.diaryNo}">다이어리 번호</td>
-                <td th:text="${mySoDiary.commenterNo}">댓글 작성자</td>
-                <td th:text="${mySoDiary.commentContent}">댓글 내용</td>
-                <td th:text="${mySoDiary.commentCreatedDate}">댓글 작성일시</td>
-                <td th:text="${mySoDiary.webtoonNo}">웹툰 번호</td>
-                <td th:text="${mySoDiary.writerNo}">작성자</td>
-                <td th:text="${mySoDiary.title}">제목</td>
-                <td th:text="${mySoDiary.diaryContent}">다이어리 내용</td>
-                <td th:text="${mySoDiary.statusCode}">상태 코드</td>
-                <td th:text="${mySoDiary.diaryCreatedDate}">다이어리 작성일시</td>
-                <td th:text="${mySoDiary.diaryModifiedDate}">다이어리 수정일시</td>
-                <td th:text="${mySoDiary.viewCnt}">조회수</td>
-            </tr>
-            </tbody>
-        </table>
+<div class="row">
+    <aside class="col-md-3">
+        <div class="panel">
+            <ul class="list-group">
+                <li><a th:href="@{/user/my}" class="nav-link px-2">나의 웹툰</a></li>
+                <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
+                <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+            </ul>
+        </div>
+    </aside>
+    <div class="col-md-9">
+        <div class="review-list">
+            <h2>내가 남긴 다이어리 댓글</h2>
+            <form id="sort-form" th:action="@{/user/my/so/diary}" method="get">
+                <label>
+                    <select name="orderBy" onchange="this.form.submit()">
+                        <option value="recentposted" th:selected="${orderBy == 'recentposted'}">최근남긴순</option>
+                        <option value="oldestposted" th:selected="${orderBy == 'oldestposted'}">오래된순</option>
+
+                        <option value="recentadded" th:selected="${orderBy == 'recentadded'}">최근작성순</option>
+                        <option value="oldestadded" th:selected="${orderBy == 'oldestadded'}">오래된작성순</option>
+
+                        <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>
+                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>
+                    </select>
+                </label>
+            </form>
+            <table>
+                <thead>
+                <tr>
+                    <th>댓글 번호</th>
+                    <th>다이어리 번호</th>
+                    <th>댓글 작성자</th>
+                    <th>댓글 내용</th>
+                    <th>댓글 작성일시</th>
+                    <th>웹툰 번호</th>
+                    <th>작성자</th>
+                    <th>제목</th>
+                    <th>다이어리 내용</th>
+                    <th>상태 코드</th>
+                    <th>다이어리 작성일시</th>
+                    <th>다이어리 수정일시</th>
+                    <th>조회수</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="mySoDiary : ${mySoDiaries}" class="clickable-row" th:attr="data-href=@{/social/diaries/{diaryNo}(diaryNo=${mySoDiary.diaryNo})}">
+                    <td th:text="${mySoDiary.commentNo}">댓글 번호</td>
+                    <td th:text="${mySoDiary.diaryNo}">다이어리 번호</td>
+                    <td th:text="${mySoDiary.commenterNo}">댓글 작성자</td>
+                    <td th:text="${mySoDiary.commentContent}">댓글 내용</td>
+                    <td th:text="${mySoDiary.commentCreatedDate}">댓글 작성일시</td>
+                    <td th:text="${mySoDiary.webtoonNo}">웹툰 번호</td>
+                    <td th:text="${mySoDiary.writerNo}">작성자</td>
+                    <td th:text="${mySoDiary.title}">제목</td>
+                    <td th:text="${mySoDiary.diaryContent}">다이어리 내용</td>
+                    <td th:text="${mySoDiary.statusCode}">상태 코드</td>
+                    <td th:text="${mySoDiary.diaryCreatedDate}">다이어리 작성일시</td>
+                    <td th:text="${mySoDiary.diaryModifiedDate}">다이어리 수정일시</td>
+                    <td th:text="${mySoDiary.viewCnt}">조회수</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
     </div>
 </div>
 </body>

--- a/src/main/resources/templates/user/mypage_so_review.html
+++ b/src/main/resources/templates/user/mypage_so_review.html
@@ -4,6 +4,21 @@
 <head>
     <title>KHG30: 마이페이지-나의소셜-좋아요한리뷰</title>
     <meta charset="UTF-8">
+
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <!-- 폰트: 'Noto Sans KR' 사용 -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap">
+    <!-- 프로젝트 툰게더 전용 css 스타일 시트 -->
+    <link rel="stylesheet" th:href="@{/css/styles.css}">
+
+    <!-- jQuery library -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+
+    <!-- Latest compiled JavaScript -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+
+
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script>
         $(document).ready(function($) {
@@ -71,61 +86,98 @@
 <body>
 
 <div th:replace="~{common/menubar}"></div>
-<div layout:fragment="content">
-    <nav class="navbar navbar-expand-md">
-        <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-            <li><a th:href="@{/user/my}" class="nav-link px-2">나의 웹툰</a></li>
-            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
-            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-        </ul>
-    </nav>
+<style>
+    .jumbotron {
+    position : relative;
+    }
+    .jumbotron .row {
+    position : absolute;
+    width : 100%;
+    bottom: 0%;
+    }
+</style>
+<div class="jumbotron">
+    <div class="row">
+        <div class="col-md-3">
+            <h3>나의 소셜</h3>
+        </div>
+        <div class="col-md-9">
+            <nav class="navbar navbar-expand-md">
+                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                    <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">좋아요한 리뷰</a></li>
+                    <li><a th:href="@{/user/my/so/diary}" class="nav-link px-2">내가 남긴 다이어리 댓글</a></li>
+                </ul>
+            </nav>
+        </div>
+    </div>
 </div>
-<div layout:fragment="content">
-    <nav class="navbar navbar-expand-md">
-        <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">좋아요한 리뷰</a></li>
-            <li><a th:href="@{/user/my/so/diary}" class="nav-link px-2">내가 남긴 다이어리 댓글</a></li>
-        </ul>
-    </nav>
-</div>
-<div class="container">
-    <div class="review-list">
-        <h2>좋아요한 리뷰</h2>
-        <table>
-            <thead>
-            <tr>
-                <th>좋아요 번호</th>
-                <th>리뷰 번호</th>
-                <th>좋아요 한 회원</th>
-                <th>좋아요 일시</th>
-                <th>웹툰 번호</th>
-                <th>제목</th>
-                <th>내용</th>
-                <th>별점 평가</th>
-                <th>작성일시</th>
-                <th>수정일시</th>
-                <th>조회수</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr th:each="mySoReview : ${mySoReviews}" class="clickable-row" th:attr="data-href=@{/social/reviews/{reviewNo}(reviewNo=${mySoReview.reviewNo})}">
-                <td th:text="${mySoReview.likeNo}">좋아요 번호</td>
-                <td th:text="${mySoReview.reviewNo}">리뷰 번호</td>
-                <td th:text="${mySoReview.likedUser}">좋아요 한 회원</td>
-                <td th:text="${mySoReview.likedDate}">좋아요 일시</td>
-                <td th:text="${mySoReview.webtoonNo}">웹툰 번호</td>
-                <td th:text="${mySoReview.title}">제목</td>
-                <td th:text="${mySoReview.content}">내용</td>
-                <td th:text="${mySoReview.starRating}">별점 평가</td>
-                <td th:text="${mySoReview.createdDate}">작성일시</td>
-                <td th:text="${mySoReview.modifiedDate}">수정일시</td>
-                <td th:text="${mySoReview.viewCnt}">조회수</td>
-            </tr>
-            </tbody>
-        </table>
+<div class="row">
+    <aside class="col-md-3">
+        <div class="panel">
+            <ul class="list-group">
+                <li><a th:href="@{/user/my}" class="nav-link px-2">나의 웹툰</a></li>
+                <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
+                <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+            </ul>
+        </div>
+    </aside>
+    <div class="col-md-9">
+        <div class="review-list">
+            <h2>좋아요한 리뷰</h2>
+            <form id="sort-form" th:action="@{/user/my/so/review}" method="get">
+                <label>
+                    <select name="orderBy" onchange="this.form.submit()">
+                        <option value="recentliked" th:selected="${orderBy == 'recentliked'}">최근좋아요순</option>
+                        <option value="oldestliked" th:selected="${orderBy == 'oldestliked'}">오래된좋아요순</option>
+
+                        <option value="recentadded" th:selected="${orderBy == 'recentadded'}">최근작성순</option>
+                        <option value="oldestadded" th:selected="${orderBy == 'oldestadded'}">오래된작성순</option>
+
+                        <option value="highrated" th:selected="${orderBy == 'highrated'}">별점높은순</option>
+                        <option value="lowrated" th:selected="${orderBy == 'lowrated'}">별점낮은순</option>
+
+                        <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>
+                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>
+                    </select>
+                </label>
+            </form>
+
+            <table>
+                <thead>
+                <tr>
+                    <th>좋아요 번호</th>
+                    <th>리뷰 번호</th>
+                    <th>좋아요 한 회원</th>
+                    <th>좋아요 일시</th>
+                    <th>웹툰 번호</th>
+                    <th>제목</th>
+                    <th>내용</th>
+                    <th>별점 평가</th>
+                    <th>작성일시</th>
+                    <th>수정일시</th>
+                    <th>조회수</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="mySoReview : ${mySoReviews}" class="clickable-row" th:attr="data-href=@{/social/reviews/{reviewNo}(reviewNo=${mySoReview.reviewNo})}">
+                    <td th:text="${mySoReview.likeNo}">좋아요 번호</td>
+                    <td th:text="${mySoReview.reviewNo}">리뷰 번호</td>
+                    <td th:text="${mySoReview.likedUser}">좋아요 한 회원</td>
+                    <td th:text="${mySoReview.likedDate}">좋아요 일시</td>
+                    <td th:text="${mySoReview.webtoonNo}">웹툰 번호</td>
+                    <td th:text="${mySoReview.title}">제목</td>
+                    <td th:text="${mySoReview.content}">내용</td>
+                    <td th:text="${mySoReview.starRating}">별점 평가</td>
+                    <td th:text="${mySoReview.createdDate}">작성일시</td>
+                    <td th:text="${mySoReview.modifiedDate}">수정일시</td>
+                    <td th:text="${mySoReview.viewCnt}">조회수</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
     </div>
 </div>
 </body>

--- a/src/main/resources/templates/user/mypage_wt_comment.html
+++ b/src/main/resources/templates/user/mypage_wt_comment.html
@@ -4,6 +4,21 @@
 <head>
     <title>KHG21: 마이페이지-나의웹툰-내가남긴코멘트</title>
     <meta charset="UTF-8">
+
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <!-- 폰트: 'Noto Sans KR' 사용 -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap">
+    <!-- 프로젝트 툰게더 전용 css 스타일 시트 -->
+    <link rel="stylesheet" th:href="@{/css/styles.css}">
+
+    <!-- jQuery library -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+
+    <!-- Latest compiled JavaScript -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+
+
     <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
     <script>
         $(document).ready(function($) {
@@ -71,72 +86,102 @@
 <body>
 
 <div th:replace="~{common/menubar}"></div>
-<div layout:fragment="content">
-    <nav class="navbar navbar-expand-md">
-        <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-            <li><a th:href="@{/user/my}" class="nav-link px-2">나의 웹툰</a></li>
-            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
-            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-        </ul>
-    </nav>
+<style>
+    .jumbotron {
+    position : relative;
+    }
+    .jumbotron .row {
+    position : absolute;
+    width : 100%;
+    bottom: 0%;
+    }
+</style>
+<div class="jumbotron">
+    <div class="row">
+        <div class="col-md-3">
+            <h3>나의 웹툰</h3>
+        </div>
+        <div class="col-md-9">
+            <nav class="navbar navbar-expand-md">
+                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                    <li><a th:href="@{/user/my}" class="nav-link px-2">북마크한 웹툰</a></li>
+                    <li><a th:href="@{/user/my/wt/comment}" class="nav-link px-2">내가 남긴 코멘트</a></li>
+                </ul>
+            </nav>
+        </div>
+    </div>
 </div>
-<div layout:fragment="content">
-    <nav class="navbar navbar-expand-md">
-        <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-            <li><a th:href="@{/user/my}" class="nav-link px-2">북마크한 웹툰</a></li>
-            <li><a th:href="@{/user/my/wt/comment}" class="nav-link px-2">내가 남긴 코멘트</a></li>
-        </ul>
-    </nav>
-</div>
-<div class="container">
-    <div class="review-list">
-        <h2>내가 남긴 코멘트</h2>
-        <table>
-            <thead>
-            <tr>
-                <th>댓글 번호</th>
-                <th>웹툰 번호</th>
-                <th>유저 번호</th>
-                <th>내용</th>
-                <th>좋아요</th>
-                <th>싫어요</th>
-                <th>웹툰아이디</th>
-                <th>플렛폼</th>
-                <th>제목</th>
-                <th>작가</th>
-                <th>이미지URL</th>
-                <th>장르</th>
-                <th>태그</th>
-                <th>조회수</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr th:each="myWtComment : ${myWtComments}" class="clickable-row"
-                th:attr="data-href=@{/webtoon/one(
-            webtoon_id=${(myWtComment.platform == 1 ? 'naver_' : myWtComment.platform == 2 ? 'kakao_' : '') + myWtComment.webtoonId},
-            webtoon_name=${myWtComment.webtoonName},
-            author=${myWtComment.author}
-            )}">
-                <td th:text="${myWtComment.commentNo}">댓글 번호</td>
-                <td th:text="${myWtComment.webtoonNo}">웹툰 번호</td>
-                <td th:text="${myWtComment.userNo}">유저 번호</td>
-                <td th:text="${myWtComment.content}">내용</td>
-                <td th:text="${myWtComment.liked}">좋아요</td>
-                <td th:text="${myWtComment.dislike}">싫어요</td>
-                <td th:text="${myWtComment.webtoonId}">웹툰아이디</td>
-                <td th:text="${myWtComment.platform}">플렛폼</td>
-                <td th:text="${myWtComment.webtoonName}">제목</td>
-                <td th:text="${myWtComment.author}">작가</td>
-                <td th:text="${myWtComment.thumbnailUrl}">이미지URL</td>
-                <td th:text="${myWtComment.genre}">장르</td>
-                <td th:text="${myWtComment.tags}">태그</td>
-                <td th:text="${myWtComment.count}">조회수</td>
-            </tr>
-            </tbody>
-        </table>
+<div class="row">
+    <aside class="col-md-3">
+        <div class="panel">
+            <ul class="list-group">
+                <li><a th:href="@{/user/my}" class="nav-link px-2">나의 웹툰</a></li>
+                <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
+                <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+            </ul>
+        </div>
+    </aside>
+    <div class="col-md-9">
+        <div class="review-list">
+            <h2>내가 남긴 코멘트</h2>
+            <form id="sort-form" th:action="@{/user/my/wt/comment}" method="get">
+                <label>
+                    <select name="orderBy" onchange="this.form.submit()">
+                        <option value="recent" th:selected="${orderBy == 'recent'}">최근남긴순</option>
+                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>
+                        <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>
+                        <option value="likes" th:selected="${orderBy == 'likes'}">댓글좋아요많은순</option>
+                    </select>
+                </label>
+            </form>
+
+            <table>
+                <thead>
+                <tr>
+                    <th>댓글 번호</th>
+                    <th>웹툰 번호</th>
+                    <th>유저 번호</th>
+                    <th>내용</th>
+                    <th>좋아요</th>
+                    <th>싫어요</th>
+                    <th>웹툰아이디</th>
+                    <th>플렛폼</th>
+                    <th>제목</th>
+                    <th>작가</th>
+                    <th>이미지URL</th>
+                    <th>장르</th>
+                    <th>태그</th>
+                    <th>조회수</th>
+                </tr>
+                </thead>
+                <tbody>
+                <tr th:each="myWtComment : ${myWtComments}" class="clickable-row"
+                    th:attr="data-href=@{/webtoon/one(
+                webtoon_id=${(myWtComment.platform == 1 ? 'naver_' : myWtComment.platform == 2 ? 'kakao_' : '') + myWtComment.webtoonId},
+                webtoon_name=${myWtComment.webtoonName},
+                author=${myWtComment.author}
+                )}">
+                    <td th:text="${myWtComment.commentNo}">댓글 번호</td>
+                    <td th:text="${myWtComment.webtoonNo}">웹툰 번호</td>
+                    <td th:text="${myWtComment.userNo}">유저 번호</td>
+                    <td th:text="${myWtComment.content}">내용</td>
+                    <td th:text="${myWtComment.liked}">좋아요</td>
+                    <td th:text="${myWtComment.dislike}">싫어요</td>
+                    <td th:text="${myWtComment.webtoonId}">웹툰아이디</td>
+                    <td th:text="${myWtComment.platform}">플렛폼</td>
+                    <td th:text="${myWtComment.webtoonName}">제목</td>
+                    <td th:text="${myWtComment.author}">작가</td>
+                    <td th:text="${myWtComment.thumbnailUrl}">이미지URL</td>
+                    <td th:text="${myWtComment.genre}">장르</td>
+                    <td th:text="${myWtComment.tags}">태그</td>
+                    <td th:text="${myWtComment.count}">조회수</td>
+                </tr>
+                </tbody>
+            </table>
+        </div>
     </div>
 </div>
 </body>

--- a/src/main/resources/templates/user/pwfound.html
+++ b/src/main/resources/templates/user/pwfound.html
@@ -4,6 +4,20 @@
 <head>
     <title>KHG13: 비밀번호찾기 성공</title>
     <meta charset="UTF-8">
+
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <!-- 폰트: 'Noto Sans KR' 사용 -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap">
+    <!-- 프로젝트 툰게더 전용 css 스타일 시트 -->
+    <link rel="stylesheet" th:href="@{/css/styles.css}">
+
+    <!-- jQuery library -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+
+    <!-- Latest compiled JavaScript -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+
     <style>
         .navbar {
           position: fixed;
@@ -14,44 +28,83 @@
 <body>
 
 <div th:replace="~{common/menubar}"></div>
-<div>
-    비밀번호 찾기<br>
-
-    <a href="#">아이디 찾기</a><br>
-    <a href="/user/findpw">비밀번호 찾기</a><br>
-
-    <div th:if="${password != null}">
-        임시 비밀번호를<br>
-        회원정보에 등록된 이메일 주소로<br>
-        발송하였습니다.<br>
-        메일함을 확인해 주세요.<br>
-<!--        (추후 수정예정)찾으시는 비밀번호는<br>-->
-<!--        <span th:text="${password}"></span><br>-->
-<!--        입니다.<br>-->
+<style>
+    .jumbotron {
+    position : relative;
+    }
+    .jumbotron .row {
+    position : absolute;
+    width : 100%;
+    bottom: 0%;
+    }
+</style>
+<div class="jumbotron">
+    <div class="row">
+        <div class="col-md-3">
+            <h3>로그인</h3>
+        </div>
+        <div class="col-md-9">
+            <nav class="navbar navbar-expand-md">
+                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                    <li>-</li>
+                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                </ul>
+            </nav>
+        </div>
     </div>
-    <div th:if="${password == null}">
-        비밀번호 찾기에 실패했습니다.<br>
-        다시 시도해주세요.<br>
+</div>
+<div class="row">
+    <aside class="col-md-3">
+        <div class="panel">
+            <ul class="list-group">
+                <li><a th:href="@{/user/login}" class="nav-link px-2">로그인</a></li>
+                <li><a th:href="@{/user/signup}" class="nav-link px-2">회원가입</a></li>
+            </ul>
+        </div>
+    </aside>
+    <div class="col-md-9">
+        <div>
+            비밀번호 찾기<br>
+
+            <a href="#">아이디 찾기</a><br>
+            <a href="/user/findpw">비밀번호 찾기</a><br>
+
+            <div th:if="${password != null}">
+                임시 비밀번호를<br>
+                회원정보에 등록된 이메일 주소로<br>
+                발송하였습니다.<br>
+                메일함을 확인해 주세요.<br>
+        <!--        (추후 수정예정)찾으시는 비밀번호는<br>-->
+        <!--        <span th:text="${password}"></span><br>-->
+        <!--        입니다.<br>-->
+            </div>
+            <div th:if="${password == null}">
+                비밀번호 찾기에 실패했습니다.<br>
+                다시 시도해주세요.<br>
+            </div>
+
+            <a href="/user/login">로그인</a>
+            <!--    <form th:action="@{/user/signup}" th:object="${user}" method="post">-->
+            <!--        아이디 : <input type="text" name="userId"><br>-->
+            <!--        비밀번호 : <input type="password" name="password"><br>-->
+            <!--        비밀번호 확인 : <br>-->
+            <!--        닉네임 : <input type="text" name="nickname"><br>-->
+            <!--        연락처 : <input type="text" name="contactNumber"><br>-->
+            <!--        성별 : <select name="gender">-->
+            <!--        <option>성별을 공개하지 않습니다-->
+            <!--        <option>여-->
+            <!--        <option>남</select><br>-->
+            <!--        생년월일 : <input type="text" name="dateOfBirth"><br>-->
+            <!--        이메일 : <input type="text" name="email"><br>-->
+            <!--        자기소개(선택사항) : <input type="text" name="bio"><br>-->
+            <!--        <input type="checkbox" name="termsAgreement">본인은 툰게더 회원 약관에 동의합니다.<br>-->
+
+            <!--        <input type="submit">가입하기-->
+            <!--    </form>-->
+        </div>
     </div>
-
-    <a href="/user/login">로그인</a>
-    <!--    <form th:action="@{/user/signup}" th:object="${user}" method="post">-->
-    <!--        아이디 : <input type="text" name="userId"><br>-->
-    <!--        비밀번호 : <input type="password" name="password"><br>-->
-    <!--        비밀번호 확인 : <br>-->
-    <!--        닉네임 : <input type="text" name="nickname"><br>-->
-    <!--        연락처 : <input type="text" name="contactNumber"><br>-->
-    <!--        성별 : <select name="gender">-->
-    <!--        <option>성별을 공개하지 않습니다-->
-    <!--        <option>여-->
-    <!--        <option>남</select><br>-->
-    <!--        생년월일 : <input type="text" name="dateOfBirth"><br>-->
-    <!--        이메일 : <input type="text" name="email"><br>-->
-    <!--        자기소개(선택사항) : <input type="text" name="bio"><br>-->
-    <!--        <input type="checkbox" name="termsAgreement">본인은 툰게더 회원 약관에 동의합니다.<br>-->
-
-    <!--        <input type="submit">가입하기-->
-    <!--    </form>-->
 </div>
 </body>
 </html>

--- a/src/main/resources/templates/user/signup.html
+++ b/src/main/resources/templates/user/signup.html
@@ -6,6 +6,21 @@
 <head>
     <title>KHG01: 회원가입</title>
     <meta charset="UTF-8">
+
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <!-- 폰트: 'Noto Sans KR' 사용 -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap">
+    <!-- 프로젝트 툰게더 전용 css 스타일 시트 -->
+    <link rel="stylesheet" th:href="@{/css/styles.css}">
+
+    <!-- jQuery library -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+
+    <!-- Latest compiled JavaScript -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+
+
     <style>
         .navbar {
           position: fixed;
@@ -74,6 +89,8 @@
             const phoneNumberInput = document.querySelector('input[name="contactNumber"]');
             const phoneNumber = phoneNumberInput.value;
 
+            const termsCheckbox = document.getElementById('termsAgreementCheckbox');
+
             // 이메일 검증
             if (!validateEmail(email)) {
                 alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
@@ -94,47 +111,159 @@
                 event.preventDefault(); // 폼 제출을 막음
                 return;
             }
-        }
+
+            // 필수 약관동의 검증
+            if (!termsCheckbox.checked) {
+                alert('필수 약관에 동의하지 않았습니다.');
+                event.preventDefault(); // 폼 제출을 막음
+                return;
+            }
+
+        } //validateForm(event)
     </script>
 </head>
 <body>
 
 <div th:replace="~{common/menubar}"></div>
-<div>
-    <form th:action="@{/user/signup}" th:object="${user}" method="post" onsubmit="validateForm(event)">
-        아이디 : <input type="text" th:field="*{userId}" maxlength="20" minlength="4"/> (중복불가)<br>
-        비밀번호 : <input type="password" th:field="*{password}" maxlength="30" minlength="8"/><br>
-        비밀번호 확인 : <br>
-        닉네임 : <input type="text" th:field="*{nickname}" maxlength="20" minlength="4"/> (중복불가)<br>
-        연락처 : <input type="text" th:field="*{contactNumber}" oninput="autoFormatPhoneNumber(this)" placeholder="000-0000-0000"/><br>
-        성별 : <select th:field="*{gender}">
-        <option value="P">성별을 공개하지 않습니다
-        <option value="F">여
-        <option value="M">남</select><br>
-        생년월일 : <input type="text" th:field="*{dateOfBirth}" oninput="autoFormatDate(this)" placeholder="yyyy-mm-dd"/><br>
-        이메일 : <input type="text" th:field="*{email}"/> (중복불가)<br>
-        자기소개(선택사항) : <input type="text" th:field="*{bio}"/><br>
-        <input type="checkbox" th:field="*{termsAgreement}"/>본인은 툰게더 회원 약관에 동의합니다.<br>
+<style>
+    .jumbotron {
+    position : relative;
+    }
+    .jumbotron .row {
+    position : absolute;
+    width : 100%;
+    bottom: 0%;
+    }
+</style>
+<div class="jumbotron">
+    <div class="row">
+        <div class="col-md-3">
+            <h3>회원 가입</h3>
+        </div>
+        <div class="col-md-9">
+            <nav class="navbar navbar-expand-md">
+                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                    <li>-</li>
+                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                </ul>
+            </nav>
+        </div>
+    </div>
+</div>
+<div class="row">
+    <aside class="col-md-3">
+        <div class="panel">
+            <ul class="list-group">
+                <li><a th:href="@{/user/login}" class="nav-link px-2">로그인</a></li>
+                <li><a th:href="@{/user/signup}" class="nav-link px-2">회원가입</a></li>
+            </ul>
+        </div>
+    </aside>
+    <script>
+        // id available check
+        function checkIdDuplicate() {
+            const userId = document.getElementById('userId').value;
 
-        <input type="submit">가입하기
-    </form>
-    <!--    <form th:action="@{/user/signup}" th:object="${user}" method="post">-->
-    <!--        아이디 : <input type="text" name="userId"><br>-->
-    <!--        비밀번호 : <input type="password" name="password"><br>-->
-    <!--        비밀번호 확인 : <br>-->
-    <!--        닉네임 : <input type="text" name="nickname"><br>-->
-    <!--        연락처 : <input type="text" name="contactNumber"><br>-->
-    <!--        성별 : <select name="gender">-->
-    <!--        <option>성별을 공개하지 않습니다-->
-    <!--        <option>여-->
-    <!--        <option>남</select><br>-->
-    <!--        생년월일 : <input type="text" name="dateOfBirth"><br>-->
-    <!--        이메일 : <input type="text" name="email"><br>-->
-    <!--        자기소개(선택사항) : <input type="text" name="bio"><br>-->
-    <!--        <input type="checkbox" name="termsAgreement">본인은 툰게더 회원 약관에 동의합니다.<br>-->
+            if(!userId) {
+                alert('아이디를 입력해 주세요.');
+                return;
+            }
 
-    <!--        <input type="submit">가입하기-->
-    <!--    </form>-->
+            fetch(`/user/checkIdDuplicate?userId=${encodeURIComponent(userId)}`)
+                .then(response => response.json())
+                .then(data => {
+                    if (data.isDuplicate) alert('이미 존재하는 아이디입니다. ');
+                    else alert('사용 가능한 아이디입니다.');
+                })
+                .catch(error => {
+                    console.error('Error: ', error);
+                });
+        } //checkIdDuplicate()
+
+        // nickname available check
+        function checkNicknameDuplicate() {
+            const nickname = document.getElementById('nickname').value;
+
+            if(!nickname) {
+                alert('닉네임을 입력해 주세요.');
+                return;
+            }
+
+            fetch(`/user/checkNicknameDuplicate?nickname=${encodeURIComponent(nickname)}`)
+                .then(response => response.json())
+                .then(data => {
+                    if (data.isDuplicate) alert('이미 사용 중인 닉네임입니다.');
+                    else alert('사용 가능한 닉네임입니다.');
+                })
+                .catch(error => {
+                    console.error('Error: ', error);
+                });
+        } //checkNicknameDuplicate()
+
+        // email available check
+        function checkEmailDuplicate() {
+            const email = document.getElementById('email').value;
+
+            if(!email) {
+                alert('이메일을 입력해 주세요.');
+                return;
+            }
+
+            fetch(`/user/checkEmailDuplicate?email=${encodeURIComponent(email)}`)
+                .then(response => response.json())
+                .then(data => {
+                    if (data.isDuplicate) alert('이미 등록된 이메일입니다.');
+                    else alert('등록 가능한 이메일입니다.');
+                })
+                .catch(error => {
+                    console.error('Error: ', error);
+                });
+        } //checkEmailDuplicate()
+    </script>
+    <div class="col-md-9">
+        <form th:action="@{/user/signup}" th:object="${user}" method="post" onsubmit="validateForm(event)">
+            아이디 : <input type="text" th:field="*{userId}" maxlength="20" minlength="4"/>
+            <button type="button" onclick="checkIdDuplicate()">중복확인</button>
+            <br>
+            비밀번호 : <input type="password" th:field="*{password}" maxlength="30" minlength="8"/><br>
+            비밀번호 확인 : <br>
+            닉네임 : <input type="text" th:field="*{nickname}" maxlength="20" minlength="4"/>
+            <button type="button" onclick="checkNicknameDuplicate()">중복확인</button>
+            <br>
+            연락처 : <input type="text" th:field="*{contactNumber}" oninput="autoFormatPhoneNumber(this)" placeholder="000-0000-0000"/><br>
+            성별 : <select th:field="*{gender}">
+            <option value="P">성별을 공개하지 않습니다
+            <option value="F">여
+            <option value="M">남</select><br>
+            생년월일 : <input type="text" th:field="*{dateOfBirth}" oninput="autoFormatDate(this)" placeholder="yyyy-mm-dd"/><br>
+            이메일 : <input type="text" th:field="*{email}"/>
+            <button type="button" onclick="checkEmailDuplicate()">중복확인</button>
+            <br>
+            자기소개(선택사항) : <input type="text" th:field="*{bio}"/><br>
+            <input type="checkbox" id="termsAgreementCheckbox" th:field="*{termsAgreement}"/>[필수] 본인은 툰게더 회원 약관에 동의합니다.<br>
+
+            <input type="submit">가입하기
+        </form>
+        <!--    <form th:action="@{/user/signup}" th:object="${user}" method="post">-->
+        <!--        아이디 : <input type="text" name="userId"><br>-->
+        <!--        비밀번호 : <input type="password" name="password"><br>-->
+        <!--        비밀번호 확인 : <br>-->
+        <!--        닉네임 : <input type="text" name="nickname"><br>-->
+        <!--        연락처 : <input type="text" name="contactNumber"><br>-->
+        <!--        성별 : <select name="gender">-->
+        <!--        <option>성별을 공개하지 않습니다-->
+        <!--        <option>여-->
+        <!--        <option>남</select><br>-->
+        <!--        생년월일 : <input type="text" name="dateOfBirth"><br>-->
+        <!--        이메일 : <input type="text" name="email"><br>-->
+        <!--        자기소개(선택사항) : <input type="text" name="bio"><br>-->
+        <!--        <input type="checkbox" name="termsAgreement">본인은 툰게더 회원 약관에 동의합니다.<br>-->
+
+        <!--        <input type="submit">가입하기-->
+        <!--    </form>-->
+    </div>
 </div>
 </body>
 </html>


### PR DESCRIPTION
**[강현구-240806] merge :: 소셜로그인/마이페이지 구현 등**
[강현구-240806-01]feat :: 소셜로그인 구현
-/user/controller/AuthController.java 로 분리하여 소셜로그인 2종(네이버/카카오) 구현하였습니다.

fix :: 프론트 1차 구현(jumbotron, aside)
-bootstrap의 jumbotron, aside를 통해 UI 설계서에 맞게 구조 잡았습니다.

feat :: 마이페이지 토글/소팅 기능 추가
-마이페이지의 모든 리스트에 소팅 구현
-토글 구현하였습니다.

feat :: 회원가입/수정/관리자회원관리 중복확인 추가
-아이디/닉네임/이메일 중복체크 가능하도록 구현하였습니다.
-/user/controller/AuthController.java 로 분리하여 소셜로그인 2종(네이버/카카오) 구현하였습니다.

fix :: 프론트 1차 구현(jumbotron, aside)
-bootstrap의 jumbotron, aside를 통해 UI 설계서에 맞게 구조 잡았습니다.

feat :: 마이페이지 토글/소팅 기능 추가
-마이페이지의 모든 리스트에 소팅 구현
-토글 구현하였습니다.

feat :: 회원가입/수정/관리자회원관리 중복확인 추가
-아이디/닉네임/이메일 중복체크 가능하도록 구현하였습니다.