### PR TITLE
[강현구-240819] merge :: 통합테스트 대비 보완

### DIFF
--- a/src/main/java/com/multi/toonGather/security/CustomUserDetailsService.java
+++ b/src/main/java/com/multi/toonGather/security/CustomUserDetailsService.java
@@ -22,7 +22,7 @@ public class CustomUserDetailsService implements UserDetailsService {
         try {
             userDTO = userMapper.selectOneByUserId(userId);
         } catch(Exception e) {
-            throw new UsernameNotFoundException("[CustomUserDetailsService] 해당 아이디는 DB에 존재하지 않습니다: " + userId, e);
+            throw new UsernameNotFoundException("[CustomUserDetailsService] 해당 아이디는 DB에 존재하지 않습니다: " + userId);
         }
 
         if(userDTO == null) {

--- a/src/main/java/com/multi/toonGather/user/controller/AuthController.java
+++ b/src/main/java/com/multi/toonGather/user/controller/AuthController.java
@@ -18,6 +18,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Controller;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
@@ -135,12 +136,21 @@ public class AuthController {
         else return "redirect:/user/login";
 
         // 유저로 등록된 적이 없으면 새로 등록.
+        // 탈퇴후 다시 로그인할 때 문제가 생긴다. 이런경우에는 withdrawn = 'N'으로 변경..
         if(userService.checkUserIdExists(userDTO.getUserId()) == 0) userService.insertUser(userDTO);
 
         // 스프링 시큐리티 인증
         System.out.println("[TEST] customUserDetailsService.loadUserByUsername(): "+customUserDetailsService.loadUserByUsername(userDTO.getUserId()).getPassword());
 
-        UserDetails customUserDetails = (CustomUserDetails) customUserDetailsService.loadUserByUsername(userDTO.getUserId());   //이거 왜 CustomUserDetails 안될까? 의문이당..
+//        UserDetails customUserDetails = (CustomUserDetails) customUserDetailsService.loadUserByUsername(userDTO.getUserId());   //이거 왜 CustomUserDetails 안될까? 의문이당..
+        UserDetails customUserDetails;
+
+        try {
+            customUserDetails = (CustomUserDetails) customUserDetailsService.loadUserByUsername(userDTO.getUserId());
+        } catch (UsernameNotFoundException e) {
+            System.out.println("예외처리?");
+            return "redirect:/user/login?error";
+        }
 
         UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
 
@@ -255,12 +265,21 @@ public class AuthController {
         else return "redirect:/user/login";
 
         // 유저로 등록된 적이 없으면 새로 등록.
+        // 탈퇴후 다시 로그인할 때 문제가 생긴다. 이런경우에는 withdrawn = 'N'으로 변경..
         if(userService.checkUserIdExists(userDTO.getUserId()) == 0) userService.insertUser(userDTO);
 
         // 스프링 시큐리티 인증
         System.out.println("[TEST] customUserDetailsService.loadUserByUsername(): "+customUserDetailsService.loadUserByUsername(userDTO.getUserId()).getPassword());
 
-        UserDetails customUserDetails = (CustomUserDetails) customUserDetailsService.loadUserByUsername(userDTO.getUserId());   //이거 왜 CustomUserDetails 안될까? 의문이당..
+//        UserDetails customUserDetails = (CustomUserDetails) customUserDetailsService.loadUserByUsername(userDTO.getUserId());   //이거 왜 CustomUserDetails 안될까? 의문이당..
+        UserDetails customUserDetails;
+
+        try {
+            customUserDetails = (CustomUserDetails) customUserDetailsService.loadUserByUsername(userDTO.getUserId());
+        } catch (UsernameNotFoundException e) {
+            System.out.println("예외처리?");
+            return "redirect:/user/login?error";
+        }
 
         UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(customUserDetails, null, customUserDetails.getAuthorities());
 

--- a/src/main/java/com/multi/toonGather/user/controller/AuthController.java
+++ b/src/main/java/com/multi/toonGather/user/controller/AuthController.java
@@ -118,7 +118,7 @@ public class AuthController {
                 userDTO.setTypeCode('N');
                 userDTO.setAuthCode('B');
                 userDTO.setPassword("BASEDNAVERLOGINAPIS@");  //고민해보기1
-                userDTO.setEmail("BASEDNAVERLOGINAPIS@");     //고민해보기1
+                userDTO.setEmail("BASEDNAVERLOGINAPIS@" +naverId +".naver");     //고민해보기1
 //                userDTO.setDateOfBirth(LocalDate.now());     //고민해보기3_웹툰 성인인증 관련해서 문제 해결
                 userDTO.setTermsAgreement(true);            //고민해보기2 추가수집?
 
@@ -238,7 +238,7 @@ public class AuthController {
                 userDTO.setTypeCode('K');
                 userDTO.setAuthCode('B');
                 userDTO.setPassword("BASEDKAKAOLOGINAPIS@");  //고민해보기1
-                userDTO.setEmail("BASEDKAKAOLOGINAPIS@");     //고민해보기1
+                userDTO.setEmail("BASEDKAKAOLOGINAPIS@" +kakaoId + ".kakao");     //고민해보기1
                 userDTO.setGender('P');                     //고민해보기2 추가수집해볼?
 //                userDTO.setDateOfBirth(LocalDate.now());     //고민해보기3_웹툰 성인인증 관련해서 문제 해결
                 userDTO.setTermsAgreement(true);            //고민해보기2

--- a/src/main/java/com/multi/toonGather/user/controller/MailController.java
+++ b/src/main/java/com/multi/toonGather/user/controller/MailController.java
@@ -18,23 +18,24 @@ public class MailController {
 
     // 인증 이메일 전송
     @PostMapping("/mailSend")
-    public HashMap<String, Object> mailSend(@RequestBody Map<String, String> payload) {
+    public ResponseEntity<Boolean> mailSend(@RequestBody Map<String, String> payload) {
         HashMap<String, Object> map = new HashMap<>();
         System.out.println("mailsend 실행됨");
         String mail = payload.get("mail");
 
         try {
             number = mailService.sendMail(mail);
-            String num = String.valueOf(number);
-
-            map.put("success", Boolean.TRUE);
-            map.put("number", num);
+//            String num = String.valueOf(number);
+//            map.put("success", Boolean.TRUE);
+//            map.put("number", num);
+            return ResponseEntity.ok(Boolean.TRUE);
         } catch (Exception e) {
-            map.put("success", Boolean.FALSE);
-            map.put("error", e.getMessage());
+//            map.put("success", Boolean.FALSE);
+//            map.put("error", e.getMessage());
+            return ResponseEntity.ok(Boolean.FALSE);
         }
 
-        return map;
+//        return ResponseEntity.ok(Boolean.FALSE);
     }
 
     // 인증번호 일치여부 확인

--- a/src/main/java/com/multi/toonGather/user/controller/UserController.java
+++ b/src/main/java/com/multi/toonGather/user/controller/UserController.java
@@ -192,8 +192,10 @@ public class UserController {
 
 
         //회원 정보 수정 처리
-        userService.updateProfile(userNo, userDTO, image, request);
-        return "redirect:/user/my/editprofile";
+        int result = userService.updateProfile(userNo, userDTO, image, request);
+        if(result > 0){
+            return "redirect:/user/my/editprofile?status=editSuccess";
+        } else return "redirect:/user/my/editprofile?status=editFailure";
 
     }
 
@@ -209,7 +211,7 @@ public class UserController {
             request.getSession().invalidate();
             return "redirect:/user/withdrawn"; // 성공 메시지
         } else {
-            return "redirect:/user/my/editprofile?status=failure"; // 실패 메시지
+            return "redirect:/user/my/editprofile?status=withdrawnFailure"; // 실패 메시지
         }
     }
 

--- a/src/main/java/com/multi/toonGather/user/controller/UserController.java
+++ b/src/main/java/com/multi/toonGather/user/controller/UserController.java
@@ -356,8 +356,17 @@ public class UserController {
     public String adminDeleteUser(@RequestParam("userNo") int userNo, @ModelAttribute UserDTO userDTO, HttpServletRequest request, Model model) throws Exception {
         System.out.println("adminDeleteUser @RequestParam userNo: "+userNo);
         //회원 정보 삭제 처리
-        userService.deleteProfile(userNo, userDTO);
-        return "redirect:/user/admin/userlist";
+        userService.deleteProfileAdmin(userNo);
+        return "redirect:/user/admin/userdetails?userNo="+userNo+"&status=withdrawnSuccess";
+    }
+
+    //KHG81-(4)POST
+    @PostMapping("/admin/reactiveuser")
+    public String adminRcactiveUser(@RequestParam("userNo") int userNo, @ModelAttribute UserDTO userDTO, HttpServletRequest request, Model model) throws Exception {
+        System.out.println("adminRcactiveUser @RequestParam userNo: "+userNo);
+        //회원 정보 삭제 처리
+        userService.reactiveProfileAdmin(userNo);
+        return "redirect:/user/admin/userdetails?userNo="+userNo+"&status=reactiveSuccess";
     }
 
 

--- a/src/main/java/com/multi/toonGather/user/controller/UserController.java
+++ b/src/main/java/com/multi/toonGather/user/controller/UserController.java
@@ -203,8 +203,20 @@ public class UserController {
         int userNo = c.getUserDTO().getUserNo();
         System.out.println("deleteProfileReq @RequestParam userNo: "+userNo);
         //회원 정보 삭제 처리
-        userService.deleteProfile(userNo);
-        return "redirect:/logout";
+        int result = userService.deleteProfile(userNo, userDTO);
+        if (result > 0) {
+            System.out.println("탈퇴처리 됨");
+            request.getSession().invalidate();
+            return "redirect:/user/withdrawn"; // 성공 메시지
+        } else {
+            return "redirect:/user/my/editprofile?status=failure"; // 실패 메시지
+        }
+    }
+
+    //KHG70-(3)탈퇴후 이동
+    @RequestMapping("/withdrawn")
+    public String withdrawn(HttpServletRequest request) throws Exception {
+        return "/user/withdrawn";
     }
 
     //KHG80
@@ -339,7 +351,7 @@ public class UserController {
     public String adminDeleteUser(@RequestParam("userNo") int userNo, @ModelAttribute UserDTO userDTO, HttpServletRequest request, Model model) throws Exception {
         System.out.println("adminDeleteUser @RequestParam userNo: "+userNo);
         //회원 정보 삭제 처리
-        userService.deleteProfile(userNo);
+        userService.deleteProfile(userNo, userDTO);
         return "redirect:/user/admin/userlist";
     }
 

--- a/src/main/java/com/multi/toonGather/user/controller/UserController.java
+++ b/src/main/java/com/multi/toonGather/user/controller/UserController.java
@@ -344,8 +344,11 @@ public class UserController {
     public String adminUpdateUser(@RequestParam("userNo") int userNo, @ModelAttribute UserDTO userDTO, @RequestParam("image") MultipartFile image, HttpServletRequest request, Model model) throws Exception {
         System.out.println("adminUpdateUser @RequestParam userNo: "+userNo);
         //회원 정보 수정 처리
-        userService.updateProfileAdmin(userNo, userDTO, image, request);
-        return "redirect:/user/admin/userlist";
+        int result = userService.updateProfileAdmin(userNo, userDTO, image, request);
+        if(result > 0) {
+            return "redirect:/user/admin/userlist?status=editSuccess";
+        }
+        else return "redirect:/user/admin/userdetails?userNo="+userNo+"&status=editFailure";
     }
 
     //KHG81-(3)POST

--- a/src/main/java/com/multi/toonGather/user/model/dto/MyWtWebtoonDTO.java
+++ b/src/main/java/com/multi/toonGather/user/model/dto/MyWtWebtoonDTO.java
@@ -22,4 +22,23 @@ public class MyWtWebtoonDTO {
     private String genre;
     private String tags;
     private int count;
+
+    public String getFirstHashtag() {
+        if (tags == null || tags.isEmpty()) {
+            return "";
+        }
+
+        // Find the start and end of the first hashtag
+        int startIndex = tags.indexOf('#'); // The index of the first #
+        if (startIndex == -1) {
+            return "";
+        }
+
+        int endIndex = tags.indexOf('#', startIndex + 1); // The index of the second #
+        if (endIndex == -1) {
+            endIndex = tags.length(); // No second #, so take the rest of the string
+        }
+
+        return tags.substring(startIndex, endIndex);
+    }
 }

--- a/src/main/java/com/multi/toonGather/user/model/dto/UserDTO.java
+++ b/src/main/java/com/multi/toonGather/user/model/dto/UserDTO.java
@@ -30,6 +30,7 @@ public class UserDTO {
    private LocalDateTime termsAgreementDatetime;
    private LocalDateTime registrationDatetime;
    private LocalDateTime lastModifiedDatetime;
+   private char withdrawn;
 
    //DB 외 영역 (생년월일 처리를 위함)
    private String year;

--- a/src/main/java/com/multi/toonGather/user/model/mapper/UserMapper.java
+++ b/src/main/java/com/multi/toonGather/user/model/mapper/UserMapper.java
@@ -15,6 +15,9 @@ public interface UserMapper {
     // Mybatis가 내가 mapper에 짜놓은 "실행된 쿼리"를 바탕으로 반환된 행의 수를 리턴해준다고 함.
 
     UserDTO selectOneByUserId(@Param("userId") String userId) throws Exception;
+    UserDTO selectOneByUserIdWithdrawn(@Param("userId") String userId) throws Exception;
+    int reactiveUserByUserId(@Param("userId") String userId) throws Exception;
+
     UserDTO selectOneByContactNumber(@Param("contactNumber") String contactNumber) throws Exception;
     UserDTO selectOneByUserIdAndEmail(@Param("userId") String userId, @Param("email") String email) throws Exception;
     UserDTO selectOneByUserNo(@Param("userNo") String userNo) throws Exception;

--- a/src/main/java/com/multi/toonGather/user/model/mapper/UserMapper.java
+++ b/src/main/java/com/multi/toonGather/user/model/mapper/UserMapper.java
@@ -17,6 +17,7 @@ public interface UserMapper {
     UserDTO selectOneByUserId(@Param("userId") String userId) throws Exception;
     UserDTO selectOneByUserIdWithdrawn(@Param("userId") String userId) throws Exception;
     int reactiveUserByUserId(@Param("userId") String userId) throws Exception;
+    int reactiveUserByUserNo(@Param("userNo") int userNo) throws Exception;
 
     UserDTO selectOneByContactNumber(@Param("contactNumber") String contactNumber) throws Exception;
     UserDTO selectOneByUserIdAndEmail(@Param("userId") String userId, @Param("email") String email) throws Exception;

--- a/src/main/java/com/multi/toonGather/user/service/UserService.java
+++ b/src/main/java/com/multi/toonGather/user/service/UserService.java
@@ -14,7 +14,7 @@ public interface UserService {
     UserDTO findPw(UserDTO userDTO) throws Exception;
     UserDTO getProfile(int userNo) throws Exception;
     int updateProfile(int userNo, UserDTO userDTO, MultipartFile image, HttpServletRequest request) throws Exception;
-    void updateProfileAdmin(int userNo, UserDTO userDTO, MultipartFile image, HttpServletRequest request) throws Exception;
+    int updateProfileAdmin(int userNo, UserDTO userDTO, MultipartFile image, HttpServletRequest request) throws Exception;
     int deleteProfile(int userNo, UserDTO userDTO) throws Exception;
 
     int checkUserIdExists(String userId) throws Exception;

--- a/src/main/java/com/multi/toonGather/user/service/UserService.java
+++ b/src/main/java/com/multi/toonGather/user/service/UserService.java
@@ -16,6 +16,8 @@ public interface UserService {
     int updateProfile(int userNo, UserDTO userDTO, MultipartFile image, HttpServletRequest request) throws Exception;
     int updateProfileAdmin(int userNo, UserDTO userDTO, MultipartFile image, HttpServletRequest request) throws Exception;
     int deleteProfile(int userNo, UserDTO userDTO) throws Exception;
+    int deleteProfileAdmin(int userNo) throws Exception;
+    int reactiveProfileAdmin(int userNo) throws Exception;
 
     int checkUserIdExists(String userId) throws Exception;
     int checkNicknameExists(String nickname) throws Exception;

--- a/src/main/java/com/multi/toonGather/user/service/UserService.java
+++ b/src/main/java/com/multi/toonGather/user/service/UserService.java
@@ -15,7 +15,7 @@ public interface UserService {
     UserDTO getProfile(int userNo) throws Exception;
     void updateProfile(int userNo, UserDTO userDTO, MultipartFile image, HttpServletRequest request) throws Exception;
     void updateProfileAdmin(int userNo, UserDTO userDTO, MultipartFile image, HttpServletRequest request) throws Exception;
-    void deleteProfile(int userNo) throws Exception;
+    int deleteProfile(int userNo, UserDTO userDTO) throws Exception;
 
     int checkUserIdExists(String userId) throws Exception;
     int checkNicknameExists(String nickname) throws Exception;

--- a/src/main/java/com/multi/toonGather/user/service/UserService.java
+++ b/src/main/java/com/multi/toonGather/user/service/UserService.java
@@ -13,7 +13,7 @@ public interface UserService {
     String findId(UserDTO userDTO) throws Exception;
     UserDTO findPw(UserDTO userDTO) throws Exception;
     UserDTO getProfile(int userNo) throws Exception;
-    void updateProfile(int userNo, UserDTO userDTO, MultipartFile image, HttpServletRequest request) throws Exception;
+    int updateProfile(int userNo, UserDTO userDTO, MultipartFile image, HttpServletRequest request) throws Exception;
     void updateProfileAdmin(int userNo, UserDTO userDTO, MultipartFile image, HttpServletRequest request) throws Exception;
     int deleteProfile(int userNo, UserDTO userDTO) throws Exception;
 

--- a/src/main/java/com/multi/toonGather/user/service/UserServiceImpl.java
+++ b/src/main/java/com/multi/toonGather/user/service/UserServiceImpl.java
@@ -89,34 +89,52 @@ public class UserServiceImpl implements UserService {
         UserDTO response2 = userMapper.selectOneByNickname(userDTO.getNickname());
 
         System.out.println("userDTO: "+ userDTO);   //request
-        System.out.println("response: "+ response); //response1 : 이메일을 통해 검색
-        System.out.println("response2: "+ response2); //response2 : 닉네임을 통해 검색
-        try{
-            if(userDTO.getNickname().equals(response.getNickname())) return response.getUserId();
-            else if(response2.getTypeCode() == 'K') {//소셜 가입후 이메일을 수정한경우
-                System.out.println("[UserService.findId] 카카오");
-                return "RETURNMESSAGE:ALREADYSIGNEDUPBYKAKAOAPI";
+        System.out.println("response: "+ response); //response1 : 이메일을 통해 조회해온 결과
+        System.out.println("response2: "+ response2); //response2 : 닉네임을 통해 조회해온 결과
+        if(response == null || response2 == null) {
+            if(response == null && response2 != null) { //닉네임은 찾았으나 이메일 못찾음
+                if(response2.getTypeCode() == 'K') {
+                    System.out.println("[UserService.findId] 카카오");
+                    return "RETURNMESSAGE:ALREADYSIGNEDUPBYKAKAOAPI";
+                }
+                else if(response2.getTypeCode() == 'N') {
+                    System.out.println("[UserService.findId] 네이버");
+                    return "RETURNMESSAGE:ALREADYSIGNEDUPBYNAVERAPI";
+                }
             }
-            else if(response2.getTypeCode() == 'N') {
-                System.out.println("[UserService.findId] 네이버");
-                return "RETURNMESSAGE:ALREADYSIGNEDUPBYNAVERAPI";
-            }
-            else {
-                System.out.println("[MESSAGE] 불일치. nickname: "+userDTO.getNickname()+" email: "+userDTO.getEmail());
-                return null;
-            }
-        } catch(Exception e){ //response가 null일 때. 이메일로 검색했더니 존재하지 않을 때
-            if(response2.getTypeCode() == 'K') {
-                System.out.println("[UserService.findId] 카카오");
-                return "RETURNMESSAGE:ALREADYSIGNEDUPBYKAKAOAPI";
-            }
-            else if(response2.getTypeCode() == 'N') {
-                System.out.println("[UserService.findId] 네이버");
-                return "RETURNMESSAGE:ALREADYSIGNEDUPBYNAVERAPI";
-            }
-
-            System.err.println("[UserService.findId] getProfile 예외처리 : response or response2가 null입니다! " + e.getMessage());
             return null;
+        }
+        else { //둘다 not null일 때는, response1(이메일)과 response2(닉네임)의 각각 userNo가 일치하는지부터 본다.
+            if(response.getUserNo() == response2.getUserNo()){
+                if(response.getTypeCode() == 'K') {
+                    System.out.println("[UserService.findId] 카카오");
+                    return "RETURNMESSAGE:ALREADYSIGNEDUPBYKAKAOAPI";
+                }
+                else if(response.getTypeCode() == 'N') {
+                    System.out.println("[UserService.findId] 네이버");
+                    return "RETURNMESSAGE:ALREADYSIGNEDUPBYNAVERAPI";
+                }
+                else return response.getUserId();
+            }
+            else return null;
+//            try{
+//                if(userDTO.getNickname().equals(response.getNickname())) return response.getUserId();
+//                else if(response2.getTypeCode() == 'K') {//소셜 가입후 이메일을 수정한경우
+//                    System.out.println("[UserService.findId] 카카오");
+//                    return "RETURNMESSAGE:ALREADYSIGNEDUPBYKAKAOAPI";
+//                }
+//                else if(response2.getTypeCode() == 'N') {
+//                    System.out.println("[UserService.findId] 네이버");
+//                    return "RETURNMESSAGE:ALREADYSIGNEDUPBYNAVERAPI";
+//                }
+//                else {
+//                    System.out.println("[MESSAGE] 불일치. nickname: "+userDTO.getNickname()+" email: "+userDTO.getEmail());
+//                    return null;
+//                }
+//            } catch(Exception e){
+//        }
+//
+//            return null;
         }
 //        if(userDTO.getNickname() == response.getNickname()) return response.getUserId();
 //        else return "ERROR";    //추후변경해야함!

--- a/src/main/java/com/multi/toonGather/user/service/UserServiceImpl.java
+++ b/src/main/java/com/multi/toonGather/user/service/UserServiceImpl.java
@@ -358,8 +358,9 @@ public class UserServiceImpl implements UserService {
         int result = 0;
         try{
             UserDTO userDTO = userMapper.selectOneByUserId(userId);
-            //탈퇴한 회원의 아이디도 사용할 수 없음
-            if(userDTO == null) userDTO = userMapper.selectOneByUserIdWithdrawn(userId);
+//            //탈퇴한 회원의 아이디도 사용할 수 없음
+//            if(userDTO == null)
+//                userDTO = userMapper.selectOneByUserIdWithdrawn(userId);
             if(userId.equals(userDTO.getUserId())) result = 1;
             return result;
         } catch(Exception e) {

--- a/src/main/java/com/multi/toonGather/user/service/UserServiceImpl.java
+++ b/src/main/java/com/multi/toonGather/user/service/UserServiceImpl.java
@@ -73,7 +73,7 @@ public class UserServiceImpl implements UserService {
     }
 
     public String findId(UserDTO userDTO) throws Exception{
-        UserDTO response = userMapper.selectOneByContactNumber(userDTO.getContactNumber());
+        UserDTO response = userMapper.selectOneByEmail(userDTO.getEmail());
         System.out.println("userDTO: "+ userDTO);
         System.out.println("response: "+ response);
         try{

--- a/src/main/java/com/multi/toonGather/user/service/UserServiceImpl.java
+++ b/src/main/java/com/multi/toonGather/user/service/UserServiceImpl.java
@@ -74,16 +74,36 @@ public class UserServiceImpl implements UserService {
 
     public String findId(UserDTO userDTO) throws Exception{
         UserDTO response = userMapper.selectOneByEmail(userDTO.getEmail());
-        System.out.println("userDTO: "+ userDTO);
-        System.out.println("response: "+ response);
+        UserDTO response2 = userMapper.selectOneByNickname(userDTO.getNickname());
+
+        System.out.println("userDTO: "+ userDTO);   //request
+        System.out.println("response: "+ response); //response1 : 이메일을 통해 검색
+        System.out.println("response2: "+ response2); //response2 : 닉네임을 통해 검색
         try{
             if(userDTO.getNickname().equals(response.getNickname())) return response.getUserId();
-            else{
-                System.out.println("[MESSAGE] 불일치. nickname: "+userDTO.getNickname()+" contact_number: "+userDTO.getContactNumber());
+            else if(response2.getTypeCode() == 'K') {//소셜 가입후 이메일을 수정한경우
+                System.out.println("[UserService.findId] 카카오");
+                return "RETURNMESSAGE:ALREADYSIGNEDUPBYKAKAOAPI";
+            }
+            else if(response2.getTypeCode() == 'N') {
+                System.out.println("[UserService.findId] 네이버");
+                return "RETURNMESSAGE:ALREADYSIGNEDUPBYNAVERAPI";
+            }
+            else {
+                System.out.println("[MESSAGE] 불일치. nickname: "+userDTO.getNickname()+" email: "+userDTO.getEmail());
                 return null;
             }
-        } catch(Exception e){
-            System.err.println("[ERROR] getProfile 예외처리 오류: " + e.getMessage());
+        } catch(Exception e){ //response가 null일 때. 이메일로 검색했더니 존재하지 않을 때
+            if(response2.getTypeCode() == 'K') {
+                System.out.println("[UserService.findId] 카카오");
+                return "RETURNMESSAGE:ALREADYSIGNEDUPBYKAKAOAPI";
+            }
+            else if(response2.getTypeCode() == 'N') {
+                System.out.println("[UserService.findId] 네이버");
+                return "RETURNMESSAGE:ALREADYSIGNEDUPBYNAVERAPI";
+            }
+
+            System.err.println("[UserService.findId] getProfile 예외처리 : response or response2가 null입니다! " + e.getMessage());
             return null;
         }
 //        if(userDTO.getNickname() == response.getNickname()) return response.getUserId();

--- a/src/main/java/com/multi/toonGather/user/service/UserServiceImpl.java
+++ b/src/main/java/com/multi/toonGather/user/service/UserServiceImpl.java
@@ -163,7 +163,8 @@ public class UserServiceImpl implements UserService {
 
     }
 
-    public void updateProfile(int userNo, UserDTO userDTO, MultipartFile image, HttpServletRequest request) throws Exception {
+    public int updateProfile(int userNo, UserDTO userDTO, MultipartFile image, HttpServletRequest request) throws Exception {
+        int result = 0;
         // 가장 먼저: password, confirmPassword의 일치여부 확인
         if (!userDTO.getPassword().equals(userDTO.getConfirmPassword())) {
             throw new Exception("[ERROR] insertUser 실패. 비밀번호 불일치");
@@ -223,7 +224,7 @@ public class UserServiceImpl implements UserService {
             } // if origin not null
 
             // 회원정보 수정 후 세션등록
-            int result = userMapper.updateUser(userNo, userDTO);
+            result = userMapper.updateUser(userNo, userDTO);
             CustomUserDetails c = (CustomUserDetails)
                     customUserDetailsService.loadUserByUsername(userMapper.selectOneByUserNo(Integer.toString(userNo)).getUserId());
 
@@ -231,9 +232,11 @@ public class UserServiceImpl implements UserService {
 
             SecurityContextHolder.getContext().setAuthentication(authentication);
 
-            if(result == 0) throw new Exception("[ERROR] updateUser 실패. [userNo: " + userNo + "]");
+            if(result == 0)
+                System.out.println("[ERROR] updateUser 실패. [userNo: " + userNo + "]");
         }
 
+        return result;
     }
 
     public void updateProfileAdmin(int userNo, UserDTO userDTO, MultipartFile image, HttpServletRequest request) throws Exception {

--- a/src/main/java/com/multi/toonGather/user/service/UserServiceImpl.java
+++ b/src/main/java/com/multi/toonGather/user/service/UserServiceImpl.java
@@ -334,6 +334,26 @@ public class UserServiceImpl implements UserService {
         return result;
     }
 
+    public int deleteProfileAdmin(int userNo) throws Exception{
+        int result = 0;
+        System.out.println("[service.deleteProfileAdmin()]userNo: " + userNo);
+
+        // (1A) 관리자의 경우 특별한 확인과정 없이 바로 deleteUser (from UserService.deleteProfile()의 1A)
+        result = userMapper.deleteUser(userNo); //탈퇴허가: withdrawn만 'Y'으로 바뀜.
+
+        if(result == 0) System.out.println("[ERROR] deleteUser 실패. [userNo: " + userNo + "]");
+        return result;
+    }
+
+    public int reactiveProfileAdmin(int userNo) throws Exception {
+        int result = 0;
+        System.out.println("[service.reactiveProfileAdmin()]userNo: " + userNo);
+        result = userMapper.reactiveUserByUserNo(userNo); //탈퇴취소: withdrawn만 'N'으로 바뀜.
+
+        if(result == 0) System.out.println("[ERROR] reactiveUser 실패. [userNo: " + userNo + "]");
+        return result;
+    }
+
     public int checkUserIdExists(String userId)  {
         int result = 0;
         try{

--- a/src/main/java/com/multi/toonGather/user/service/UserServiceImpl.java
+++ b/src/main/java/com/multi/toonGather/user/service/UserServiceImpl.java
@@ -239,13 +239,13 @@ public class UserServiceImpl implements UserService {
         return result;
     }
 
-    public void updateProfileAdmin(int userNo, UserDTO userDTO, MultipartFile image, HttpServletRequest request) throws Exception {
+    public int updateProfileAdmin(int userNo, UserDTO userDTO, MultipartFile image, HttpServletRequest request) throws Exception {
 
-        if (userDTO.getPassword() == null || userDTO.getPassword().isEmpty()) {
-            String currentPassword = userMapper.selectOneByUserNo(Integer.toString(userNo)).getPassword();
-            userDTO.setPassword(currentPassword);
-            System.out.println("UserService.updateProfileAdmin(): 비밀번호를 변경하지 않았음.");
-        }
+//        if (userDTO.getPassword() == null || userDTO.getPassword().isEmpty()) {
+//            String currentPassword = userMapper.selectOneByUserNo(Integer.toString(userNo)).getPassword();
+//            userDTO.setPassword(currentPassword);
+//            System.out.println("UserService.updateProfileAdmin(): 비밀번호를 변경하지 않았음.");
+//        }
 
             System.out.println("userNo: " + userNo);
             System.out.println("userDTO: " + userDTO);
@@ -300,9 +300,9 @@ public class UserServiceImpl implements UserService {
 
             // 회원정보 수정
             int result = userMapper.updateUser(userNo, userDTO);
+            if(result == 0) System.out.println("[ERROR] updateUser 실패. [userNo: " + userNo + "]");
 
-            if(result == 0) new Exception("[ERROR] updateUser 실패. [userNo: " + userNo + "]");
-
+            return result;
     }
 
     public int deleteProfile(int userNo, UserDTO userDTO) throws Exception{

--- a/src/main/resources/mappers/user/UserMapper.xml
+++ b/src/main/resources/mappers/user/UserMapper.xml
@@ -51,7 +51,8 @@
         terms_agreement AS termsAgreement,
         terms_agreement_datetime AS termsAgreementDatetime,
         registration_datetime AS registrationDatetime,
-        last_modified_datetime AS lastModifiedDatetime
+        last_modified_datetime AS lastModifiedDatetime,
+        withdrawn AS withdrawn
         FROM users
         WHERE user_id = #{userId}
         AND
@@ -75,7 +76,8 @@
         terms_agreement AS termsAgreement,
         terms_agreement_datetime AS termsAgreementDatetime,
         registration_datetime AS registrationDatetime,
-        last_modified_datetime AS lastModifiedDatetime
+        last_modified_datetime AS lastModifiedDatetime,
+        withdrawn AS withdrawn
         FROM users
         WHERE user_id = #{userId}
         AND
@@ -89,6 +91,15 @@
         last_modified_datetime = NOW()
         WHERE
         user_id = #{userId}
+    </update>
+
+    <update id="reactiveUserByUserNo" parameterType="int">
+        UPDATE users
+        SET
+        withdrawn = 'N',
+        last_modified_datetime = NOW()
+        WHERE
+        user_no = #{userNo}
     </update>
 
     <select id="selectOneByNickname" parameterType="string" resultType="userDTO">
@@ -109,7 +120,8 @@
         terms_agreement AS termsAgreement,
         terms_agreement_datetime AS termsAgreementDatetime,
         registration_datetime AS registrationDatetime,
-        last_modified_datetime AS lastModifiedDatetime
+        last_modified_datetime AS lastModifiedDatetime,
+        withdrawn AS withdrawn
         FROM users
         WHERE nickname = #{nickname}
     </select>
@@ -132,7 +144,8 @@
         terms_agreement AS termsAgreement,
         terms_agreement_datetime AS termsAgreementDatetime,
         registration_datetime AS registrationDatetime,
-        last_modified_datetime AS lastModifiedDatetime
+        last_modified_datetime AS lastModifiedDatetime,
+        withdrawn AS withdrawn
         FROM users
         WHERE email = #{email}
     </select>
@@ -197,7 +210,8 @@
         terms_agreement AS termsAgreement,
         terms_agreement_datetime AS termsAgreementDatetime,
         registration_datetime AS registrationDatetime,
-        last_modified_datetime AS lastModifiedDatetime
+        last_modified_datetime AS lastModifiedDatetime,
+        withdrawn AS withdrawn
         FROM users
         WHERE contact_number = #{contactNumber}
     </select>
@@ -220,7 +234,8 @@
         terms_agreement AS termsAgreement,
         terms_agreement_datetime AS termsAgreementDatetime,
         registration_datetime AS registrationDatetime,
-        last_modified_datetime AS lastModifiedDatetime
+        last_modified_datetime AS lastModifiedDatetime,
+        withdrawn AS withdrawn
         FROM users
         WHERE user_id = #{userId} AND email = #{email}
     </select>
@@ -243,7 +258,8 @@
         terms_agreement AS termsAgreement,
         terms_agreement_datetime AS termsAgreementDatetime,
         registration_datetime AS registrationDatetime,
-        last_modified_datetime AS lastModifiedDatetime
+        last_modified_datetime AS lastModifiedDatetime,
+        withdrawn AS withdrawn
         FROM users
         WHERE user_no = #{userNo}
     </select>
@@ -299,7 +315,8 @@
         terms_agreement AS termsAgreement,
         terms_agreement_datetime AS termsAgreementDatetime,
         registration_datetime AS registrationDatetime,
-        last_modified_datetime AS lastModifiedDatetime
+        last_modified_datetime AS lastModifiedDatetime,
+        withdrawn AS withdrawn
         FROM users
         WHERE 1=1
         <if test="searchBy != null and searchTerm != null and searchTerm != ''">
@@ -337,7 +354,10 @@
             </choose>
         </if>
         <if test="toggleValue == 'Y'">
-            AND auth_code = 'C'
+            AND withdrawn = 'Y'
+        </if>
+        <if test="toggleValue == 'N'">
+            AND withdrawn = 'N'
         </if>
         <choose>
             <when test="orderBy == 'recent'">
@@ -397,7 +417,10 @@
             </choose>
         </if>
         <if test="toggleValue == 'Y'">
-            AND auth_code = 'C'
+            AND withdrawn = 'Y'
+        </if>
+        <if test="toggleValue == 'N'">
+            AND withdrawn = 'N'
         </if>
         <choose>
             <when test="orderBy == 'recent'">

--- a/src/main/resources/mappers/user/UserMapper.xml
+++ b/src/main/resources/mappers/user/UserMapper.xml
@@ -366,6 +366,9 @@
             <when test="orderBy == 'oldest'">
                 ORDER BY user_no ASC
             </when>
+            <when test="orderBy == 'recentUpdated'">
+                ORDER BY last_modified_datetime DESC
+            </when>
             <when test="orderBy == 'nickname'">
                 ORDER BY nickname ASC
             </when>
@@ -428,6 +431,9 @@
             </when>
             <when test="orderBy == 'oldest'">
                 ORDER BY user_no ASC
+            </when>
+            <when test="orderBy == 'recentUpdated'">
+                ORDER BY last_modified_datetime DESC
             </when>
             <when test="orderBy == 'nickname'">
                 ORDER BY nickname ASC

--- a/src/main/resources/mappers/user/UserMapper.xml
+++ b/src/main/resources/mappers/user/UserMapper.xml
@@ -54,7 +54,42 @@
         last_modified_datetime AS lastModifiedDatetime
         FROM users
         WHERE user_id = #{userId}
+        AND
+        withdrawn = 'N'
     </select>
+    <select id="selectOneByUserIdWithdrawn" parameterType="string" resultType="userDTO">
+        SELECT
+        user_no AS userNo,
+        type_code AS typeCode,
+        auth_code AS authCode,
+        user_id AS userId,
+        password,
+        nickname,
+        contact_number AS contactNumber,
+        email,
+        profile_image_path AS profileImagePath,
+        bio,
+        gender,
+        date_of_birth AS dateOfBirth,
+        real_name AS realName,
+        terms_agreement AS termsAgreement,
+        terms_agreement_datetime AS termsAgreementDatetime,
+        registration_datetime AS registrationDatetime,
+        last_modified_datetime AS lastModifiedDatetime
+        FROM users
+        WHERE user_id = #{userId}
+        AND
+        withdrawn = 'Y'
+    </select>
+
+    <update id="reactiveUserByUserId" parameterType="string">
+        UPDATE users
+        SET
+        withdrawn = 'N',
+        last_modified_datetime = NOW()
+        WHERE
+        user_id = #{userId}
+    </update>
 
     <select id="selectOneByNickname" parameterType="string" resultType="userDTO">
         SELECT
@@ -236,10 +271,16 @@
         WHERE user_no = #{userNo}
     </update>
 
-    <delete id="deleteUser" parameterType="int">
-        DELETE FROM users
-        WHERE user_no = #{userNo}
-    </delete>
+    <update id="deleteUser" parameterType="int">
+        <!--DELETE FROM users
+        WHERE user_no = #{userNo} -->
+        UPDATE users
+        SET
+        withdrawn = 'Y',
+        last_modified_datetime = NOW()
+        WHERE
+        user_no = #{userNo}
+    </update>
 
     <select id="selectList" resultType="userDTO">
         SELECT

--- a/src/main/resources/static/js/uservalidation.js
+++ b/src/main/resources/static/js/uservalidation.js
@@ -1,0 +1,365 @@
+//Group A) 오토포맷 (1개 : 연락처)
+    // (A1) 연락처 오토포맷
+    function autoFormatPhoneNumber(input) {
+        let phoneNumber = input.value.replace(/\D/g, ''); // Remove all non-digit characters
+        if (phoneNumber.length > 3 && phoneNumber.length <= 7) {
+            phoneNumber = phoneNumber.substring(0, 3) + '-' + phoneNumber.substring(3);
+        } else if (phoneNumber.length > 7) {
+            phoneNumber = phoneNumber.substring(0, 3) + '-' + phoneNumber.substring(3, 7) + '-' + phoneNumber.substring(7, 11);
+        }
+        input.value = phoneNumber;
+    }
+
+//Group B) validate (4개 : 비번/연락처/이메일/약관동의)
+    // (B1) 비밀번호 일치 여부를 검증하는 함수
+    function validatePasswordMatch() {
+        const password = document.querySelector('input[name="password"]').value;
+        const confirmPassword = document.querySelector('input[name="confirmPassword"]').value;
+
+        if (!password || !confirmPassword) {
+            alert('비밀번호와 비밀번호 확인란 모두 입력해 주세요.');
+            return false; // 비밀번호가 입력되지 않으면 폼 제출을 막음
+        }
+
+        if (password.length < 8 || password.length >30 || confirmPassword.length < 8 || confirmPassword.length >30) {
+            alert('비밀번호는 8~30자를 허용합니다.');
+            return;
+        }
+
+        if (password !== confirmPassword) {
+            alert('비밀번호를 다시 확인해주세요.');
+            return false; // 비밀번호가 일치하지 않으면 폼 제출을 막음
+        }
+
+        return true; // 비밀번호가 일치하고 둘 다 입력되었으면 폼 제출을 진행
+    }
+
+
+    // (B0) 아이디 형식을 확인하는 함수
+    function validateUserId(userId) {
+        const validIdPattern = /^[a-zA-Z0-9]+$/;    //영문과 숫자의 조합
+        return validIdPattern.test(userId);
+
+    }
+    
+   
+    // (B3) 연락처 형식을 확인하는 함수
+    function validatePhoneNumber(phoneNumber) {
+        const phonePattern = /^\d{3}-\d{4}-\d{4}$/; // 000-0000-0000 형식
+        return phonePattern.test(phoneNumber);
+    }
+
+    // (B4) 이메일 형식을 확인하는 함수
+    function validateEmail(email) {
+        // 이메일 형식을 검증하는 정규 표현식
+        const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        return emailPattern.test(email);
+    }
+
+    // 폼 제출 전에 모든 필드를 검증하는 함수
+    async function validateForm(event) {
+        event.preventDefault(); // 폼 제출 기본 동작 방지
+
+        ////////////////////////////////////////////
+        //리마인드:HTML에서 정한 자수제한 + (DB에서 정한 자수제한)
+        //아이디*       4~20    (~50)#UK
+        //비밀번호*      8~30   (~255)#
+        //비밀번호확인*   8~30    (없음)
+        //닉네임*       4~20    (~50)#UK
+        //연락처--------------------- UK
+        //성별----------------------#
+        //생년월일-------------------
+        //실명          0~10    (~20)
+        //이메일*        5~100  (~100)#UK
+        //인증번호입력*   0~6     (없음)
+        //자기소개       0~150   (text)
+        //약관동의*------------------#
+        ////////////////////////////////////////////
+
+
+        //셀렉터 정리
+            // (B0) 아이디
+            const userId = document.getElementById('userId').value;
+            // (B1) 비밀번호
+            // (B2) 닉네임
+            const nickname = document.getElementById('nickname').value;
+            // (B3) 연락처
+            const phoneNumberInput = document.querySelector('input[name="contactNumber"]');
+            const phoneNumber = phoneNumberInput.value;
+            // (B4) 이메일
+            const emailInput = document.querySelector('input[name="email"]');
+            const email = emailInput.value;
+            // (B5) 약관동의
+            const termsCheckbox = document.getElementById('termsAgreementCheckbox');
+            var verificationCheckbox = document.getElementById('verificationCheckbox');
+
+
+        // (B0) 아이디 검증 (공란O/형식O/자수O)
+        if(!userId) {
+            alert('아이디를 입력해 주세요.');
+            return;
+        }
+        if (!validateUserId(userId)) {
+            alert('아이디는 영문과 숫자의 조합으로만 가능합니다.');
+            return;
+        }
+        if (userId.length < 4 || userId.length >20) {
+            alert('아이디의 글자수는 4~20자를 허용합니다.');
+            return;
+        }
+
+        // (B1) 비밀번호 일치 여부 검증 (공란O/형식O/자수O)
+        if (!validatePasswordMatch()) {
+            //alert('비밀번호를 다시 확인해주세요.'); // 비밀번호 불일치 시 경고
+            return; // 폼 제출을 막음
+        }
+
+        // (B2) 닉네임 검증 (공란O/형식-/자수O)
+        if(!nickname) {
+            alert('닉네임을 입력해 주세요.');
+            return;
+        }
+        if (nickname.length < 4 || nickname.length >20) {
+            alert('닉네임의 글자수는 4~20자를 허용합니다.');
+            return;
+        }
+        
+        // (B3) 연락처 검증 (공란-/형식O/자수O)
+        if (phoneNumber.length > 0 && !validatePhoneNumber(phoneNumber)) {
+            alert("연락처 형식이 올바르지 않습니다. 예: 000-0000-0000");
+            event.preventDefault(); // 폼 제출을 막음
+            return;
+        }
+        if (phoneNumber.length >13) {
+            alert('연락처로 허용될 수 있는 자수를 초과했습니다.');
+            return;
+        }
+
+        // (B4-1) 이메일 검증 (공란O/형식O/자수O)
+        if(!email) {
+            alert('이메일을 입력해 주세요.');
+            return;
+        }
+        if (!validateEmail(email)) {
+            alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
+            event.preventDefault(); // 폼 제출을 막음
+            return;
+        }
+        if (email.length < 5 || email.length >100) {
+            alert('이메일의 허용범위는 최대 100자입니다.');
+            return;
+        }
+
+        // (B4-2) 이메일 인증 검증 (공란O/형식-/자수-)
+        if (!verificationCheckbox.checked) {
+            alert('이메일 인증을 완료해야 합니다.');
+            event.preventDefault(); // 폼 제출을 막음
+            return false;
+        }
+
+        // (B5) 필수 약관동의 검증 (공란O/형식-/자수-)
+        if (!termsCheckbox.checked) {
+            alert('필수 약관에 동의하지 않았습니다.');
+            event.preventDefault(); // 폼 제출을 막음
+            return;
+        }
+
+        // (C1~C3) 중복체크 3종(아이디/닉네임/이메일)의 더블체크
+        const isDuplicate = await checkDuplicates(userId, nickname, email);
+
+        if (isDuplicate) {
+        alert('중복체크를 다시 해 주세요.');
+        return; // 폼 제출을 막음
+        }
+
+        // 모든 검증이 성공하면 폼을 제출
+        event.target.submit();
+
+    } //validateForm(event)
+
+//Group C) 중복확인 (3개 : 아이디/닉네임/이메일)
+    // (C1) id available check
+    function checkIdDuplicate() {
+        const userId = document.getElementById('userId').value;
+
+        // (B0) 아이디 검증 (공란O/형식O/자수O)
+        if(!userId) {
+            alert('아이디를 입력해 주세요.');
+            return;
+        }
+        if (!validateUserId(userId)) {
+            alert('아이디는 영문과 숫자의 조합으로만 가능합니다.');
+            return;
+        }
+        if (userId.length < 4 || userId.length >20) {
+            alert('아이디의 글자수는 4~20자를 허용합니다.');
+            return;
+        }
+
+        // 본격 아이디 중복테스트
+        fetch(`/user/checkIdDuplicate?userId=${encodeURIComponent(userId)}`)
+            .then(response => response.json())
+            .then(data => {
+                if (data.isDuplicate) alert('이미 존재하는 아이디입니다. ');
+                else alert('사용 가능한 아이디입니다.');
+            })
+            .catch(error => {
+                console.error('Error: ', error);
+            });
+    } //checkIdDuplicate()
+
+    // (C2) nickname available check
+    function checkNicknameDuplicate() {
+        const nickname = document.getElementById('nickname').value;
+
+        // (B2) 닉네임 검증 (공란O/형식-/자수O)
+        if(!nickname) {
+            alert('닉네임을 입력해 주세요.');
+            return;
+        }
+        if (nickname.length < 4 || nickname.length >20) {
+            alert('닉네임의 글자수는 4~20자를 허용합니다.');
+            return;
+        }
+
+        // 본격 닉네임 중복테스트
+        fetch(`/user/checkNicknameDuplicate?nickname=${encodeURIComponent(nickname)}`)
+            .then(response => response.json())
+            .then(data => {
+                if (data.isDuplicate) alert('이미 사용 중인 닉네임입니다.');
+                else alert('사용 가능한 닉네임입니다.');
+            })
+            .catch(error => {
+                console.error('Error: ', error);
+            });
+    } //checkNicknameDuplicate()
+
+    // (C3) email available check
+    function checkEmailDuplicatePromise() {
+        return new Promise((resolve, reject) => {
+            const email = document.getElementById('email').value;
+
+            // (B4-1) 이메일 검증 (공란O/형식O/자수O)
+            if(!email) {
+                alert('이메일을 입력해 주세요.');
+                return;
+            }
+            if (!validateEmail(email)) {
+                alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
+                event.preventDefault(); // 폼 제출을 막음
+                return;
+            }
+            if (email.length < 5 || email.length >100) {
+                alert('이메일의 허용범위는 최대 100자입니다.');
+                return;
+            }
+
+            // 본격 이메일 중복테스트
+            fetch(`/user/checkEmailDuplicate?email=${encodeURIComponent(email)}`)
+                .then(response => response.json())
+                .then(data => {
+                    if (data.isDuplicate) {
+                        alert('이미 등록된 이메일입니다.');
+                        reject(); // 중복된 이메일일 경우 Promise를 reject
+                    } else {
+                        resolve(); // 이메일이 중복되지 않으면 Promise를 resolve
+                    }
+                })
+                .catch(error => {
+                    console.error('Error: ', error);
+                    reject(); // 오류 발생 시 Promise를 reject
+                });
+        });
+    }
+
+    // (C0) 제출전 3가지 동시에 체크하기
+    async function checkDuplicates(userId, nickname, email) {
+        try {
+            const responses = await Promise.all([
+                fetch(`/user/checkIdDuplicate?userId=${encodeURIComponent(userId)}`),
+                fetch(`/user/checkNicknameDuplicate?nickname=${encodeURIComponent(nickname)}`),
+                fetch(`/user/checkEmailDuplicate?email=${encodeURIComponent(email)}`)
+            ]);
+
+            const [idResponse, nicknameResponse, emailResponse] = await Promise.all(responses.map(response => response.json()));
+
+            if (idResponse.isDuplicate || nicknameResponse.isDuplicate || emailResponse.isDuplicate) {
+                return true; // 중복이 발견되면 true 반환
+            }
+
+            return false; // 중복이 없으면 false 반환
+        } catch (error) {
+            console.error('Error checking duplicates:', error);
+            return true; // 에러 발생 시 중복 체크 실패로 간주
+        }
+    } //checkDuplicates
+
+//Group D) 이메일인증
+    function sendNumber() {
+        checkEmailDuplicatePromise()
+            .then(() => {
+                // 이메일 중복이 확인되지 않았을 때만 AJAX 요청 실행
+                $.ajax({
+                    url: "/user/mail/mailSend",
+                    type: "post",
+                    contentType: "application/json; charset=UTF-8",
+                    dataType: "json",
+                    data: JSON.stringify({ "mail": $("#email").val() }),
+                    success: function(response) {
+                        if (response === true) {
+                            alert("인증번호를 발송했습니다. 메일을 확인해주세요.");
+                            // 인증하기 버튼 바꾸기
+                            $("#emailVerifyButton").text("다시 전송");
+                        } else {
+                            alert("메일 발송에 실패했습니다");
+                        }
+                    },
+                    error: function(xhr, status, error) {
+                        alert("요청 처리 중 오류가 발생했습니다: " + error);
+                    }
+                });
+            })
+            .catch(() => {
+                // 중복된 이메일이거나, 오류가 발생했을 경우 AJAX 요청이 실행되지 않음
+            });
+    }
+
+    function confirmNumber() {
+        $.ajax({
+            url: "/user/mail/mailCheck",
+            type: "get",
+            dataType: "json",
+            data: { "userNumber": $("#mailNumber").val() },
+            success: function(response) {
+                if (response === true) {
+                    // 인증이 성공한 경우 hidden checkbox를 체크
+                    $("#verificationCheckbox").prop("checked", true);
+                    // 이메일 입력 박스를 readonly로 설정
+                    $("#email").prop("readonly", true);
+                    alert("인증되었습니다.");
+                    // 인증하기 버튼 바꾸기
+                    $("#emailVerifyButton").text("인증완료");
+                    // 인증번호란 readonly로 설정
+                    $("#mailNumber").prop("readonly", true);
+                    //버튼의 색 바꾸기 #EEEEEE
+                    $("#emailVerifyButton").css("background-color", "grey");
+                    // 인증하기 버튼 비활성화
+                    $("#emailVerifyButton").prop("disabled", true);
+                    // 인증확인 버튼 인증완료로 바꾸기
+                    $("#emailConfirmButton").text("인증완료");
+                    // 인증확인 버튼 색 바꾸기
+                    $("#emailConfirmButton").css("background-color", "grey");
+                    // 인증확인 버튼 비활성화
+                    $("#emailConfirmButton").prop("disabled", true);
+                } else {
+                    // 인증이 실패한 경우
+                    $("#verificationCheckbox").prop("checked", false);
+                    alert("인증번호가 일치하지 않습니다.");
+                }
+            },
+            error: function(jqXHR, textStatus, errorThrown) {
+                console.error("인증 요청 실패:", textStatus, errorThrown);
+                alert("인증 과정 중 오류가 발생했습니다.");
+            }
+        });
+    }

--- a/src/main/resources/static/js/uservalidation.js
+++ b/src/main/resources/static/js/uservalidation.js
@@ -354,7 +354,15 @@
                 } else {
                     // 인증이 실패한 경우
                     $("#verificationCheckbox").prop("checked", false);
-                    alert("인증번호가 일치하지 않습니다.");
+                    //alert("인증번호가 일치하지 않습니다.");
+                    // #emailVerifyButton의 text를 가져와서 조건에 따라 alert 메시지 변경
+                    var buttonText = $("#emailVerifyButton").text().trim();
+
+                    if (buttonText === "인증하기") {
+                        alert("먼저 이메일을 입력해서 이메일 인증을 진행해 주세요.");
+                    } else {
+                        alert("인증번호가 일치하지 않습니다.");
+                    }
                 }
             },
             error: function(jqXHR, textStatus, errorThrown) {

--- a/src/main/resources/static/js/uservalidation2.js
+++ b/src/main/resources/static/js/uservalidation2.js
@@ -1,0 +1,392 @@
+//////////////////////////////////
+// uservalidation.js와의 차이점
+// (1) 아이디의 밸리데이션체크를 배제합니다.
+//////////////////////////////////
+//Group A) 오토포맷 (1개 : 연락처)
+    // (A1) 연락처 오토포맷
+    function autoFormatPhoneNumber(input) {
+        let phoneNumber = input.value.replace(/\D/g, ''); // Remove all non-digit characters
+        if (phoneNumber.length > 3 && phoneNumber.length <= 7) {
+            phoneNumber = phoneNumber.substring(0, 3) + '-' + phoneNumber.substring(3);
+        } else if (phoneNumber.length > 7) {
+            phoneNumber = phoneNumber.substring(0, 3) + '-' + phoneNumber.substring(3, 7) + '-' + phoneNumber.substring(7, 11);
+        }
+        input.value = phoneNumber;
+    }
+
+//Group B) validate (4개 : 비번/연락처/이메일/약관동의)
+    // (B1) 비밀번호 일치 여부를 검증하는 함수
+    function validatePasswordMatch() {
+        const password = document.querySelector('input[name="password"]').value;
+        const confirmPassword = document.querySelector('input[name="confirmPassword"]').value;
+
+        if (!password || !confirmPassword) {
+            alert('비밀번호와 비밀번호 확인란 모두 입력해 주세요.');
+            return false; // 비밀번호가 입력되지 않으면 폼 제출을 막음
+        }
+
+        if (password.length < 8 || password.length >30 || confirmPassword.length < 8 || confirmPassword.length >30) {
+            alert('비밀번호는 8~30자를 허용합니다.');
+            return;
+        }
+
+        if (password !== confirmPassword) {
+            alert('비밀번호를 다시 확인해주세요.');
+            return false; // 비밀번호가 일치하지 않으면 폼 제출을 막음
+        }
+
+        return true; // 비밀번호가 일치하고 둘 다 입력되었으면 폼 제출을 진행
+    }
+
+
+    // (B0) 아이디 형식을 확인하는 함수
+    // function validateUserId(userId) {
+    //     const validIdPattern = /^[a-zA-Z0-9]+$/;    //영문과 숫자의 조합
+    //     return validIdPattern.test(userId);
+
+    // }
+    
+   
+    // (B3) 연락처 형식을 확인하는 함수
+    function validatePhoneNumber(phoneNumber) {
+        const phonePattern = /^\d{3}-\d{4}-\d{4}$/; // 000-0000-0000 형식
+        return phonePattern.test(phoneNumber);
+    }
+
+    // (B4) 이메일 형식을 확인하는 함수
+    function validateEmail(email) {
+        // 이메일 형식을 검증하는 정규 표현식
+        const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        return emailPattern.test(email);
+    }
+
+    // 폼 제출 전에 모든 필드를 검증하는 함수
+    async function validateForm(event) {
+        // 클릭된 버튼이 탈퇴 버튼인지 확인
+        if (event.submitter && event.submitter.id === "deleteUserForm") {
+            return; // "탈퇴하기" 버튼을 클릭한 경우, validateForm 실행을 중단
+        }
+
+        event.preventDefault(); // 폼 제출 기본 동작 방지
+
+        ////////////////////////////////////////////
+        //리마인드:HTML에서 정한 자수제한 + (DB에서 정한 자수제한)
+        //아이디*       4~20    (~50)#UK
+        //비밀번호*      8~30   (~255)#
+        //비밀번호확인*   8~30    (없음)
+        //닉네임*       4~20    (~50)#UK
+        //연락처--------------------- UK
+        //성별----------------------#
+        //생년월일-------------------
+        //실명          0~10    (~20)
+        //이메일*        5~100  (~100)#UK
+        //인증번호입력*   0~6     (없음)
+        //자기소개       0~150   (text)
+        //약관동의*------------------#
+        ////////////////////////////////////////////
+
+
+        //셀렉터 정리
+            // (B0) 아이디
+            // const userId = document.getElementById('userId').value;
+            // (B1) 비밀번호
+            // (B2) 닉네임
+            const nickname = document.getElementById('nickname').value;
+            // (B3) 연락처
+            const phoneNumberInput = document.querySelector('input[name="contactNumber"]');
+            const phoneNumber = phoneNumberInput.value;
+            // (B4) 이메일
+            const emailInput = document.querySelector('input[name="email"]');
+            const email = emailInput.value;
+            // (B5) 약관동의
+            // const termsCheckbox = document.getElementById('termsAgreementCheckbox');
+            // var verificationCheckbox = document.getElementById('verificationCheckbox');
+
+
+        // (B0) 아이디 검증 (공란O/형식O/자수O)
+        // if(!userId) {
+        //     alert('아이디를 입력해 주세요.');
+        //     return;
+        // }
+        // if (!validateUserId(userId)) {
+        //     alert('아이디는 영문과 숫자의 조합으로만 가능합니다.');
+        //     return;
+        // }
+        // if (userId.length < 4 || userId.length >20) {
+        //     alert('아이디의 글자수는 4~20자를 허용합니다.');
+        //     return;
+        // }
+
+        // (B1) 비밀번호 일치 여부 검증 (공란O/형식O/자수O)
+        if (!validatePasswordMatch()) {
+            //alert('비밀번호를 다시 확인해주세요.'); // 비밀번호 불일치 시 경고
+            return; // 폼 제출을 막음
+        }
+
+        // (B2) 닉네임 검증 (공란O/형식-/자수O)
+        if(!nickname) {
+            alert('닉네임을 입력해 주세요.');
+            return;
+        }
+        if (nickname.length < 4 || nickname.length >20) {
+            alert('닉네임의 글자수는 4~20자를 허용합니다.');
+            return;
+        }
+        
+        // (B3) 연락처 검증 (공란-/형식O/자수O)
+        if (phoneNumber.length > 0 && !validatePhoneNumber(phoneNumber)) {
+            alert("연락처 형식이 올바르지 않습니다. 예: 000-0000-0000");
+            event.preventDefault(); // 폼 제출을 막음
+            return;
+        }
+        if (phoneNumber.length >13) {
+            alert('연락처로 허용될 수 있는 자수를 초과했습니다.');
+            return;
+        }
+
+        // (B4-1) 이메일 검증 (공란O/형식O/자수O)
+        if(!email) {
+            alert('이메일을 입력해 주세요.');
+            return;
+        }
+        if (!validateEmail(email)) {
+            alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
+            event.preventDefault(); // 폼 제출을 막음
+            return;
+        }
+        if (email.length < 5 || email.length >100) {
+            alert('이메일의 허용범위는 최대 100자입니다.');
+            return;
+        }
+
+        // (B4-2) 이메일 인증 검증 (공란O/형식-/자수-)
+        // if (!verificationCheckbox.checked) {
+        //     alert('이메일 인증을 완료해야 합니다.');
+        //     event.preventDefault(); // 폼 제출을 막음
+        //     return false;
+        // }
+
+        // (B5) 필수 약관동의 검증 (공란O/형식-/자수-)
+        // if (!termsCheckbox.checked) {
+        //     alert('필수 약관에 동의하지 않았습니다.');
+        //     event.preventDefault(); // 폼 제출을 막음
+        //     return;
+        // }
+
+        // (C1~C3) 중복체크 3종(아이디/닉네임/이메일)의 더블체크
+        const isDuplicate = await checkDuplicates(/*userId,*/ nickname, email);
+
+        if (isDuplicate) {
+        alert('중복체크를 다시 해 주세요.');
+        return; // 폼 제출을 막음
+        }
+
+        // 모든 검증이 성공하면 폼을 제출
+        event.target.submit();
+
+    } //validateForm(event)
+
+//Group C) 중복확인 (3개 : 아이디/닉네임/이메일)
+    // (C1) id available check
+    // function checkIdDuplicate() {
+    //     const userId = document.getElementById('userId').value;
+
+    //     // (B0) 아이디 검증 (공란O/형식O/자수O)
+    //     if(!userId) {
+    //         alert('아이디를 입력해 주세요.');
+    //         return;
+    //     }
+    //     if (!validateUserId(userId)) {
+    //         alert('아이디는 영문과 숫자의 조합으로만 가능합니다.');
+    //         return;
+    //     }
+    //     if (userId.length < 4 || userId.length >20) {
+    //         alert('아이디의 글자수는 4~20자를 허용합니다.');
+    //         return;
+    //     }
+
+    //     // 본격 아이디 중복테스트
+    //     fetch(`/user/checkIdDuplicate?userId=${encodeURIComponent(userId)}`)
+    //         .then(response => response.json())
+    //         .then(data => {
+    //             if (data.isDuplicate) alert('이미 존재하는 아이디입니다. ');
+    //             else alert('사용 가능한 아이디입니다.');
+    //         })
+    //         .catch(error => {
+    //             console.error('Error: ', error);
+    //         });
+    // } //checkIdDuplicate()
+
+    // (C2) nickname available check
+    function checkNicknameDuplicate() {
+        const nickname = document.getElementById('nickname').value;
+
+        // (B2) 닉네임 검증 (공란O/형식-/자수O)
+        if(!nickname) {
+            alert('닉네임을 입력해 주세요.');
+            return;
+        }
+        if (nickname.length < 4 || nickname.length >20) {
+            alert('닉네임의 글자수는 4~20자를 허용합니다.');
+            return;
+        }
+
+        // (회원정보 수정 전용) 기존의 것은 제외시켜야 한다.
+        const hiddenNickname = document.getElementById('hiddenNickname').value; // 기존 닉네임
+
+        // 본격 닉네임 중복테스트
+        fetch(`/user/checkNicknameDuplicate?nickname=${encodeURIComponent(nickname)}`)
+            .then(response => response.json())
+            .then(data => {
+                if (nickname === hiddenNickname) {
+                    alert('현재 회원님이 사용 중인 닉네임입니다.');
+                } else if (data.isDuplicate) {
+                    alert('이미 사용 중인 닉네임입니다.');
+                } else {
+                    alert('사용 가능한 닉네임입니다.');
+                }
+            })
+            .catch(error => {
+                console.error('Error: ', error);
+            });
+    } //checkNicknameDuplicate() 수정됨
+
+    // (C3) email available check
+    function checkEmailDuplicate() {
+        const email = document.getElementById('email').value;
+
+        // (B4-1) 이메일 검증 (공란O/형식O/자수O)
+        if (!email) {
+            alert('이메일을 입력해 주세요.');
+            return;
+        }
+        if (!validateEmail(email)) {
+            alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
+            return;
+        }
+        if (email.length < 5 || email.length > 100) {
+            alert('이메일의 허용범위는 최대 100자입니다.');
+            return;
+        }
+
+        // (회원정보 수정 전용) 기존의 이메일은 제외시켜야 한다.
+        const hiddenEmail = document.getElementById('hiddenEmail').value; // 기존 이메일
+
+        // 본격 이메일 중복테스트
+        fetch(`/user/checkEmailDuplicate?email=${encodeURIComponent(email)}`)
+            .then(response => response.json())
+            .then(data => {
+                if (email === hiddenEmail) {
+                    alert('현재 회원님이 사용 중인 이메일입니다.');
+                } else if (data.isDuplicate) {
+                    alert('이미 등록된 이메일입니다.');
+                } else {
+                    alert('사용 가능한 이메일입니다.');
+                }
+            })
+            .catch(error => {
+                console.error('Error: ', error);
+            });
+    }
+
+
+    // (C0) 제출 전 3가지 동시에 체크하기
+    async function checkDuplicates(nickname, email) {
+        try {
+            const hiddenNickname = document.getElementById('hiddenNickname').value; // 기존 닉네임
+            const hiddenEmail = document.getElementById('hiddenEmail').value; // 기존 이메일
+
+            const responses = await Promise.all([
+                fetch(`/user/checkNicknameDuplicate?nickname=${encodeURIComponent(nickname)}`),
+                fetch(`/user/checkEmailDuplicate?email=${encodeURIComponent(email)}`)
+            ]);
+
+            const [nicknameResponse, emailResponse] = await Promise.all(responses.map(response => response.json()));
+
+            // 만약 닉네임이 기존 닉네임과 같다면 중복 아님으로 간주
+            const isNicknameDuplicate = nicknameResponse.isDuplicate && nickname !== hiddenNickname;
+            
+            // 만약 이메일이 기존 이메일과 같다면 중복 아님으로 간주
+            const isEmailDuplicate = emailResponse.isDuplicate && email !== hiddenEmail;
+
+            if (isNicknameDuplicate || isEmailDuplicate) {
+                return true; // 중복이 발견되면 true 반환
+            }
+
+            return false; // 중복이 없으면 false 반환
+        } catch (error) {
+            console.error('Error checking duplicates:', error);
+            return true; // 에러 발생 시 중복 체크 실패로 간주
+        }
+    }
+
+
+//Group D) 이메일인증
+    function sendNumber() {
+        checkEmailDuplicatePromise()
+            .then(() => {
+                // 이메일 중복이 확인되지 않았을 때만 AJAX 요청 실행
+                $.ajax({
+                    url: "/user/mail/mailSend",
+                    type: "post",
+                    contentType: "application/json; charset=UTF-8",
+                    dataType: "json",
+                    data: JSON.stringify({ "mail": $("#email").val() }),
+                    success: function(response) {
+                        if (response === true) {
+                            alert("인증번호를 발송했습니다. 메일을 확인해주세요.");
+                            // 인증하기 버튼 바꾸기
+                            $("#emailVerifyButton").text("다시 전송");
+                        } else {
+                            alert("메일 발송에 실패했습니다");
+                        }
+                    },
+                    error: function(xhr, status, error) {
+                        alert("요청 처리 중 오류가 발생했습니다: " + error);
+                    }
+                });
+            })
+            .catch(() => {
+                // 중복된 이메일이거나, 오류가 발생했을 경우 AJAX 요청이 실행되지 않음
+            });
+    }
+
+    function confirmNumber() {
+        $.ajax({
+            url: "/user/mail/mailCheck",
+            type: "get",
+            dataType: "json",
+            data: { "userNumber": $("#mailNumber").val() },
+            success: function(response) {
+                if (response === true) {
+                    // 인증이 성공한 경우 hidden checkbox를 체크
+                    $("#verificationCheckbox").prop("checked", true);
+                    // 이메일 입력 박스를 readonly로 설정
+                    $("#email").prop("readonly", true);
+                    alert("인증되었습니다.");
+                    // 인증하기 버튼 바꾸기
+                    $("#emailVerifyButton").text("인증완료");
+                    // 인증번호란 readonly로 설정
+                    $("#mailNumber").prop("readonly", true);
+                    //버튼의 색 바꾸기 #EEEEEE
+                    $("#emailVerifyButton").css("background-color", "grey");
+                    // 인증하기 버튼 비활성화
+                    $("#emailVerifyButton").prop("disabled", true);
+                    // 인증확인 버튼 인증완료로 바꾸기
+                    $("#emailConfirmButton").text("인증완료");
+                    // 인증확인 버튼 색 바꾸기
+                    $("#emailConfirmButton").css("background-color", "grey");
+                    // 인증확인 버튼 비활성화
+                    $("#emailConfirmButton").prop("disabled", true);
+                } else {
+                    // 인증이 실패한 경우
+                    $("#verificationCheckbox").prop("checked", false);
+                    alert("인증번호가 일치하지 않습니다.");
+                }
+            },
+            error: function(jqXHR, textStatus, errorThrown) {
+                console.error("인증 요청 실패:", textStatus, errorThrown);
+                alert("인증 과정 중 오류가 발생했습니다.");
+            }
+        });
+    }

--- a/src/main/resources/static/js/uservalidation3.js
+++ b/src/main/resources/static/js/uservalidation3.js
@@ -1,0 +1,403 @@
+//////////////////////////////////
+// uservalidation2.js와의 차이점
+// (2) 비밀번호 밸리데이션체크를 배제합니다.
+//////////////////////////////////
+//////////////////////////////////
+// uservalidation.js와의 차이점
+// (1) 아이디의 밸리데이션체크를 배제합니다.
+//////////////////////////////////
+//Group A) 오토포맷 (1개 : 연락처)
+    // (A1) 연락처 오토포맷
+    function autoFormatPhoneNumber(input) {
+        let phoneNumber = input.value.replace(/\D/g, ''); // Remove all non-digit characters
+        if (phoneNumber.length > 3 && phoneNumber.length <= 7) {
+            phoneNumber = phoneNumber.substring(0, 3) + '-' + phoneNumber.substring(3);
+        } else if (phoneNumber.length > 7) {
+            phoneNumber = phoneNumber.substring(0, 3) + '-' + phoneNumber.substring(3, 7) + '-' + phoneNumber.substring(7, 11);
+        }
+        input.value = phoneNumber;
+    }
+
+//Group B) validate (4개 : 비번/연락처/이메일/약관동의)
+    // (B1) 비밀번호 일치 여부를 검증하는 함수
+    // function validatePasswordMatch() {
+    //     const password = document.querySelector('input[name="password"]').value;
+    //     const confirmPassword = document.querySelector('input[name="confirmPassword"]').value;
+
+    //     if (!password || !confirmPassword) {
+    //         alert('비밀번호와 비밀번호 확인란 모두 입력해 주세요.');
+    //         return false; // 비밀번호가 입력되지 않으면 폼 제출을 막음
+    //     }
+
+    //     if (password.length < 8 || password.length >30 || confirmPassword.length < 8 || confirmPassword.length >30) {
+    //         alert('비밀번호는 8~30자를 허용합니다.');
+    //         return;
+    //     }
+
+    //     if (password !== confirmPassword) {
+    //         alert('비밀번호를 다시 확인해주세요.');
+    //         return false; // 비밀번호가 일치하지 않으면 폼 제출을 막음
+    //     }
+
+    //     return true; // 비밀번호가 일치하고 둘 다 입력되었으면 폼 제출을 진행
+    // }
+
+
+    // (B0) 아이디 형식을 확인하는 함수
+    // function validateUserId(userId) {
+    //     const validIdPattern = /^[a-zA-Z0-9]+$/;    //영문과 숫자의 조합
+    //     return validIdPattern.test(userId);
+
+    // }
+
+
+    // (B3) 연락처 형식을 확인하는 함수
+    function validatePhoneNumber(phoneNumber) {
+        const phonePattern = /^\d{3}-\d{4}-\d{4}$/; // 000-0000-0000 형식
+        return phonePattern.test(phoneNumber);
+    }
+
+    // (B4) 이메일 형식을 확인하는 함수
+    function validateEmail(email) {
+        // 이메일 형식을 검증하는 정규 표현식
+        const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+        return emailPattern.test(email);
+    }
+
+    // 폼 제출 전에 모든 필드를 검증하는 함수
+    async function validateForm(event) {
+        // 클릭된 버튼이 탈퇴 버튼인지 확인
+        if (event.submitter && (event.submitter.id === "deleteUserForm" || event.submitter.id === "reactiveUserForm")) {
+            return; // "탈퇴하기" 버튼을 클릭한 경우, validateForm 실행을 중단
+        }
+        event.preventDefault(); // 폼 제출 기본 동작 방지
+
+        ////////////////////////////////////////////
+        //리마인드:HTML에서 정한 자수제한 + (DB에서 정한 자수제한)
+        //아이디*       4~20    (~50)#UK
+        //비밀번호*      8~30   (~255)#
+        //비밀번호확인*   8~30    (없음)
+        //닉네임*       4~20    (~50)#UK
+        //연락처--------------------- UK
+        //성별----------------------#
+        //생년월일-------------------
+        //실명          0~10    (~20)
+        //이메일*        5~100  (~100)#UK
+        //인증번호입력*   0~6     (없음)
+        //자기소개       0~150   (text)
+        //약관동의*------------------#
+        ////////////////////////////////////////////
+
+
+        //셀렉터 정리
+            // (B0) 아이디
+            // const userId = document.getElementById('userId').value;
+            // (B1) 비밀번호
+            // (B2) 닉네임
+            const nickname = document.getElementById('nickname').value;
+            // (B3) 연락처
+            const phoneNumberInput = document.querySelector('input[name="contactNumber"]');
+            const phoneNumber = phoneNumberInput.value;
+            // (B4) 이메일
+            const emailInput = document.querySelector('input[name="email"]');
+            const email = emailInput.value;
+            // (B5) 약관동의
+            // const termsCheckbox = document.getElementById('termsAgreementCheckbox');
+            // var verificationCheckbox = document.getElementById('verificationCheckbox');
+
+
+        // (B0) 아이디 검증 (공란O/형식O/자수O)
+        // if(!userId) {
+        //     alert('아이디를 입력해 주세요.');
+        //     return;
+        // }
+        // if (!validateUserId(userId)) {
+        //     alert('아이디는 영문과 숫자의 조합으로만 가능합니다.');
+        //     return;
+        // }
+        // if (userId.length < 4 || userId.length >20) {
+        //     alert('아이디의 글자수는 4~20자를 허용합니다.');
+        //     return;
+        // }
+
+        // (B1) 비밀번호 일치 여부 검증 (공란O/형식O/자수O)
+        // if (!validatePasswordMatch()) {
+        //     //alert('비밀번호를 다시 확인해주세요.'); // 비밀번호 불일치 시 경고
+        //     return; // 폼 제출을 막음
+        // }
+
+        // (B2) 닉네임 검증 (공란O/형식-/자수O)
+        if(!nickname) {
+            alert('닉네임을 입력해 주세요.');
+            return;
+        }
+        if (nickname.length < 4 || nickname.length >20) {
+            alert('닉네임의 글자수는 4~20자를 허용합니다.');
+            return;
+        }
+
+        // (B3) 연락처 검증 (공란-/형식O/자수O)
+        if (phoneNumber.length > 0 && !validatePhoneNumber(phoneNumber)) {
+            alert("연락처 형식이 올바르지 않습니다. 예: 000-0000-0000");
+            event.preventDefault(); // 폼 제출을 막음
+            return;
+        }
+        if (phoneNumber.length >13) {
+            alert('연락처로 허용될 수 있는 자수를 초과했습니다.');
+            return;
+        }
+
+        // (B4-1) 이메일 검증 (공란O/형식O/자수O)
+        if(!email) {
+            alert('이메일을 입력해 주세요.');
+            return;
+        }
+        if (!validateEmail(email)) {
+            alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
+            event.preventDefault(); // 폼 제출을 막음
+            return;
+        }
+        if (email.length < 5 || email.length >100) {
+            alert('이메일의 허용범위는 최대 100자입니다.');
+            return;
+        }
+
+        // (B4-2) 이메일 인증 검증 (공란O/형식-/자수-)
+        // if (!verificationCheckbox.checked) {
+        //     alert('이메일 인증을 완료해야 합니다.');
+        //     event.preventDefault(); // 폼 제출을 막음
+        //     return false;
+        // }
+
+        // (B5) 필수 약관동의 검증 (공란O/형식-/자수-)
+        // if (!termsCheckbox.checked) {
+        //     alert('필수 약관에 동의하지 않았습니다.');
+        //     event.preventDefault(); // 폼 제출을 막음
+        //     return;
+        // }
+
+        // (C1~C3) 중복체크 3종(아이디/닉네임/이메일)의 더블체크
+        const isDuplicate = await checkDuplicates(/*userId,*/ nickname, email);
+
+        if (isDuplicate) {
+        alert('중복체크를 다시 해 주세요.');
+        return; // 폼 제출을 막음
+        }
+
+        // 모든 검증이 성공하면 폼을 제출
+        // form.submit();
+        // event.target.submit();
+        const form = event.target.closest('form');
+        console.log(form);
+        if (form) {
+            form.submit(); // 폼 제출
+        } else {
+            console.error('폼을 찾을 수 없습니다.');
+        }
+
+    } //validateForm(event)
+
+//Group C) 중복확인 (3개 : 아이디/닉네임/이메일)
+    // (C1) id available check
+    // function checkIdDuplicate() {
+    //     const userId = document.getElementById('userId').value;
+
+    //     // (B0) 아이디 검증 (공란O/형식O/자수O)
+    //     if(!userId) {
+    //         alert('아이디를 입력해 주세요.');
+    //         return;
+    //     }
+    //     if (!validateUserId(userId)) {
+    //         alert('아이디는 영문과 숫자의 조합으로만 가능합니다.');
+    //         return;
+    //     }
+    //     if (userId.length < 4 || userId.length >20) {
+    //         alert('아이디의 글자수는 4~20자를 허용합니다.');
+    //         return;
+    //     }
+
+    //     // 본격 아이디 중복테스트
+    //     fetch(`/user/checkIdDuplicate?userId=${encodeURIComponent(userId)}`)
+    //         .then(response => response.json())
+    //         .then(data => {
+    //             if (data.isDuplicate) alert('이미 존재하는 아이디입니다. ');
+    //             else alert('사용 가능한 아이디입니다.');
+    //         })
+    //         .catch(error => {
+    //             console.error('Error: ', error);
+    //         });
+    // } //checkIdDuplicate()
+
+    // (C2) nickname available check
+    function checkNicknameDuplicate() {
+        const nickname = document.getElementById('nickname').value;
+
+        // (B2) 닉네임 검증 (공란O/형식-/자수O)
+        if(!nickname) {
+            alert('닉네임을 입력해 주세요.');
+            return;
+        }
+        if (nickname.length < 4 || nickname.length >20) {
+            alert('닉네임의 글자수는 4~20자를 허용합니다.');
+            return;
+        }
+
+        // (회원정보 수정 전용) 기존의 것은 제외시켜야 한다.
+        const hiddenNickname = document.getElementById('hiddenNickname').value; // 기존 닉네임
+
+        // 본격 닉네임 중복테스트
+        fetch(`/user/checkNicknameDuplicate?nickname=${encodeURIComponent(nickname)}`)
+            .then(response => response.json())
+            .then(data => {
+                if (nickname === hiddenNickname) {
+                    alert('현재 회원님이 사용 중인 닉네임입니다.');
+                } else if (data.isDuplicate) {
+                    alert('이미 사용 중인 닉네임입니다.');
+                } else {
+                    alert('사용 가능한 닉네임입니다.');
+                }
+            })
+            .catch(error => {
+                console.error('Error: ', error);
+            });
+    } //checkNicknameDuplicate() 수정됨
+
+    // (C3) email available check
+    function checkEmailDuplicate() {
+        const email = document.getElementById('email').value;
+
+        // (B4-1) 이메일 검증 (공란O/형식O/자수O)
+        if (!email) {
+            alert('이메일을 입력해 주세요.');
+            return;
+        }
+        if (!validateEmail(email)) {
+            alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
+            return;
+        }
+        if (email.length < 5 || email.length > 100) {
+            alert('이메일의 허용범위는 최대 100자입니다.');
+            return;
+        }
+
+        // (회원정보 수정 전용) 기존의 이메일은 제외시켜야 한다.
+        const hiddenEmail = document.getElementById('hiddenEmail').value; // 기존 이메일
+
+        // 본격 이메일 중복테스트
+        fetch(`/user/checkEmailDuplicate?email=${encodeURIComponent(email)}`)
+            .then(response => response.json())
+            .then(data => {
+                if (email === hiddenEmail) {
+                    alert('현재 회원님이 사용 중인 이메일입니다.');
+                } else if (data.isDuplicate) {
+                    alert('이미 등록된 이메일입니다.');
+                } else {
+                    alert('사용 가능한 이메일입니다.');
+                }
+            })
+            .catch(error => {
+                console.error('Error: ', error);
+            });
+    }
+
+
+    // (C0) 제출 전 3가지 동시에 체크하기
+    async function checkDuplicates(nickname, email) {
+        try {
+            const hiddenNickname = document.getElementById('hiddenNickname').value; // 기존 닉네임
+            const hiddenEmail = document.getElementById('hiddenEmail').value; // 기존 이메일
+
+            const responses = await Promise.all([
+                fetch(`/user/checkNicknameDuplicate?nickname=${encodeURIComponent(nickname)}`),
+                fetch(`/user/checkEmailDuplicate?email=${encodeURIComponent(email)}`)
+            ]);
+
+            const [nicknameResponse, emailResponse] = await Promise.all(responses.map(response => response.json()));
+
+            // 만약 닉네임이 기존 닉네임과 같다면 중복 아님으로 간주
+            const isNicknameDuplicate = nicknameResponse.isDuplicate && nickname !== hiddenNickname;
+
+            // 만약 이메일이 기존 이메일과 같다면 중복 아님으로 간주
+            const isEmailDuplicate = emailResponse.isDuplicate && email !== hiddenEmail;
+
+            if (isNicknameDuplicate || isEmailDuplicate) {
+                return true; // 중복이 발견되면 true 반환
+            }
+
+            return false; // 중복이 없으면 false 반환
+        } catch (error) {
+            console.error('Error checking duplicates:', error);
+            return true; // 에러 발생 시 중복 체크 실패로 간주
+        }
+    }
+
+
+//Group D) 이메일인증
+    function sendNumber() {
+        checkEmailDuplicatePromise()
+            .then(() => {
+                // 이메일 중복이 확인되지 않았을 때만 AJAX 요청 실행
+                $.ajax({
+                    url: "/user/mail/mailSend",
+                    type: "post",
+                    contentType: "application/json; charset=UTF-8",
+                    dataType: "json",
+                    data: JSON.stringify({ "mail": $("#email").val() }),
+                    success: function(response) {
+                        if (response === true) {
+                            alert("인증번호를 발송했습니다. 메일을 확인해주세요.");
+                            // 인증하기 버튼 바꾸기
+                            $("#emailVerifyButton").text("다시 전송");
+                        } else {
+                            alert("메일 발송에 실패했습니다");
+                        }
+                    },
+                    error: function(xhr, status, error) {
+                        alert("요청 처리 중 오류가 발생했습니다: " + error);
+                    }
+                });
+            })
+            .catch(() => {
+                // 중복된 이메일이거나, 오류가 발생했을 경우 AJAX 요청이 실행되지 않음
+            });
+    }
+
+    function confirmNumber() {
+        $.ajax({
+            url: "/user/mail/mailCheck",
+            type: "get",
+            dataType: "json",
+            data: { "userNumber": $("#mailNumber").val() },
+            success: function(response) {
+                if (response === true) {
+                    // 인증이 성공한 경우 hidden checkbox를 체크
+                    $("#verificationCheckbox").prop("checked", true);
+                    // 이메일 입력 박스를 readonly로 설정
+                    $("#email").prop("readonly", true);
+                    alert("인증되었습니다.");
+                    // 인증하기 버튼 바꾸기
+                    $("#emailVerifyButton").text("인증완료");
+                    // 인증번호란 readonly로 설정
+                    $("#mailNumber").prop("readonly", true);
+                    //버튼의 색 바꾸기 #EEEEEE
+                    $("#emailVerifyButton").css("background-color", "grey");
+                    // 인증하기 버튼 비활성화
+                    $("#emailVerifyButton").prop("disabled", true);
+                    // 인증확인 버튼 인증완료로 바꾸기
+                    $("#emailConfirmButton").text("인증완료");
+                    // 인증확인 버튼 색 바꾸기
+                    $("#emailConfirmButton").css("background-color", "grey");
+                    // 인증확인 버튼 비활성화
+                    $("#emailConfirmButton").prop("disabled", true);
+                } else {
+                    // 인증이 실패한 경우
+                    $("#verificationCheckbox").prop("checked", false);
+                    alert("인증번호가 일치하지 않습니다.");
+                }
+            },
+            error: function(jqXHR, textStatus, errorThrown) {
+                console.error("인증 요청 실패:", textStatus, errorThrown);
+                alert("인증 과정 중 오류가 발생했습니다.");
+            }
+        });
+    }

--- a/src/main/resources/templates/user/admin/userdetails.html
+++ b/src/main/resources/templates/user/admin/userdetails.html
@@ -513,6 +513,23 @@
 </div>
 <div th:replace="common/footer.html"></div>
 <script>
+
+    //탈퇴 폼 제출 후처리
+    window.onload = function() {
+          const urlParams = new URLSearchParams(window.location.search);
+          const status = urlParams.get('status');
+          if (status === 'editSuccess') {
+              alert("프로필 수정이 완료되었습니다.");
+          }
+          else if (status === 'editFailure') {
+              alert("프로필 수정 중 문제가 발생했습니다. 다시 시도해주세요.");
+          }
+          else if (status === 'withdrawnFailure') {
+              alert("회원 탈퇴 처리 중 문제가 발생했습니다.");
+          }
+      }
+</script>
+<script>
     document.getElementById('image').addEventListener('change', function(event) {
       const files = event.target.files;
       const imagePreview = document.getElementById('imagePreview');

--- a/src/main/resources/templates/user/admin/userdetails.html
+++ b/src/main/resources/templates/user/admin/userdetails.html
@@ -18,6 +18,9 @@
     <!-- Latest compiled JavaScript -->
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
 
+    <!--KHG USER VALIDATION JS-->
+    <script src="/js/uservalidation3.js"></script>
+
     <style>
         .navbar {
           position: fixed;
@@ -25,92 +28,6 @@
         }
     </style>
 
-
-    <script>
-        //VALIDATION 1) 생년월일
-            function autoFormatDate(input) {
-                // Remove all non-digit characters
-                let date = input.value.replace(/\D/g, '');
-
-                // Apply the formatting based on the length of the input
-                if (date.length > 4 && date.length <= 6) {
-                    date = date.substring(0, 4) + '-' + date.substring(4);
-                } else if (date.length > 6) {
-                    date = date.substring(0, 4) + '-' + date.substring(4, 6) + '-' + date.substring(6, 8);
-                }
-
-                // Update the input value
-                input.value = date;
-            }
-
-            // 생년월일을 검증하는 함수
-            function validateDateOfBirth(dateOfBirth) {
-                const datePattern = /^\d{4}-\d{2}-\d{2}$/; // yyyy-mm-dd 형식
-                return datePattern.test(dateOfBirth);
-            }
-
-        //VALIDATION 2) 연락처
-            function autoFormatPhoneNumber(input) {
-                let phoneNumber = input.value.replace(/\D/g, ''); // Remove all non-digit characters
-                if (phoneNumber.length > 3 && phoneNumber.length <= 7) {
-                    phoneNumber = phoneNumber.substring(0, 3) + '-' + phoneNumber.substring(3);
-                } else if (phoneNumber.length > 7) {
-                    phoneNumber = phoneNumber.substring(0, 3) + '-' + phoneNumber.substring(3, 7) + '-' + phoneNumber.substring(7, 11);
-                }
-                input.value = phoneNumber;
-            }
-
-
-            // 연락처를 검증하는 함수
-            function validatePhoneNumber(phoneNumber) {
-                const phonePattern = /^\d{3}-\d{4}-\d{4}$/; // 000-0000-0000 형식
-                return phonePattern.test(phoneNumber);
-            }
-
-        // 폼 제출 전에 모든 필드를 검증하는 함수
-
-        //VALIDATION 3) 이메일
-            // 이메일 형식을 확인하는 함수
-            function validateEmail(email) {
-                // 이메일 형식을 검증하는 정규 표현식
-                const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-                return emailPattern.test(email);
-            }
-
-        function validateForm(event) {
-        const emailInput = document.querySelector('input[name="email"]');
-        const email = emailInput.value;
-
-        //const dateOfBirthInput = document.querySelector('input[name="dateOfBirth"]');
-        //const dateOfBirth = dateOfBirthInput.value;
-
-        const phoneNumberInput = document.querySelector('input[name="contactNumber"]');
-        const phoneNumber = phoneNumberInput.value;
-
-        // 이메일 검증
-        if (!validateEmail(email)) {
-            alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
-            event.preventDefault(); // 폼 제출을 막음
-            return;
-        }
-
-        // 생년월일 검증
-       // if (!validateDateOfBirth(dateOfBirth)) {
-       //     alert("생년월일 형식이 올바르지 않습니다. 예: yyyy-mm-dd");
-       //     event.preventDefault(); // 폼 제출을 막음
-       //     return;
-       // }
-
-        // 연락처 검증
-        if (phoneNumber.length > 0 && !validatePhoneNumber(phoneNumber)) {
-            alert("연락처 형식이 올바르지 않습니다. 예: 000-0000-0000");
-            event.preventDefault(); // 폼 제출을 막음
-            return;
-        }
-
-        } //validateForm(event)
-
-    </script>
 </head>
 <body>
 
@@ -264,63 +181,12 @@
                     </div>
                 </div>
             </aside>
-            <script>
-                // nickname available check
-                function checkNicknameDuplicate() {
-                    const nickname = document.getElementById('nickname').value;
 
-                    if(!nickname) {
-                        alert('닉네임을 입력해 주세요.');
-                        return;
-                    }
-
-                    if (nickname.length < 4) {
-                        alert('닉네임의 글자수는 최소 4자입니다.');
-                        return;
-                    }
-
-                    fetch(`/user/checkNicknameDuplicate?nickname=${encodeURIComponent(nickname)}`)
-                        .then(response => response.json())
-                        .then(data => {
-                            if (data.isDuplicate) alert('이미 사용 중인 닉네임입니다.');
-                            else alert('사용 가능한 닉네임입니다.');
-                        })
-                        .catch(error => {
-                            console.error('Error: ', error);
-                        });
-                } //checkNicknameDuplicate()
-
-                // email available check
-                function checkEmailDuplicate() {
-                    const email = document.getElementById('email').value;
-
-                    if(!email) {
-                        alert('이메일을 입력해 주세요.');
-                        return;
-                    }
-
-                    // 이메일 검증
-                    if (!validateEmail(email)) {
-                        alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
-                        return;
-                    }
-
-                    fetch(`/user/checkEmailDuplicate?email=${encodeURIComponent(email)}`)
-                        .then(response => response.json())
-                        .then(data => {
-                            if (data.isDuplicate) alert('이미 등록된 이메일입니다.');
-                            else alert('등록 가능한 이메일입니다.');
-                        })
-                        .catch(error => {
-                            console.error('Error: ', error);
-                        });
-                } //checkEmailDuplicate()
-            </script>
             <div class="col-md-9" style="position:relative; top:-30px; z-index:1000;">
                 <div class="row justify-content-start" style="color: #828282;">
                     <div class="col-8 p-3" id="loginbox">
-                        <form th:object="${user}" method="post"
-                              enctype="multipart/form-data" onsubmit="validateForm(event)">
+                        <form th:action="@{/user/admin/updateuser(userNo=${user.userNo})}" th:object="${user}" method="post"
+                              enctype="multipart/form-data">
                             <div class="row p-2">
                                 <div class="col-3 m-0 p-0" id="profileimagebox">
                                     <div id="imagePreview">
@@ -378,6 +244,10 @@
 
                             </div>
                             <div class="row p-2">
+                                <!--(회원가입과의 차이점) 기존의 닉네임/이메일은 중복체크 대상이면 안된다-->
+                                <input id="hiddenNickname" type="hidden" th:value="${user.nickname}"/>
+                                <input id="hiddenEmail" type="hidden"th:value="${user.email}"/>
+                                <!--(회원가입과의 차이점) 기존의 닉네임/이메일은 중복체크 대상이면 안된다-->
                                 <div class="col-3">
                                     아이디 <span class="required-star">*</span>
                                 </div>
@@ -474,10 +344,10 @@
                                     이메일 <span class="required-star">*</span>
                                 </div>
                                 <div class="col-6">
-                                    <input class="form-control" type="text" th:field="*{email}"/>
+                                    <input class="form-control" type="text" th:field="*{email}"  minlength="5" maxlength="100"/>
                                 </div>
                                 <div class="col-3">
-                                    <button type="button" class="btn btn-primary btn-block"
+                                    <button id="emailVerifyButton" type="button" class="btn btn-primary btn-block"
                                             style="background-color:#03C75A;" onclick="checkEmailDuplicate()">중복확인
                                     </button>
                                 </div>
@@ -498,9 +368,9 @@
                             </div>
                             <div class="row">
                                 <div class="col-3 p-2">
-                                    <button type="submit" class="btn btn-primary btn-block"
+                                    <button id="updateUserButton" type="submit" class="btn btn-primary btn-block"
                                             style="background-color:#03C75A; height:50px;"
-                                            th:attr="formaction=@{/user/admin/updateuser(userNo=${user.userNo})}">수정하기
+                                            th:attr="formaction=@{/user/admin/updateuser(userNo=${user.userNo})}" onclick="validateForm(event)">수정하기
                                     </button>
 
                                     <th:block th:if="${#strings.toString(user.withdrawn) == 'N'}">
@@ -554,19 +424,12 @@
 </div>
 <div th:replace="common/footer.html"></div>
 <script>
+    //수정 관련
+    //document.getElementById('updateUserButton').addEventListener('click', function(event) {
+     //   validateForm(event);
+    //});
+
     //탈퇴 관련
-    function confirmAndValidateDeletion(event) {
-          event.preventDefault(); // 기본 동작을 방지하여 링크 클릭 시 바로 제출되지 않도록 합니다.
-
-          const confirmation = confirm("정말로 해당 회원을 탈퇴처리하시겠습니까?");
-
-          if (confirmation && validatePasswordMatch()) {
-              // 확인 창에서 "예"를 선택하고, 비밀번호가 유효한 경우에 폼을 제출합니다.
-              // 폼을 제출하였을 때 비밀번호 일치여부를 UserService에서 확인할 것임
-              document.getElementById('deleteUserForm').click();
-          }
-      }
-      //탈퇴 버튼 관련
 
       //탈퇴 폼 제출 후처리
       window.onload = function() {

--- a/src/main/resources/templates/user/admin/userdetails.html
+++ b/src/main/resources/templates/user/admin/userdetails.html
@@ -208,19 +208,21 @@
 
 </style>
 <div class="jumbotron">
-    <div class="row">
-        <div class="col-md-3 px-4">
-            <h3>회원 관리</h3>
-        </div>
-        <div class="col-md-9">
-            <nav class="navbar navbar-expand-md">
-                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                    <li><a th:href="@{/user/my}" class="nav-link px-2">마이페이지(테스트용)</a></li>
-                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                </ul>
-            </nav>
+    <div class="container">
+        <div class="row">
+            <div class="col-md-3 px-4">
+                <h3>회원 관리</h3>
+            </div>
+            <div class="col-md-9">
+                <nav class="navbar navbar-expand-md">
+                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                        <li><a th:href="@{/user/my}" class="nav-link px-2">마이페이지(테스트용)</a></li>
+                        <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                        <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                        <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                    </ul>
+                </nav>
+            </div>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/user/admin/userdetails.html
+++ b/src/main/resources/templates/user/admin/userdetails.html
@@ -210,18 +210,22 @@
 <div class="jumbotron">
     <div class="container">
         <div class="row">
-            <div class="col-md-3 px-4">
-                <h3>회원 관리</h3>
-            </div>
-            <div class="col-md-9">
-                <nav class="navbar navbar-expand-md">
-                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                        <li><a th:href="@{/user/my}" class="nav-link px-2">마이페이지(테스트용)</a></li>
-                        <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                        <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                        <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                    </ul>
-                </nav>
+            <div class="col-9">
+                <div class="row">
+                    <div class="col-md-3 px-4">
+                        <h3>회원 관리</h3>
+                    </div>
+                    <div class="col-md-9">
+                        <nav class="navbar navbar-expand-md">
+                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                <li><a th:href="@{/user/my}" class="nav-link px-2">마이페이지(테스트용)</a></li>
+                                <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                                <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                                <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                            </ul>
+                        </nav>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/user/admin/userdetails.html
+++ b/src/main/resources/templates/user/admin/userdetails.html
@@ -298,7 +298,7 @@
                     });
             } //checkEmailDuplicate()
         </script>
-        <div class="col-md-9">
+        <div class="col-md-9" style="position:relative; top:-30px; z-index:1000;">
             <div class="row justify-content-start" style="color: #828282;">
                 <div class="col-8 p-3" id="loginbox">
                     <form th:object="${user}" method="post"

--- a/src/main/resources/templates/user/admin/userdetails.html
+++ b/src/main/resources/templates/user/admin/userdetails.html
@@ -234,8 +234,8 @@
     <div class="row">
         <aside class="col-md-3 px-4">
             <div class="row">
-                <div class="col-3"></div>
-                <div class="col-6">
+                <div class="col-1"></div>
+                <div class="col-8">
                     <div class="panel">
                         <ul class="list-group">
                             <li><a th:href="@{/user/admin/userlist}" class="nav-link px-2" style="color: #03C75A;">회원

--- a/src/main/resources/templates/user/admin/userdetails.html
+++ b/src/main/resources/templates/user/admin/userdetails.html
@@ -226,261 +226,283 @@
         </div>
     </div>
 </div>
-<div class="row">
-    <aside class="col-md-3 px-4">
-        <div class="row">
-            <div class="col-3"></div>
-            <div class="col-6">
-                <div class="panel">
-                    <ul class="list-group">
-                        <li><a th:href="@{/user/admin/userlist}" class="nav-link px-2" style="color: #03C75A;">회원 관리</a></li>
-                        <li><a th:href="@{/recruit/free/report/list}" class="nav-link px-2">신고 관리</a></li>
-                    </ul>
+<div class="container" style="padding:0;">
+    <div class="row">
+        <aside class="col-md-3 px-4">
+            <div class="row">
+                <div class="col-3"></div>
+                <div class="col-6">
+                    <div class="panel">
+                        <ul class="list-group">
+                            <li><a th:href="@{/user/admin/userlist}" class="nav-link px-2" style="color: #03C75A;">회원
+                                관리</a></li>
+                            <li><a th:href="@{/recruit/free/report/list}" class="nav-link px-2">신고 관리</a></li>
+                        </ul>
+                    </div>
                 </div>
             </div>
-        </div>
-    </aside>
-    <script>
-        // nickname available check
-        function checkNicknameDuplicate() {
-            const nickname = document.getElementById('nickname').value;
+        </aside>
+        <script>
+            // nickname available check
+            function checkNicknameDuplicate() {
+                const nickname = document.getElementById('nickname').value;
 
-            if(!nickname) {
-                alert('닉네임을 입력해 주세요.');
-                return;
-            }
+                if(!nickname) {
+                    alert('닉네임을 입력해 주세요.');
+                    return;
+                }
 
-            if (nickname.length < 4) {
-                alert('닉네임의 글자수는 최소 4자입니다.');
-                return;
-            }
+                if (nickname.length < 4) {
+                    alert('닉네임의 글자수는 최소 4자입니다.');
+                    return;
+                }
 
-            fetch(`/user/checkNicknameDuplicate?nickname=${encodeURIComponent(nickname)}`)
-                .then(response => response.json())
-                .then(data => {
-                    if (data.isDuplicate) alert('이미 사용 중인 닉네임입니다.');
-                    else alert('사용 가능한 닉네임입니다.');
-                })
-                .catch(error => {
-                    console.error('Error: ', error);
-                });
-        } //checkNicknameDuplicate()
+                fetch(`/user/checkNicknameDuplicate?nickname=${encodeURIComponent(nickname)}`)
+                    .then(response => response.json())
+                    .then(data => {
+                        if (data.isDuplicate) alert('이미 사용 중인 닉네임입니다.');
+                        else alert('사용 가능한 닉네임입니다.');
+                    })
+                    .catch(error => {
+                        console.error('Error: ', error);
+                    });
+            } //checkNicknameDuplicate()
 
-        // email available check
-        function checkEmailDuplicate() {
-            const email = document.getElementById('email').value;
+            // email available check
+            function checkEmailDuplicate() {
+                const email = document.getElementById('email').value;
 
-            if(!email) {
-                alert('이메일을 입력해 주세요.');
-                return;
-            }
+                if(!email) {
+                    alert('이메일을 입력해 주세요.');
+                    return;
+                }
 
-            // 이메일 검증
-            if (!validateEmail(email)) {
-                alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
-                return;
-            }
+                // 이메일 검증
+                if (!validateEmail(email)) {
+                    alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
+                    return;
+                }
 
-            fetch(`/user/checkEmailDuplicate?email=${encodeURIComponent(email)}`)
-                .then(response => response.json())
-                .then(data => {
-                    if (data.isDuplicate) alert('이미 등록된 이메일입니다.');
-                    else alert('등록 가능한 이메일입니다.');
-                })
-                .catch(error => {
-                    console.error('Error: ', error);
-                });
-        } //checkEmailDuplicate()
-    </script>
-    <div class="col-md-9">
-        <div class="row justify-content-start" style="color: #828282;">
-            <div class="col-8 p-3" id="loginbox">
-                <form th:action="@{/user/admin/updateuser(userNo=${user.userNo})}" th:object="${user}" method="post" enctype="multipart/form-data" onsubmit="validateForm(event)">
-                    <div class="row p-2">
-                        <div class="col-3 m-0 p-0" id="profileimagebox">
-                            <img th:if="${user.profileImagePath == null}" src="/images/defaultprofileimage.png" style="width: 100px; height: auto;" class="profile-image"/>
-                            <img th:if="${user.profileImagePath != null}" th:src="@{/uploadFiles/{fileName}(fileName=${user.profileImagePath})}" style="width: 100px; height: auto;" class="profile-image"/>
-                            <div id="profileuploadbutton">
-                                <label for="image">
-                                    <div class="btn-upload" style="width: 30px; height: 30px; background-color: #828282; border-radius: 50%; display: flex; align-items: center; justify-content: center;">
-                                        <div style="z-index:100;">
-                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#FFFFFF" class="bi bi-camera-fill" viewBox="0 0 16 16">
-                                                <path d="M10.5 8.5a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0"/>
-                                                <path d="M2 4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2h-1.172a2 2 0 0 1-1.414-.586l-.828-.828A2 2 0 0 0 9.172 2H6.828a2 2 0 0 0-1.414.586l-.828.828A2 2 0 0 1 3.172 4zm.5 2a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1m9 2.5a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0"/>
-                                            </svg>
-<!--                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#FFFFFF" class="bi bi-plus" viewBox="0 0 16 16">-->
-<!--                                                <path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4"/>-->
-<!--                                            </svg>-->
+                fetch(`/user/checkEmailDuplicate?email=${encodeURIComponent(email)}`)
+                    .then(response => response.json())
+                    .then(data => {
+                        if (data.isDuplicate) alert('이미 등록된 이메일입니다.');
+                        else alert('등록 가능한 이메일입니다.');
+                    })
+                    .catch(error => {
+                        console.error('Error: ', error);
+                    });
+            } //checkEmailDuplicate()
+        </script>
+        <div class="col-md-9">
+            <div class="row justify-content-start" style="color: #828282;">
+                <div class="col-8 p-3" id="loginbox">
+                    <form th:action="@{/user/admin/updateuser(userNo=${user.userNo})}" th:object="${user}" method="post"
+                          enctype="multipart/form-data" onsubmit="validateForm(event)">
+                        <div class="row p-2">
+                            <div class="col-3 m-0 p-0" id="profileimagebox">
+                                <img th:if="${user.profileImagePath == null}" src="/images/defaultprofileimage.png"
+                                     style="width: 100px; height: auto;" class="profile-image"/>
+                                <img th:if="${user.profileImagePath != null}"
+                                     th:src="@{/uploadFiles/{fileName}(fileName=${user.profileImagePath})}"
+                                     style="width: 100px; height: auto;" class="profile-image"/>
+                                <div id="profileuploadbutton">
+                                    <label for="image">
+                                        <div class="btn-upload"
+                                             style="width: 30px; height: 30px; background-color: #828282; border-radius: 50%; display: flex; align-items: center; justify-content: center;">
+                                            <div style="z-index:100;">
+                                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                                     fill="#FFFFFF" class="bi bi-camera-fill" viewBox="0 0 16 16">
+                                                    <path d="M10.5 8.5a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0"/>
+                                                    <path d="M2 4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2h-1.172a2 2 0 0 1-1.414-.586l-.828-.828A2 2 0 0 0 9.172 2H6.828a2 2 0 0 0-1.414.586l-.828.828A2 2 0 0 1 3.172 4zm.5 2a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1m9 2.5a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0"/>
+                                                </svg>
+                                                <!--                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#FFFFFF" class="bi bi-plus" viewBox="0 0 16 16">-->
+                                                <!--                                                <path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4"/>-->
+                                                <!--                                            </svg>-->
+                                            </div>
                                         </div>
+                                    </label>
+                                    <input type="file" name="image" id="image">
+                                </div>
+                            </div>
+                            <div class="col-9"></div>
+                        </div>
+                        <div class="row p-2">
+                            <div class="col-3">
+                                권한 임의설정
+                            </div>
+                            <div class="col-9">
+                                <div class="row">
+                                    <div class="col-4">
+                                        <label>
+                                            <input type="radio" th:field="*{authCode}" value="A"/> 관리자
+                                        </label>
                                     </div>
-                                </label>
-                                <input type="file" name="image" id="image">
+                                    <div class="col-4">
+                                        <label>
+                                            <input type="radio" th:field="*{authCode}" value="B"/> 일반회원
+                                        </label>
+                                    </div>
+                                    <div class="col-4">
+                                        <label>
+                                            <input type="radio" th:field="*{authCode}" value="C"/> 창작자
+                                        </label>
+                                    </div>
+                                </div>
+                            </div>
+
+                        </div>
+                        <div class="row p-2">
+                            <div class="col-3">
+                                아이디 <span class="required-star">*</span>
+                            </div>
+                            <div class="col-6">
+                                <input class="form-control px-3" type="text" th:field="*{userId}" maxlength="20"
+                                       minlength="4" readonly/>
+                            </div>
+                            <div class="col-3">
                             </div>
                         </div>
-                        <div class="col-9"></div>
-                    </div>
-                    <div class="row p-2">
-                        <div class="col-3">
-                            권한 임의설정
+                        <div class="row p-2">
+                            <div class="col-3">
+                                닉네임 <span class="required-star">*</span>
+                            </div>
+                            <div class="col-6">
+                                <input class="form-control px-3" type="text" th:field="*{nickname}" maxlength="20"
+                                       minlength="4"/>
+                            </div>
+                            <div class="col-3">
+                                <button type="button" class="btn btn-primary btn-block"
+                                        style="background-color:#03C75A;" onclick="checkNicknameDuplicate()">중복확인
+                                </button>
+                            </div>
                         </div>
-                        <div class="col-9">
-                            <div class="row">
-                                <div class="col-4">
-                                    <label>
-                                        <input type="radio" th:field="*{authCode}" value="A"/> 관리자
-                                    </label>
+                        <div class="row p-2">
+                            <div class="col-3">
+                                연락처
+                            </div>
+                            <div class="col-6">
+                                <input class="form-control px-3 logininput" type="text" th:field="*{contactNumber}"
+                                       oninput="autoFormatPhoneNumber(this)" placeholder="000-0000-0000"/>
+                            </div>
+                            <div class="col-3">
+                            </div>
+                        </div>
+                        <div class="row p-2">
+                            <div class="col-3">
+                                성별
+                            </div>
+                            <div class="col-6">
+                                <select class="form-select px-3" th:field="*{gender}">
+                                    <option value="P">성별을 공개하지 않습니다</option>
+                                    <option value="F">여</option>
+                                    <option value="M">남</option>
+                                </select>
+                            </div>
+                            <div class="col-3">
+                            </div>
+                        </div>
+                        <div class="row p-2">
+                            <div class="col-3">
+                                <!-- 생년월일을 연도, 월, 일로 나누어 드롭다운 박스 형태로 입력 -->
+                                생년월일
+                            </div>
+                            <div class="col-6">
+                                <div class="row">
+                                    <div class="col-4">
+                                        <select class="form-select" id="year" name="year" th:field="*{year}"
+                                                style="text-align:center;">
+                                            <option th:each="y : ${years}" th:value="${y}" th:text="${y}">연도</option>
+                                        </select>
+                                    </div>
+                                    <div class="col-4">
+                                        <select class="form-select" id="month" name="month" th:field="*{month}"
+                                                style="text-align:center;">
+                                            <option th:each="m : ${months}" th:value="${m}" th:text="${m}">월</option>
+                                        </select>
+                                    </div>
+                                    <div class="col-4">
+                                        <select class="form-select" id="day" name="day" th:field="*{day}"
+                                                style="text-align:center;">
+                                            <option th:each="d : ${days}" th:value="${d}" th:text="${d}">일</option>
+                                        </select>
+                                    </div>
                                 </div>
-                                <div class="col-4">
-                                    <label>
-                                        <input type="radio" th:field="*{authCode}" value="B"/> 일반회원
-                                    </label>
-                                </div>
-                                <div class="col-4">
-                                    <label>
-                                        <input type="radio" th:field="*{authCode}" value="C"/> 창작자
-                                    </label>
-                                </div>
+                            </div>
+                            <div class="col-3">
+                            </div>
+                        </div>
+                        <div class="row p-2">
+                            <div class="col-3">
+                                실명
+                            </div>
+                            <div class="col-6">
+                                <input class="form-control" type="text" th:field="*{realName}" maxlength="10"/>
+                            </div>
+                            <div class="col-3">
+                            </div>
+                        </div>
+                        <div class="row p-2">
+                            <div class="col-3">
+                                이메일 <span class="required-star">*</span>
+                            </div>
+                            <div class="col-6">
+                                <input class="form-control" type="text" th:field="*{email}"/>
+                            </div>
+                            <div class="col-3">
+                                <button type="button" class="btn btn-primary btn-block"
+                                        style="background-color:#03C75A;" onclick="checkEmailDuplicate()">중복확인
+                                </button>
+                            </div>
+                        </div>
+                        <div class="row p-2">
+                            <div class="col-6">
+                                자기소개(선택사항)
+                            </div>
+                            <div class="col-6">
+                            </div>
+                            <div class="col-12">
+                                <textarea class="form-control" rows="3" maxlength="150" th:field="*{bio}"></textarea>
                             </div>
                         </div>
 
-                    </div>
-                    <div class="row p-2">
-                        <div class="col-3">
-                            아이디 <span class="required-star">*</span>
+                        <div class="col-12 p-2">
                         </div>
-                        <div class="col-6">
-                            <input class="form-control px-3" type="text" th:field="*{userId}" maxlength="20" minlength="4" readonly/>
-                        </div>
-                        <div class="col-3">
-                        </div>
-                    </div>
-                    <div class="row p-2">
-                        <div class="col-3">
-                            닉네임 <span class="required-star">*</span>
-                        </div>
-                        <div class="col-6">
-                            <input class="form-control px-3" type="text" th:field="*{nickname}" maxlength="20" minlength="4"/>
-                        </div>
-                        <div class="col-3">
-                            <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;" onclick="checkNicknameDuplicate()">중복확인</button>
-                        </div>
-                    </div>
-                    <div class="row p-2">
-                        <div class="col-3">
-                            연락처
-                        </div>
-                        <div class="col-6">
-                            <input class="form-control px-3 logininput" type="text" th:field="*{contactNumber}" oninput="autoFormatPhoneNumber(this)" placeholder="000-0000-0000"/>
-                        </div>
-                        <div class="col-3">
-                        </div>
-                    </div>
-                    <div class="row p-2">
-                        <div class="col-3">
-                            성별
-                        </div>
-                        <div class="col-6">
-                            <select class="form-select px-3" th:field="*{gender}">
-                                <option value="P">성별을 공개하지 않습니다</option>
-                                <option value="F">여</option>
-                                <option value="M">남</option>
-                            </select>
-                        </div>
-                        <div class="col-3">
-                        </div>
-                    </div>
-                    <div class="row p-2">
-                        <div class="col-3">
-                            <!-- 생년월일을 연도, 월, 일로 나누어 드롭다운 박스 형태로 입력 -->
-                            생년월일
-                        </div>
-                        <div class="col-6">
-                            <div class="row">
-                                <div class="col-4">
-                                    <select class="form-select" id="year" name="year" th:field="*{year}" style="text-align:center;">
-                                        <option th:each="y : ${years}" th:value="${y}" th:text="${y}">연도</option>
-                                    </select>
-                                </div>
-                                <div class="col-4">
-                                    <select class="form-select" id="month" name="month" th:field="*{month}" style="text-align:center;">
-                                        <option th:each="m : ${months}" th:value="${m}" th:text="${m}">월</option>
-                                    </select>
-                                </div>
-                                <div class="col-4">
-                                    <select class="form-select" id="day" name="day" th:field="*{day}" style="text-align:center;">
-                                        <option th:each="d : ${days}" th:value="${d}" th:text="${d}">일</option>
-                                    </select>
-                                </div>
+                        <div class="row">
+                            <div class="col-3 p-2">
+                                <button type="submit" class="btn btn-primary btn-block"
+                                        style="background-color:#03C75A; height:50px;">수정하기
+                                </button>
                             </div>
                         </div>
-                        <div class="col-3">
-                        </div>
-                    </div>
-                    <div class="row p-2">
-                        <div class="col-3">
-                            실명
-                        </div>
-                        <div class="col-6">
-                            <input class="form-control" type="text" th:field="*{realName}" maxlength="10"/>
-                        </div>
-                        <div class="col-3">
-                        </div>
-                    </div>
-                    <div class="row p-2">
-                        <div class="col-3">
-                            이메일 <span class="required-star">*</span>
-                        </div>
-                        <div class="col-6">
-                            <input class="form-control" type="text" th:field="*{email}"/>
-                        </div>
-                        <div class="col-3">
-                            <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;" onclick="checkEmailDuplicate()">중복확인</button>
-                        </div>
-                    </div>
-                    <div class="row p-2">
-                        <div class="col-6">
-                            자기소개(선택사항)
-                        </div>
-                        <div class="col-6">
-                        </div>
-                        <div class="col-12">
-                            <textarea class="form-control" rows="3" maxlength="150" th:field="*{bio}"></textarea>
-                        </div>
-                    </div>
-
-                    <div class="col-12 p-2">
-                    </div>
-                    <div class="row">
-                        <div class="col-3 p-2">
-                            <button type="submit" class="btn btn-primary btn-block" style="background-color:#03C75A; height:50px;">수정하기</button>
-                        </div>
-                    </div>
-                </form>
+                    </form>
+                </div>
             </div>
-        </div>
 
-        <div class="row justify-content-start" style="color: #828282;">
-            <div class="col-6" id="loginbox2">
-                <form th:action="@{/user/admin/deleteuser(userNo=${user.userNo})}" method="post">
-                    <div class="row">
-                        <div class="col-3 p-2">
-                            <button id="ban" type="submit" class="btn btn-primary btn-block" style="background-color: red; height:50px;">강제탈퇴</button>
+            <div class="row justify-content-start" style="color: #828282;">
+                <div class="col-6" id="loginbox2">
+                    <form th:action="@{/user/admin/deleteuser(userNo=${user.userNo})}" method="post">
+                        <div class="row">
+                            <div class="col-3 p-2">
+                                <button id="ban" type="submit" class="btn btn-primary btn-block"
+                                        style="background-color: red; height:50px;">강제탈퇴
+                                </button>
+                            </div>
                         </div>
-                    </div>
-                </form>
-<!--                <form id="deleteUserForm" th:action="@{/user/admin/deleteuser(userNo=${user.userNo})}" method="post">-->
-<!--                    <div class="col-12">-->
-<!--                        <a href="javascript:void(0);" onclick="document.getElementById('deleteUserForm').submit();" style="color: #828282;">탈퇴하기</a>-->
-<!--                    </div>-->
-<!--                </form>-->
+                    </form>
+                    <!--                <form id="deleteUserForm" th:action="@{/user/admin/deleteuser(userNo=${user.userNo})}" method="post">-->
+                    <!--                    <div class="col-12">-->
+                    <!--                        <a href="javascript:void(0);" onclick="document.getElementById('deleteUserForm').submit();" style="color: #828282;">탈퇴하기</a>-->
+                    <!--                    </div>-->
+                    <!--                </form>-->
+                </div>
             </div>
+
+
+            <!--        <form th:action="@{/user/admin/deleteuser(userNo=${user.userNo})}" method="post">-->
+            <!--            <button type="submit">탈퇴하기(누르면 바로 삭제되니 조심!)</button>-->
+            <!--        </form>-->
         </div>
-
-
-
-<!--        <form th:action="@{/user/admin/deleteuser(userNo=${user.userNo})}" method="post">-->
-<!--            <button type="submit">탈퇴하기(누르면 바로 삭제되니 조심!)</button>-->
-<!--        </form>-->
     </div>
 </div>
 <div th:replace="common/footer.html"></div>

--- a/src/main/resources/templates/user/admin/userdetails.html
+++ b/src/main/resources/templates/user/admin/userdetails.html
@@ -301,7 +301,7 @@
         <div class="col-md-9">
             <div class="row justify-content-start" style="color: #828282;">
                 <div class="col-8 p-3" id="loginbox">
-                    <form th:action="@{/user/admin/updateuser(userNo=${user.userNo})}" th:object="${user}" method="post"
+                    <form th:object="${user}" method="post"
                           enctype="multipart/form-data" onsubmit="validateForm(event)">
                         <div class="row p-2">
                             <div class="col-3 m-0 p-0" id="profileimagebox">
@@ -477,57 +477,89 @@
                         <div class="row">
                             <div class="col-3 p-2">
                                 <button type="submit" class="btn btn-primary btn-block"
-                                        style="background-color:#03C75A; height:50px;">수정하기
+                                        style="background-color:#03C75A; height:50px;" th:attr="formaction=@{/user/admin/updateuser(userNo=${user.userNo})}">수정하기
                                 </button>
+
+                                <th:block th:if="${#strings.toString(user.withdrawn) == 'N'}">
+                                    <button id="deleteUserForm" type="submit" class="btn btn-primary btn-block"
+                                            style="background-color: red; height:50px; display:block;" th:attr="formaction=@{/user/admin/deleteuser(userNo=${user.userNo})}">강제탈퇴
+                                    </button>
+
+                                    <button id="reactiveUserForm" type="submit" class="btn btn-primary btn-block"
+                                            style="background-color:#03C75A; height:50px; display:none; " th:attr="formaction=@{/user/admin/reactiveuser(userNo=${user.userNo})}">강제탈퇴 취소
+                                    </button>
+                                </th:block>
+                                <th:block th:if="${#strings.toString(user.withdrawn) == 'Y'}">
+                                    <button id="deleteUserForm" type="submit" class="btn btn-primary btn-block"
+                                            style="background-color: red; height:50px; display:none;" th:attr="formaction=@{/user/admin/deleteuser(userNo=${user.userNo})}">강제탈퇴
+                                    </button>
+
+                                    <button id="reactiveUserForm" type="submit" class="btn btn-primary btn-block"
+                                            style="background-color:#03C75A; height:50px; display:block; " th:attr="formaction=@{/user/admin/reactiveuser(userNo=${user.userNo})}">강제탈퇴 취소
+                                    </button>
+                                </th:block>
+
                             </div>
                         </div>
                     </form>
                 </div>
             </div>
 
-            <div class="row justify-content-start" style="color: #828282;">
-                <div class="col-6" id="loginbox2">
-                    <form th:action="@{/user/admin/deleteuser(userNo=${user.userNo})}" method="post">
-                        <div class="row">
-                            <div class="col-3 p-2">
-                                <button id="ban" type="submit" class="btn btn-primary btn-block"
-                                        style="background-color: red; height:50px;">강제탈퇴
-                                </button>
-                            </div>
-                        </div>
-                    </form>
-                    <!--                <form id="deleteUserForm" th:action="@{/user/admin/deleteuser(userNo=${user.userNo})}" method="post">-->
-                    <!--                    <div class="col-12">-->
-                    <!--                        <a href="javascript:void(0);" onclick="document.getElementById('deleteUserForm').submit();" style="color: #828282;">탈퇴하기</a>-->
-                    <!--                    </div>-->
-                    <!--                </form>-->
-                </div>
-            </div>
+<!--            <div class="row justify-content-start" style="color: #828282;">-->
+<!--                <div class="col-6" id="loginbox2">-->
+<!--                    <form th:action="@{/user/admin/deleteuser(userNo=${user.userNo})}" method="post">-->
+<!--                        <div class="row">-->
+<!--                            <div class="col-3 p-2">-->
 
+<!--                            </div>-->
+<!--                        </div>-->
+<!--                    </form>-->
+<!--                </div>-->
+<!--            </div>-->
 
-            <!--        <form th:action="@{/user/admin/deleteuser(userNo=${user.userNo})}" method="post">-->
-            <!--            <button type="submit">탈퇴하기(누르면 바로 삭제되니 조심!)</button>-->
-            <!--        </form>-->
         </div>
     </div>
 </div>
 <div th:replace="common/footer.html"></div>
 <script>
+    //탈퇴 관련
+    function confirmAndValidateDeletion(event) {
+          event.preventDefault(); // 기본 동작을 방지하여 링크 클릭 시 바로 제출되지 않도록 합니다.
 
-    //탈퇴 폼 제출 후처리
-    window.onload = function() {
-          const urlParams = new URLSearchParams(window.location.search);
-          const status = urlParams.get('status');
-          if (status === 'editSuccess') {
-              alert("프로필 수정이 완료되었습니다.");
-          }
-          else if (status === 'editFailure') {
-              alert("프로필 수정 중 문제가 발생했습니다. 다시 시도해주세요.");
-          }
-          else if (status === 'withdrawnFailure') {
-              alert("회원 탈퇴 처리 중 문제가 발생했습니다.");
+          const confirmation = confirm("정말로 해당 회원을 탈퇴처리하시겠습니까?");
+
+          if (confirmation && validatePasswordMatch()) {
+              // 확인 창에서 "예"를 선택하고, 비밀번호가 유효한 경우에 폼을 제출합니다.
+              // 폼을 제출하였을 때 비밀번호 일치여부를 UserService에서 확인할 것임
+              document.getElementById('deleteUserForm').click();
           }
       }
+      //탈퇴 버튼 관련
+
+      //탈퇴 폼 제출 후처리
+      window.onload = function() {
+            const urlParams = new URLSearchParams(window.location.search);
+            const status = urlParams.get('status');
+            if (status === 'editSuccess') {
+                alert("프로필 수정이 완료되었습니다.");
+            }
+            else if (status === 'editFailure') {
+                alert("프로필 수정 중 문제가 발생했습니다. 다시 시도해주세요.");
+            }
+            else if (status === 'withdrawnSuccess') {
+              alert("해당 회원을 강제 탈퇴처리하였습니다.");
+              //toggleButtons();
+
+            }
+            else if (status === 'reactiveSuccess') {
+              alert("해당 회원을 재활성화하였습니다.");
+              //toggleButtons();
+
+            }
+            else if (status === 'withdrawnFailure') {
+                alert("회원 탈퇴 처리 중 문제가 발생했습니다.");
+            }
+        }
 </script>
 <script>
     document.getElementById('image').addEventListener('change', function(event) {

--- a/src/main/resources/templates/user/admin/userdetails.html
+++ b/src/main/resources/templates/user/admin/userdetails.html
@@ -116,407 +116,439 @@
 
 <div th:replace="~{common/menubar}"></div>
 <style>
-    .jumbotron {
-    position : relative;
-    background-color : #EEEEEE;
+    html, body {
+        height: 100%;
+        margin: 0;
     }
-    .jumbotron .row {
-    position : absolute;
-    width : 100%;
-    bottom: 0%;
+    body {
+        display: flex;
+        flex-direction: column;
     }
-
-    #loginbox {
-    border-radius : 5%;
-    border-color : #F2F2F2;
+    .content-wrapper {
+        flex: 1 0 auto;
     }
-
-    #loginbox2 {
-    border-radius : 5%;
-    border-color : #F2F2F2;
+    footer {
+        flex-shrink: 0;
     }
-
-    .form-control {
-    background-color : #FCFCFC;
-    border : none;
-    width : 100%;
-    height : 50px;
-    }
-
-    .logininput {
-    background-color : #FCFCFC;
-    border : none;
-    height : 50px;
-    }
-
-    .logininput::placeholder {
-    color : #BBBBBB;
-    }
-
-    button {
-    background-color : #03C75A;
-    }
-
-    #ban {
-    background-color : red;
-    }
-
-    .form-select {
-    background-color : #FCFCFC;
-    border : none;
-    width : 100%;
-    height : 50px;
-    }
-
-    .form-check-input {
-    accent-color: #03C75A;
-    }
-
-    .profile-image {
-    width: 100px;
-    height: auto;
-    border-radius: 50%;
-    object-fit: cover;
-    margin-right: 15px;
-    }
-
-     .nav-link {
-            color: #828282;
-    }
-    ul {
-  list-style: none;
-  padding-left : 0px;
-  }
-     .required-star {
-        color: #03C75A;
-    }
-
-
-     #image {
-    display: none;
-  }
-
-  #profileimagebox {
-    position : relative;
-  }
-  #profileuploadbutton {
-    position : absolute;
-    bottom : -10%;
-    right : 25%;
-  }
-
 
 </style>
-<div class="jumbotron">
-    <div class="container">
-        <div class="row">
-            <div class="col-9">
-                <div class="row">
-                    <div class="col-md-3 px-4">
-                        <h3>회원 관리</h3>
-                    </div>
-                    <div class="col-md-9">
-                        <nav class="navbar navbar-expand-md">
-                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                                <li><a th:href="@{/user/my}" class="nav-link px-2">마이페이지(테스트용)</a></li>
-                                <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                                <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                                <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                            </ul>
-                        </nav>
+<div class="content-wrapper">
+    <style>
+        .jumbotron {
+        position : relative;
+        background-color : #EEEEEE;
+        }
+        .jumbotron .row {
+        position : absolute;
+        width : 100%;
+        bottom: 0%;
+        }
+
+        #loginbox {
+        border-radius : 5%;
+        border-color : #F2F2F2;
+        }
+
+        #loginbox2 {
+        border-radius : 5%;
+        border-color : #F2F2F2;
+        }
+
+        .form-control {
+        background-color : #FCFCFC;
+        border : none;
+        width : 100%;
+        height : 50px;
+        }
+
+        .logininput {
+        background-color : #FCFCFC;
+        border : none;
+        height : 50px;
+        }
+
+        .logininput::placeholder {
+        color : #BBBBBB;
+        }
+
+        button {
+        background-color : #03C75A;
+        }
+
+        #ban {
+        background-color : red;
+        }
+
+        .form-select {
+        background-color : #FCFCFC;
+        border : none;
+        width : 100%;
+        height : 50px;
+        }
+
+        .form-check-input {
+        accent-color: #03C75A;
+        }
+
+        .profile-image {
+        width: 100px;
+        height: auto;
+        border-radius: 50%;
+        object-fit: cover;
+        margin-right: 15px;
+        }
+
+         .nav-link {
+                color: #828282;
+        }
+        ul {
+      list-style: none;
+      padding-left : 0px;
+      }
+         .required-star {
+            color: #03C75A;
+        }
+
+
+         #image {
+        display: none;
+      }
+
+      #profileimagebox {
+        position : relative;
+      }
+      #profileuploadbutton {
+        position : absolute;
+        bottom : -10%;
+        right : 25%;
+      }
+
+
+    </style>
+    <div class="jumbotron">
+        <div class="container">
+            <div class="row">
+                <div class="col-9">
+                    <div class="row">
+                        <div class="col-md-3 px-4">
+                            <h3>회원 관리</h3>
+                        </div>
+                        <div class="col-md-9">
+                            <nav class="navbar navbar-expand-md">
+                                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                    <li><a th:href="@{/user/my}" class="nav-link px-2">마이페이지(테스트용)</a></li>
+                                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                                </ul>
+                            </nav>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
-<div class="container" style="padding:0;">
-    <div class="row">
-        <aside class="col-md-3 px-4">
-            <div class="row">
-                <div class="col-1"></div>
-                <div class="col-8">
-                    <div class="panel">
-                        <ul class="list-group">
-                            <li><a th:href="@{/user/admin/userlist}" class="nav-link px-2" style="color: #03C75A;">회원
-                                관리</a></li>
-                            <li><a th:href="@{/recruit/free/report/list}" class="nav-link px-2">신고 관리</a></li>
-                        </ul>
+    <div class="container" style="padding:0;">
+        <div class="row">
+            <aside class="col-md-3 px-4">
+                <div class="row">
+                    <div class="col-1"></div>
+                    <div class="col-8">
+                        <div class="panel">
+                            <ul class="list-group">
+                                <li><a th:href="@{/user/admin/userlist}" class="nav-link px-2" style="color: #03C75A;">회원
+                                    관리</a></li>
+                                <li><a th:href="@{/recruit/free/report/list}" class="nav-link px-2">신고 관리</a></li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </aside>
-        <script>
-            // nickname available check
-            function checkNicknameDuplicate() {
-                const nickname = document.getElementById('nickname').value;
+            </aside>
+            <script>
+                // nickname available check
+                function checkNicknameDuplicate() {
+                    const nickname = document.getElementById('nickname').value;
 
-                if(!nickname) {
-                    alert('닉네임을 입력해 주세요.');
-                    return;
-                }
+                    if(!nickname) {
+                        alert('닉네임을 입력해 주세요.');
+                        return;
+                    }
 
-                if (nickname.length < 4) {
-                    alert('닉네임의 글자수는 최소 4자입니다.');
-                    return;
-                }
+                    if (nickname.length < 4) {
+                        alert('닉네임의 글자수는 최소 4자입니다.');
+                        return;
+                    }
 
-                fetch(`/user/checkNicknameDuplicate?nickname=${encodeURIComponent(nickname)}`)
-                    .then(response => response.json())
-                    .then(data => {
-                        if (data.isDuplicate) alert('이미 사용 중인 닉네임입니다.');
-                        else alert('사용 가능한 닉네임입니다.');
-                    })
-                    .catch(error => {
-                        console.error('Error: ', error);
-                    });
-            } //checkNicknameDuplicate()
+                    fetch(`/user/checkNicknameDuplicate?nickname=${encodeURIComponent(nickname)}`)
+                        .then(response => response.json())
+                        .then(data => {
+                            if (data.isDuplicate) alert('이미 사용 중인 닉네임입니다.');
+                            else alert('사용 가능한 닉네임입니다.');
+                        })
+                        .catch(error => {
+                            console.error('Error: ', error);
+                        });
+                } //checkNicknameDuplicate()
 
-            // email available check
-            function checkEmailDuplicate() {
-                const email = document.getElementById('email').value;
+                // email available check
+                function checkEmailDuplicate() {
+                    const email = document.getElementById('email').value;
 
-                if(!email) {
-                    alert('이메일을 입력해 주세요.');
-                    return;
-                }
+                    if(!email) {
+                        alert('이메일을 입력해 주세요.');
+                        return;
+                    }
 
-                // 이메일 검증
-                if (!validateEmail(email)) {
-                    alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
-                    return;
-                }
+                    // 이메일 검증
+                    if (!validateEmail(email)) {
+                        alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
+                        return;
+                    }
 
-                fetch(`/user/checkEmailDuplicate?email=${encodeURIComponent(email)}`)
-                    .then(response => response.json())
-                    .then(data => {
-                        if (data.isDuplicate) alert('이미 등록된 이메일입니다.');
-                        else alert('등록 가능한 이메일입니다.');
-                    })
-                    .catch(error => {
-                        console.error('Error: ', error);
-                    });
-            } //checkEmailDuplicate()
-        </script>
-        <div class="col-md-9" style="position:relative; top:-30px; z-index:1000;">
-            <div class="row justify-content-start" style="color: #828282;">
-                <div class="col-8 p-3" id="loginbox">
-                    <form th:object="${user}" method="post"
-                          enctype="multipart/form-data" onsubmit="validateForm(event)">
-                        <div class="row p-2">
-                            <div class="col-3 m-0 p-0" id="profileimagebox">
-                                <div id="imagePreview">
-                                    <img th:if="${user.profileImagePath == null}" src="/images/defaultprofileimage.png"
-                                         style="width: 100px; height: auto;" class="profile-image"/>
-                                    <img th:if="${user.profileImagePath != null}"
-                                         th:src="@{/uploadFiles/{fileName}(fileName=${user.profileImagePath})}"
-                                         style="width: 100px; height: auto;" class="profile-image"/>
-                                </div>
-                                <div id="profileuploadbutton">
-                                    <label for="image">
-                                        <div class="btn-upload"
-                                             style="width: 30px; height: 30px; background-color: #828282; border-radius: 50%; display: flex; align-items: center; justify-content: center;">
-                                            <div style="z-index:100;">
-                                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                                     fill="#FFFFFF" class="bi bi-camera-fill" viewBox="0 0 16 16">
-                                                    <path d="M10.5 8.5a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0"/>
-                                                    <path d="M2 4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2h-1.172a2 2 0 0 1-1.414-.586l-.828-.828A2 2 0 0 0 9.172 2H6.828a2 2 0 0 0-1.414.586l-.828.828A2 2 0 0 1 3.172 4zm.5 2a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1m9 2.5a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0"/>
-                                                </svg>
-                                                <!--                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#FFFFFF" class="bi bi-plus" viewBox="0 0 16 16">-->
-                                                <!--                                                <path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4"/>-->
-                                                <!--                                            </svg>-->
+                    fetch(`/user/checkEmailDuplicate?email=${encodeURIComponent(email)}`)
+                        .then(response => response.json())
+                        .then(data => {
+                            if (data.isDuplicate) alert('이미 등록된 이메일입니다.');
+                            else alert('등록 가능한 이메일입니다.');
+                        })
+                        .catch(error => {
+                            console.error('Error: ', error);
+                        });
+                } //checkEmailDuplicate()
+            </script>
+            <div class="col-md-9" style="position:relative; top:-30px; z-index:1000;">
+                <div class="row justify-content-start" style="color: #828282;">
+                    <div class="col-8 p-3" id="loginbox">
+                        <form th:object="${user}" method="post"
+                              enctype="multipart/form-data" onsubmit="validateForm(event)">
+                            <div class="row p-2">
+                                <div class="col-3 m-0 p-0" id="profileimagebox">
+                                    <div id="imagePreview">
+                                        <img th:if="${user.profileImagePath == null}"
+                                             src="/images/defaultprofileimage.png"
+                                             style="width: 100px; height: auto;" class="profile-image"/>
+                                        <img th:if="${user.profileImagePath != null}"
+                                             th:src="@{/uploadFiles/{fileName}(fileName=${user.profileImagePath})}"
+                                             style="width: 100px; height: auto;" class="profile-image"/>
+                                    </div>
+                                    <div id="profileuploadbutton">
+                                        <label for="image">
+                                            <div class="btn-upload"
+                                                 style="width: 30px; height: 30px; background-color: #828282; border-radius: 50%; display: flex; align-items: center; justify-content: center;">
+                                                <div style="z-index:100;">
+                                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                                         fill="#FFFFFF" class="bi bi-camera-fill" viewBox="0 0 16 16">
+                                                        <path d="M10.5 8.5a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0"/>
+                                                        <path d="M2 4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2h-1.172a2 2 0 0 1-1.414-.586l-.828-.828A2 2 0 0 0 9.172 2H6.828a2 2 0 0 0-1.414.586l-.828.828A2 2 0 0 1 3.172 4zm.5 2a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1m9 2.5a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0"/>
+                                                    </svg>
+                                                    <!--                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#FFFFFF" class="bi bi-plus" viewBox="0 0 16 16">-->
+                                                    <!--                                                <path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4"/>-->
+                                                    <!--                                            </svg>-->
+                                                </div>
                                             </div>
+                                        </label>
+                                        <input type="file" name="image" id="image">
+                                    </div>
+                                </div>
+                                <div class="col-9"></div>
+                            </div>
+                            <div class="row p-2">
+                                <div class="col-3">
+                                    권한 임의설정
+                                </div>
+                                <div class="col-9">
+                                    <div class="row">
+                                        <div class="col-4">
+                                            <label>
+                                                <input type="radio" th:field="*{authCode}" value="A"/> 관리자
+                                            </label>
                                         </div>
-                                    </label>
-                                    <input type="file" name="image" id="image">
-                                </div>
-                            </div>
-                            <div class="col-9"></div>
-                        </div>
-                        <div class="row p-2">
-                            <div class="col-3">
-                                권한 임의설정
-                            </div>
-                            <div class="col-9">
-                                <div class="row">
-                                    <div class="col-4">
-                                        <label>
-                                            <input type="radio" th:field="*{authCode}" value="A"/> 관리자
-                                        </label>
-                                    </div>
-                                    <div class="col-4">
-                                        <label>
-                                            <input type="radio" th:field="*{authCode}" value="B"/> 일반회원
-                                        </label>
-                                    </div>
-                                    <div class="col-4">
-                                        <label>
-                                            <input type="radio" th:field="*{authCode}" value="C"/> 창작자
-                                        </label>
+                                        <div class="col-4">
+                                            <label>
+                                                <input type="radio" th:field="*{authCode}" value="B"/> 일반회원
+                                            </label>
+                                        </div>
+                                        <div class="col-4">
+                                            <label>
+                                                <input type="radio" th:field="*{authCode}" value="C"/> 창작자
+                                            </label>
+                                        </div>
                                     </div>
                                 </div>
-                            </div>
 
-                        </div>
-                        <div class="row p-2">
-                            <div class="col-3">
-                                아이디 <span class="required-star">*</span>
                             </div>
-                            <div class="col-6">
-                                <input class="form-control px-3" type="text" th:field="*{userId}" maxlength="20"
-                                       minlength="4" readonly/>
-                            </div>
-                            <div class="col-3">
-                            </div>
-                        </div>
-                        <div class="row p-2">
-                            <div class="col-3">
-                                닉네임 <span class="required-star">*</span>
-                            </div>
-                            <div class="col-6">
-                                <input class="form-control px-3" type="text" th:field="*{nickname}" maxlength="20"
-                                       minlength="4"/>
-                            </div>
-                            <div class="col-3">
-                                <button type="button" class="btn btn-primary btn-block"
-                                        style="background-color:#03C75A;" onclick="checkNicknameDuplicate()">중복확인
-                                </button>
-                            </div>
-                        </div>
-                        <div class="row p-2">
-                            <div class="col-3">
-                                연락처
-                            </div>
-                            <div class="col-6">
-                                <input class="form-control px-3 logininput" type="text" th:field="*{contactNumber}"
-                                       oninput="autoFormatPhoneNumber(this)" placeholder="000-0000-0000"/>
-                            </div>
-                            <div class="col-3">
-                            </div>
-                        </div>
-                        <div class="row p-2">
-                            <div class="col-3">
-                                성별
-                            </div>
-                            <div class="col-6">
-                                <select class="form-select px-3" th:field="*{gender}">
-                                    <option value="P">성별을 공개하지 않습니다</option>
-                                    <option value="F">여</option>
-                                    <option value="M">남</option>
-                                </select>
-                            </div>
-                            <div class="col-3">
-                            </div>
-                        </div>
-                        <div class="row p-2">
-                            <div class="col-3">
-                                <!-- 생년월일을 연도, 월, 일로 나누어 드롭다운 박스 형태로 입력 -->
-                                생년월일
-                            </div>
-                            <div class="col-6">
-                                <div class="row">
-                                    <div class="col-4">
-                                        <select class="form-select" id="year" name="year" th:field="*{year}"
-                                                style="text-align:center;">
-                                            <option th:each="y : ${years}" th:value="${y}" th:text="${y}">연도</option>
-                                        </select>
-                                    </div>
-                                    <div class="col-4">
-                                        <select class="form-select" id="month" name="month" th:field="*{month}"
-                                                style="text-align:center;">
-                                            <option th:each="m : ${months}" th:value="${m}" th:text="${m}">월</option>
-                                        </select>
-                                    </div>
-                                    <div class="col-4">
-                                        <select class="form-select" id="day" name="day" th:field="*{day}"
-                                                style="text-align:center;">
-                                            <option th:each="d : ${days}" th:value="${d}" th:text="${d}">일</option>
-                                        </select>
-                                    </div>
+                            <div class="row p-2">
+                                <div class="col-3">
+                                    아이디 <span class="required-star">*</span>
+                                </div>
+                                <div class="col-6">
+                                    <input class="form-control px-3" type="text" th:field="*{userId}" maxlength="20"
+                                           minlength="4" readonly/>
+                                </div>
+                                <div class="col-3">
                                 </div>
                             </div>
-                            <div class="col-3">
+                            <div class="row p-2">
+                                <div class="col-3">
+                                    닉네임 <span class="required-star">*</span>
+                                </div>
+                                <div class="col-6">
+                                    <input class="form-control px-3" type="text" th:field="*{nickname}" maxlength="20"
+                                           minlength="4"/>
+                                </div>
+                                <div class="col-3">
+                                    <button type="button" class="btn btn-primary btn-block"
+                                            style="background-color:#03C75A;" onclick="checkNicknameDuplicate()">중복확인
+                                    </button>
+                                </div>
                             </div>
-                        </div>
-                        <div class="row p-2">
-                            <div class="col-3">
-                                실명
+                            <div class="row p-2">
+                                <div class="col-3">
+                                    연락처
+                                </div>
+                                <div class="col-6">
+                                    <input class="form-control px-3 logininput" type="text" th:field="*{contactNumber}"
+                                           oninput="autoFormatPhoneNumber(this)" placeholder="000-0000-0000"/>
+                                </div>
+                                <div class="col-3">
+                                </div>
                             </div>
-                            <div class="col-6">
-                                <input class="form-control" type="text" th:field="*{realName}" maxlength="10"/>
+                            <div class="row p-2">
+                                <div class="col-3">
+                                    성별
+                                </div>
+                                <div class="col-6">
+                                    <select class="form-select px-3" th:field="*{gender}">
+                                        <option value="P">성별을 공개하지 않습니다</option>
+                                        <option value="F">여</option>
+                                        <option value="M">남</option>
+                                    </select>
+                                </div>
+                                <div class="col-3">
+                                </div>
                             </div>
-                            <div class="col-3">
+                            <div class="row p-2">
+                                <div class="col-3">
+                                    <!-- 생년월일을 연도, 월, 일로 나누어 드롭다운 박스 형태로 입력 -->
+                                    생년월일
+                                </div>
+                                <div class="col-6">
+                                    <div class="row">
+                                        <div class="col-4">
+                                            <select class="form-select" id="year" name="year" th:field="*{year}"
+                                                    style="text-align:center;">
+                                                <option th:each="y : ${years}" th:value="${y}" th:text="${y}">연도
+                                                </option>
+                                            </select>
+                                        </div>
+                                        <div class="col-4">
+                                            <select class="form-select" id="month" name="month" th:field="*{month}"
+                                                    style="text-align:center;">
+                                                <option th:each="m : ${months}" th:value="${m}" th:text="${m}">월
+                                                </option>
+                                            </select>
+                                        </div>
+                                        <div class="col-4">
+                                            <select class="form-select" id="day" name="day" th:field="*{day}"
+                                                    style="text-align:center;">
+                                                <option th:each="d : ${days}" th:value="${d}" th:text="${d}">일</option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-3">
+                                </div>
                             </div>
-                        </div>
-                        <div class="row p-2">
-                            <div class="col-3">
-                                이메일 <span class="required-star">*</span>
+                            <div class="row p-2">
+                                <div class="col-3">
+                                    실명
+                                </div>
+                                <div class="col-6">
+                                    <input class="form-control" type="text" th:field="*{realName}" maxlength="10"/>
+                                </div>
+                                <div class="col-3">
+                                </div>
                             </div>
-                            <div class="col-6">
-                                <input class="form-control" type="text" th:field="*{email}"/>
+                            <div class="row p-2">
+                                <div class="col-3">
+                                    이메일 <span class="required-star">*</span>
+                                </div>
+                                <div class="col-6">
+                                    <input class="form-control" type="text" th:field="*{email}"/>
+                                </div>
+                                <div class="col-3">
+                                    <button type="button" class="btn btn-primary btn-block"
+                                            style="background-color:#03C75A;" onclick="checkEmailDuplicate()">중복확인
+                                    </button>
+                                </div>
                             </div>
-                            <div class="col-3">
-                                <button type="button" class="btn btn-primary btn-block"
-                                        style="background-color:#03C75A;" onclick="checkEmailDuplicate()">중복확인
-                                </button>
+                            <div class="row p-2">
+                                <div class="col-6">
+                                    자기소개(선택사항)
+                                </div>
+                                <div class="col-6">
+                                </div>
+                                <div class="col-12">
+                                    <textarea class="form-control" rows="3" maxlength="150"
+                                              th:field="*{bio}"></textarea>
+                                </div>
                             </div>
-                        </div>
-                        <div class="row p-2">
-                            <div class="col-6">
-                                자기소개(선택사항)
-                            </div>
-                            <div class="col-6">
-                            </div>
-                            <div class="col-12">
-                                <textarea class="form-control" rows="3" maxlength="150" th:field="*{bio}"></textarea>
-                            </div>
-                        </div>
 
-                        <div class="col-12 p-2">
-                        </div>
-                        <div class="row">
-                            <div class="col-3 p-2">
-                                <button type="submit" class="btn btn-primary btn-block"
-                                        style="background-color:#03C75A; height:50px;" th:attr="formaction=@{/user/admin/updateuser(userNo=${user.userNo})}">수정하기
-                                </button>
-
-                                <th:block th:if="${#strings.toString(user.withdrawn) == 'N'}">
-                                    <button id="deleteUserForm" type="submit" class="btn btn-primary btn-block"
-                                            style="background-color: red; height:50px; display:block;" th:attr="formaction=@{/user/admin/deleteuser(userNo=${user.userNo})}">강제탈퇴
+                            <div class="col-12 p-2">
+                            </div>
+                            <div class="row">
+                                <div class="col-3 p-2">
+                                    <button type="submit" class="btn btn-primary btn-block"
+                                            style="background-color:#03C75A; height:50px;"
+                                            th:attr="formaction=@{/user/admin/updateuser(userNo=${user.userNo})}">수정하기
                                     </button>
 
-                                    <button id="reactiveUserForm" type="submit" class="btn btn-primary btn-block"
-                                            style="background-color:#03C75A; height:50px; display:none; " th:attr="formaction=@{/user/admin/reactiveuser(userNo=${user.userNo})}">강제탈퇴 취소
-                                    </button>
-                                </th:block>
-                                <th:block th:if="${#strings.toString(user.withdrawn) == 'Y'}">
-                                    <button id="deleteUserForm" type="submit" class="btn btn-primary btn-block"
-                                            style="background-color: red; height:50px; display:none;" th:attr="formaction=@{/user/admin/deleteuser(userNo=${user.userNo})}">강제탈퇴
-                                    </button>
+                                    <th:block th:if="${#strings.toString(user.withdrawn) == 'N'}">
+                                        <button id="deleteUserForm" type="submit" class="btn btn-primary btn-block"
+                                                style="background-color: red; height:50px; display:block;"
+                                                th:attr="formaction=@{/user/admin/deleteuser(userNo=${user.userNo})}">
+                                            강제탈퇴
+                                        </button>
 
-                                    <button id="reactiveUserForm" type="submit" class="btn btn-primary btn-block"
-                                            style="background-color:#03C75A; height:50px; display:block; " th:attr="formaction=@{/user/admin/reactiveuser(userNo=${user.userNo})}">강제탈퇴 취소
-                                    </button>
-                                </th:block>
+                                        <button id="reactiveUserForm" type="submit" class="btn btn-primary btn-block"
+                                                style="background-color:#03C75A; height:50px; display:none; "
+                                                th:attr="formaction=@{/user/admin/reactiveuser(userNo=${user.userNo})}">
+                                            강제탈퇴 취소
+                                        </button>
+                                    </th:block>
+                                    <th:block th:if="${#strings.toString(user.withdrawn) == 'Y'}">
+                                        <button id="deleteUserForm" type="submit" class="btn btn-primary btn-block"
+                                                style="background-color: red; height:50px; display:none;"
+                                                th:attr="formaction=@{/user/admin/deleteuser(userNo=${user.userNo})}">
+                                            강제탈퇴
+                                        </button>
 
+                                        <button id="reactiveUserForm" type="submit" class="btn btn-primary btn-block"
+                                                style="background-color:#03C75A; height:50px; display:block; "
+                                                th:attr="formaction=@{/user/admin/reactiveuser(userNo=${user.userNo})}">
+                                            강제탈퇴 취소
+                                        </button>
+                                    </th:block>
+
+                                </div>
                             </div>
-                        </div>
-                    </form>
+                        </form>
+                    </div>
                 </div>
+
+                <!--            <div class="row justify-content-start" style="color: #828282;">-->
+                <!--                <div class="col-6" id="loginbox2">-->
+                <!--                    <form th:action="@{/user/admin/deleteuser(userNo=${user.userNo})}" method="post">-->
+                <!--                        <div class="row">-->
+                <!--                            <div class="col-3 p-2">-->
+
+                <!--                            </div>-->
+                <!--                        </div>-->
+                <!--                    </form>-->
+                <!--                </div>-->
+                <!--            </div>-->
+
             </div>
-
-<!--            <div class="row justify-content-start" style="color: #828282;">-->
-<!--                <div class="col-6" id="loginbox2">-->
-<!--                    <form th:action="@{/user/admin/deleteuser(userNo=${user.userNo})}" method="post">-->
-<!--                        <div class="row">-->
-<!--                            <div class="col-3 p-2">-->
-
-<!--                            </div>-->
-<!--                        </div>-->
-<!--                    </form>-->
-<!--                </div>-->
-<!--            </div>-->
-
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/user/admin/userdetails.html
+++ b/src/main/resources/templates/user/admin/userdetails.html
@@ -305,11 +305,13 @@
                           enctype="multipart/form-data" onsubmit="validateForm(event)">
                         <div class="row p-2">
                             <div class="col-3 m-0 p-0" id="profileimagebox">
-                                <img th:if="${user.profileImagePath == null}" src="/images/defaultprofileimage.png"
-                                     style="width: 100px; height: auto;" class="profile-image"/>
-                                <img th:if="${user.profileImagePath != null}"
-                                     th:src="@{/uploadFiles/{fileName}(fileName=${user.profileImagePath})}"
-                                     style="width: 100px; height: auto;" class="profile-image"/>
+                                <div id="imagePreview">
+                                    <img th:if="${user.profileImagePath == null}" src="/images/defaultprofileimage.png"
+                                         style="width: 100px; height: auto;" class="profile-image"/>
+                                    <img th:if="${user.profileImagePath != null}"
+                                         th:src="@{/uploadFiles/{fileName}(fileName=${user.profileImagePath})}"
+                                         style="width: 100px; height: auto;" class="profile-image"/>
+                                </div>
                                 <div id="profileuploadbutton">
                                     <label for="image">
                                         <div class="btn-upload"
@@ -510,5 +512,27 @@
     </div>
 </div>
 <div th:replace="common/footer.html"></div>
+<script>
+    document.getElementById('image').addEventListener('change', function(event) {
+      const files = event.target.files;
+      const imagePreview = document.getElementById('imagePreview');
+      imagePreview.innerHTML = '';
+      Array.from(files).forEach(file => {
+          const reader = new FileReader();
+          reader.onload = function(e) {
+              const imgElement = document.createElement('img');
+              imgElement.src = e.target.result;
+
+              // 스타일과 클래스 추가
+              imgElement.style.width = '100px';
+              imgElement.style.height = 'auto';
+              imgElement.className = 'profile-image';
+
+              imagePreview.appendChild(imgElement);
+          }; //reader.onload
+          reader.readAsDataURL(file);
+      }); //Array.from(files).forEach()
+  }); //addEventListener()
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/user/admin/userlist.html
+++ b/src/main/resources/templates/user/admin/userlist.html
@@ -86,264 +86,282 @@
 
 <div th:replace="~{common/menubar}"></div>
 <style>
-    .jumbotron {
-    position : relative;
-    background-color : #EEEEEE;
+    html, body {
+        height: 100%;
+        margin: 0;
     }
-    .jumbotron .row {
-    position : absolute;
-    width : 100%;
-    bottom: 0%;
+    body {
+        display: flex;
+        flex-direction: column;
+    }
+    .content-wrapper {
+        flex: 1 0 auto;
+    }
+    footer {
+        flex-shrink: 0;
     }
 
-     .nav-link {
-            color: #828282;
-    }
-    ul {
-  list-style: none;
-  padding-left : 0px;
-  }
 </style>
-<div class="jumbotron">
-    <div class="container">
-        <div class="row">
-            <div class="col-9">
-                <div class="row">
-                    <div class="col-md-3 px-4">
-                        <h3>회원 관리</h3>
-                    </div>
-                    <div class="col-md-9">
-                        <nav class="navbar navbar-expand-md">
-                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                                <li><a th:href="@{/user/my}" class="nav-link px-2">마이페이지(테스트용)</a></li>
-                                <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                                <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                                <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                            </ul>
-                        </nav>
+<div class="content-wrapper">
+    <style>
+        .jumbotron {
+        position : relative;
+        background-color : #EEEEEE;
+        }
+        .jumbotron .row {
+        position : absolute;
+        width : 100%;
+        bottom: 0%;
+        }
+
+         .nav-link {
+                color: #828282;
+        }
+        ul {
+      list-style: none;
+      padding-left : 0px;
+      }
+    </style>
+    <div class="jumbotron">
+        <div class="container">
+            <div class="row">
+                <div class="col-9">
+                    <div class="row">
+                        <div class="col-md-3 px-4">
+                            <h3>회원 관리</h3>
+                        </div>
+                        <div class="col-md-9">
+                            <nav class="navbar navbar-expand-md">
+                                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                    <li><a th:href="@{/user/my}" class="nav-link px-2">마이페이지(테스트용)</a></li>
+                                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                                </ul>
+                            </nav>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
-<div class="container" style="padding:0;">
-    <div class="row">
-        <aside class="col-md-3 px-4">
-            <div class="row">
-                <div class="col-1"></div>
-                <div class="col-8">
-                    <div class="panel">
-                        <ul class="list-group">
-                            <li><a th:href="@{/user/admin/userlist}" class="nav-link px-2" style="color: #03C75A;">회원
-                                관리</a></li>
-                            <li><a th:href="@{/recruit/free/report/list}" class="nav-link px-2">신고 관리</a></li>
-                        </ul>
+    <div class="container" style="padding:0;">
+        <div class="row">
+            <aside class="col-md-3 px-4">
+                <div class="row">
+                    <div class="col-1"></div>
+                    <div class="col-8">
+                        <div class="panel">
+                            <ul class="list-group">
+                                <li><a th:href="@{/user/admin/userlist}" class="nav-link px-2" style="color: #03C75A;">회원
+                                    관리</a></li>
+                                <li><a th:href="@{/recruit/free/report/list}" class="nav-link px-2">신고 관리</a></li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </aside>
-        <script> // toggle + sorting
-        function updateCheckboxValueAndSubmit() {
-            const checkbox = document.getElementById('isToggledCheckbox');
-            const form = document.getElementById('filter-and-sort-form');
-            // 체크박스가 체크된 상태를 확인
-            checkbox.value = checkbox.checked ? 'Y' : 'N';
-            // 폼 제출
-            form.submit();
+            </aside>
+            <script> // toggle + sorting
+            function updateCheckboxValueAndSubmit() {
+                const checkbox = document.getElementById('isToggledCheckbox');
+                const form = document.getElementById('filter-and-sort-form');
+                // 체크박스가 체크된 상태를 확인
+                checkbox.value = checkbox.checked ? 'Y' : 'N';
+                // 폼 제출
+                form.submit();
+            }
+
+            function submitForm() {
+                document.getElementById('filter-and-sort-form').submit();
+            }
+            </script>
+            <style>
+                .form-select {
+                background-color : #FCFCFC;
+                border : none;
+                width : 100%;
+                height : 50px;
+                }
+                select {
+                color : #828282;
+                }
+                .form-control {
+                background-color : #FCFCFC;
+                border : none;
+                width : 100%;
+                height : 50px;
+                }
+
+
+                .form-control::placeholder {
+                color : #BBBBBB;
+                }
+
+                .date-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            background-color: #8E4B6E;
+            color: white;
+            border-radius: 10px;
+            text-align:center;
+            font-family: "Work Sans", sans-serif;
         }
 
-        function submitForm() {
-            document.getElementById('filter-and-sort-form').submit();
+        .month {
+            font-size: 1.1rem; /* M의 크기를 설정 */
+            font-weight: 550;
+            line-height: 1;
         }
-        </script>
-        <style>
-            .form-select {
-            background-color : #FCFCFC;
-            border : none;
-            width : 100%;
-            height : 50px;
-            }
-            select {
-            color : #828282;
-            }
-            .form-control {
-            background-color : #FCFCFC;
-            border : none;
-            width : 100%;
-            height : 50px;
-            }
 
+        .year {
+            font-size: 0.65rem; /* yyyy의 크기를 설정 */
+            font-weight: 400;
+        }
+        :root {
+            --background-color-light: #FFFFFF;
+            --text-color-light: #000000;
+            --toggle-background-light: #CCCCCC;
+            --toggle-ball-light: #FFFFFF;
 
-            .form-control::placeholder {
-            color : #BBBBBB;
-            }
+            --background-color-dark: #333333;
+            --text-color-dark: #FFFFFF;
+            --toggle-background-dark: #03C75A;
+            --toggle-ball-dark: #FFFFFF;
 
-            .date-container {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        background-color: #8E4B6E;
-        color: white;
-        border-radius: 10px;
-        text-align:center;
-        font-family: "Work Sans", sans-serif;
-    }
-
-    .month {
-        font-size: 1.1rem; /* M의 크기를 설정 */
-        font-weight: 550;
-        line-height: 1;
-    }
-
-    .year {
-        font-size: 0.65rem; /* yyyy의 크기를 설정 */
-        font-weight: 400;
-    }
-    :root {
-        --background-color-light: #FFFFFF;
-        --text-color-light: #000000;
-        --toggle-background-light: #CCCCCC;
-        --toggle-ball-light: #FFFFFF;
-
-        --background-color-dark: #333333;
-        --text-color-dark: #FFFFFF;
-        --toggle-background-dark: #03C75A;
-        --toggle-ball-dark: #FFFFFF;
-
-        --font-size-base: 32px; /* 기본 텍스트 크기 */
-        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
-    }
+            --font-size-base: 32px; /* 기본 텍스트 크기 */
+            --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+        }
 
 
 
-    .toggle-switch {
-        position: relative;
-        display: inline-block;
-        width: 62px; /* 너비 조정 */
-        height: 38px; /* 높이 조정 */
-    }
+        .toggle-switch {
+            position: relative;
+            display: inline-block;
+            width: 62px; /* 너비 조정 */
+            height: 38px; /* 높이 조정 */
+        }
 
-    .toggle-switch .checkbox {
-        opacity: 0;
-        width: 0;
-        height: 0;
-    }
-    #isToggledCheckbox {
-         opacity: 0;
+        .toggle-switch .checkbox {
+            opacity: 0;
             width: 0;
             height: 0;
-    }
+        }
+        #isToggledCheckbox {
+             opacity: 0;
+                width: 0;
+                height: 0;
+        }
 
-    .toggle-switch .label {
-        position: absolute;
-        cursor: pointer;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background-color: var(--toggle-background-light);
-        transition: background-color 0.4s;
-        border-radius: 38px; /* 둥근 모서리 반경 조정 */
-    }
+        .toggle-switch .label {
+            position: absolute;
+            cursor: pointer;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: var(--toggle-background-light);
+            transition: background-color 0.4s;
+            border-radius: 38px; /* 둥근 모서리 반경 조정 */
+        }
 
-    .toggle-switch .label:before {
-        position: absolute;
-        content: "";
-        height: 30px; /* 내부 원 높이 조정 */
-        width: 30px; /* 내부 원 너비 조정 */
-        left: 2px;
-        bottom: 0px;
-        background-color: var(--toggle-ball-light);
-        transition: transform 0.4s;
-        border-radius: 50%;
-    }
+        .toggle-switch .label:before {
+            position: absolute;
+            content: "";
+            height: 30px; /* 내부 원 높이 조정 */
+            width: 30px; /* 내부 원 너비 조정 */
+            left: 2px;
+            bottom: 0px;
+            background-color: var(--toggle-ball-light);
+            transition: transform 0.4s;
+            border-radius: 50%;
+        }
 
-    .toggle-switch input:checked + .label {
-        background-color: var(--toggle-background-dark);
-    }
+        .toggle-switch input:checked + .label {
+            background-color: var(--toggle-background-dark);
+        }
 
-    .toggle-switch input:checked + .label:before {
-        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
-    }
+        .toggle-switch input:checked + .label:before {
+            transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+        }
 
-             #absdiv {
+                 #absdiv {
 
-                z-index : 1000;
-            }
-
-            #searchbutton {
-                background-color: #828282;
-            }
-            .truncate {
-    max-width: 150px;  /* 원하는 너비에 맞게 조정 */
-    white-space: nowrap;
-    overflow: hidden;
-    text-overflow: ellipsis;
-  }
-        </style>
-        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
-              rel="stylesheet">
-        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
-              rel="stylesheet">
-        <div class="col-md-9">
-            <style>
-                .col-4 select {
-                    border-radius: 50px;
-                    text-align: center;
-                }
-                /* 검색창 스타일 */
-                .search-container {
-                    width: 300px;
+                    z-index : 1000;
                 }
 
-                .search-container select {
-                    position: absolute;
-                    left: 0%;
-                    width: 30%;
-                    height: 50px;
-                    color: #828282;
-                    font-size: 1rem;
-                    border-radius: 50px 0 0 50px;
-                    outline: none;
+                #searchbutton {
+                    background-color: #828282;
                 }
-                .search-container input[type="text"] {
-                    position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
-                    left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
-                    width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
-                    height: 50px;
-                    padding: 10px 40px 10px 15px;
-                    font-size: 1rem;
-                    outline: none;
-                    border-radius: 0 50px 50px 0;
-                    transition: border-color 0.3s, background-color 0.3s;
-                    color: #828282; /* 입력 텍스트 색상 변경 */
-                }
-
-                .search-container input[type="text"]::placeholder {
-                    color: #BBBBBB; /* placeholder 색상 변경 */
-                }
-
-
-                .search-container button {
-                    position: absolute;
-                    right: 1rem;
-                    top: 25px;
-                    background: none;
-                    transform: translateY(-50%);
-                    border: none;
-                    cursor: pointer;
-                }
-
-                .search-container button i {
-                    color: #A6AAB5;
-                }
-
-                .search-container button:hover i {
-                    color: #03C75A;
-                }
+                .truncate {
+        max-width: 150px;  /* 원하는 너비에 맞게 조정 */
+        white-space: nowrap;
+        overflow: hidden;
+        text-overflow: ellipsis;
+      }
             </style>
+            <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+                  rel="stylesheet">
+            <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+                  rel="stylesheet">
+            <div class="col-md-9">
+                <style>
+                    .col-4 select {
+                        border-radius: 50px;
+                        text-align: center;
+                    }
+                    /* 검색창 스타일 */
+                    .search-container {
+                        width: 300px;
+                    }
+
+                    .search-container select {
+                        position: absolute;
+                        left: 0%;
+                        width: 30%;
+                        height: 50px;
+                        color: #828282;
+                        font-size: 1rem;
+                        border-radius: 50px 0 0 50px;
+                        outline: none;
+                    }
+                    .search-container input[type="text"] {
+                        position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
+                        left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
+                        width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
+                        height: 50px;
+                        padding: 10px 40px 10px 15px;
+                        font-size: 1rem;
+                        outline: none;
+                        border-radius: 0 50px 50px 0;
+                        transition: border-color 0.3s, background-color 0.3s;
+                        color: #828282; /* 입력 텍스트 색상 변경 */
+                    }
+
+                    .search-container input[type="text"]::placeholder {
+                        color: #BBBBBB; /* placeholder 색상 변경 */
+                    }
+
+
+                    .search-container button {
+                        position: absolute;
+                        right: 1rem;
+                        top: 25px;
+                        background: none;
+                        transform: translateY(-50%);
+                        border: none;
+                        cursor: pointer;
+                    }
+
+                    .search-container button i {
+                        color: #A6AAB5;
+                    }
+
+                    .search-container button:hover i {
+                        color: #03C75A;
+                    }
+                </style>
                 <form id="filter-and-sort-form" th:action="@{/user/admin/userlist}" method="get">
                     <div class="row m-0">
                         <div class="col-7 p-0">
@@ -354,15 +372,20 @@
                                             <option value="id" th:selected="${searchBy == 'id'}">아이디</option>
                                             <option value="type" th:selected="${searchBy == 'type'}">가입유형코드</option>
                                             <option value="auth" th:selected="${searchBy == 'auth'}">권한코드</option>
-                                            <option value="nickname" th:selected="${searchBy == 'nickname'}">닉네임</option>
-                                            <option value="contactNo" th:selected="${searchBy == 'contactNo'}">연락처</option>
+                                            <option value="nickname" th:selected="${searchBy == 'nickname'}">닉네임
+                                            </option>
+                                            <option value="contactNo" th:selected="${searchBy == 'contactNo'}">연락처
+                                            </option>
                                             <option value="email" th:selected="${searchBy == 'email'}">이메일</option>
                                             <option value="bio" th:selected="${searchBy == 'bio'}">소개</option>
                                             <option value="gender" th:selected="${searchBy == 'gender'}">성별</option>
-                                            <option value="dateOfBirth" th:selected="${searchBy == 'dateOfBirth'}">생년월일</option>
+                                            <option value="dateOfBirth" th:selected="${searchBy == 'dateOfBirth'}">
+                                                생년월일
+                                            </option>
                                             <option value="realName" th:selected="${searchBy == 'realName'}">실명</option>
                                         </select>
-                                        <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
+                                        <input class="form-control px-3" type="text" name="searchTerm"
+                                               placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
                                         <!-- 검색 버튼 -->
                                         <button type="submit">
                                             <i class="fas fa-search"></i>
@@ -409,42 +432,42 @@
                     </div> <!--토글-->
                 </form>
                 <!--수정전 폼-->
-<!--                <form id="filter-and-sort-form" th:action="@{/user/admin/userlist}" method="get">-->
-<!--                    &lt;!&ndash; 검색 조건 &ndash;&gt;-->
-<!--                    <label>-->
-<!--                        <select name="searchBy">-->
-<!--                            <option value="id" th:selected="${searchBy == 'id'}">아이디</option>-->
-<!--                            <option value="type" th:selected="${searchBy == 'type'}">가입유형코드</option>-->
-<!--                            <option value="auth" th:selected="${searchBy == 'auth'}">권한코드</option>-->
-<!--                            <option value="nickname" th:selected="${searchBy == 'nickname'}">닉네임</option>-->
-<!--                            <option value="contactNo" th:selected="${searchBy == 'contactNo'}">연락처</option>-->
-<!--                            <option value="email" th:selected="${searchBy == 'email'}">이메일</option>-->
-<!--                            <option value="bio" th:selected="${searchBy == 'bio'}">소개</option>-->
-<!--                            <option value="gender" th:selected="${searchBy == 'gender'}">성별</option>-->
-<!--                            <option value="dateOfBirth" th:selected="${searchBy == 'dateOfBirth'}">생년월일</option>-->
-<!--                            <option value="realName" th:selected="${searchBy == 'realName'}">실명</option>-->
-<!--                        </select>-->
-<!--                    </label>-->
-<!--                    <input type="text logininput" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>-->
+                <!--                <form id="filter-and-sort-form" th:action="@{/user/admin/userlist}" method="get">-->
+                <!--                    &lt;!&ndash; 검색 조건 &ndash;&gt;-->
+                <!--                    <label>-->
+                <!--                        <select name="searchBy">-->
+                <!--                            <option value="id" th:selected="${searchBy == 'id'}">아이디</option>-->
+                <!--                            <option value="type" th:selected="${searchBy == 'type'}">가입유형코드</option>-->
+                <!--                            <option value="auth" th:selected="${searchBy == 'auth'}">권한코드</option>-->
+                <!--                            <option value="nickname" th:selected="${searchBy == 'nickname'}">닉네임</option>-->
+                <!--                            <option value="contactNo" th:selected="${searchBy == 'contactNo'}">연락처</option>-->
+                <!--                            <option value="email" th:selected="${searchBy == 'email'}">이메일</option>-->
+                <!--                            <option value="bio" th:selected="${searchBy == 'bio'}">소개</option>-->
+                <!--                            <option value="gender" th:selected="${searchBy == 'gender'}">성별</option>-->
+                <!--                            <option value="dateOfBirth" th:selected="${searchBy == 'dateOfBirth'}">생년월일</option>-->
+                <!--                            <option value="realName" th:selected="${searchBy == 'realName'}">실명</option>-->
+                <!--                        </select>-->
+                <!--                    </label>-->
+                <!--                    <input type="text logininput" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>-->
 
-<!--                    &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
-<!--                    <button type="submit">검색</button>-->
+                <!--                    &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
+                <!--                    <button type="submit">검색</button>-->
 
-<!--                    &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
-<!--                    <label>-->
-<!--                        <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y"-->
-<!--                               th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">창작자-->
-<!--                    </label>-->
-<!--                    &lt;!&ndash;                &lt;!&ndash; Hidden field for boardNo &ndash;&gt;&ndash;&gt;-->
-<!--                    &lt;!&ndash;                <input type="hidden" name="page" th:value="${page}" />&ndash;&gt;-->
-<!--                    <label>-->
-<!--                        <select name="orderBy" onchange="submitForm()">-->
-<!--                            <option value="recent" th:selected="${orderBy == 'recent'}">최근가입순</option>-->
-<!--                            <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
-<!--                            <option value="nickname" th:selected="${orderBy == 'nickname'}">닉네임가나다순</option>-->
-<!--                        </select>-->
-<!--                    </label>-->
-<!--                </form>-->
+                <!--                    &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
+                <!--                    <label>-->
+                <!--                        <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y"-->
+                <!--                               th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">창작자-->
+                <!--                    </label>-->
+                <!--                    &lt;!&ndash;                &lt;!&ndash; Hidden field for boardNo &ndash;&gt;&ndash;&gt;-->
+                <!--                    &lt;!&ndash;                <input type="hidden" name="page" th:value="${page}" />&ndash;&gt;-->
+                <!--                    <label>-->
+                <!--                        <select name="orderBy" onchange="submitForm()">-->
+                <!--                            <option value="recent" th:selected="${orderBy == 'recent'}">최근가입순</option>-->
+                <!--                            <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
+                <!--                            <option value="nickname" th:selected="${orderBy == 'nickname'}">닉네임가나다순</option>-->
+                <!--                        </select>-->
+                <!--                    </label>-->
+                <!--                </form>-->
                 <table>
                     <thead>
                     <tr style="font-size: 0.5 rem;">
@@ -500,29 +523,30 @@
                         </div>
                     </div>
                 </th:block>
+            </div>
         </div>
     </div>
-</div>
-<script>
+    <script>
 
-    //탈퇴 폼 제출 후처리
-    window.onload = function() {
-          const urlParams = new URLSearchParams(window.location.search);
-          const status = urlParams.get('status');
-          if (status === 'editSuccess') {
-              alert("프로필 수정이 완료되었습니다.");
+        //탈퇴 폼 제출 후처리
+        window.onload = function() {
+              const urlParams = new URLSearchParams(window.location.search);
+              const status = urlParams.get('status');
+              if (status === 'editSuccess') {
+                  alert("프로필 수정이 완료되었습니다.");
+              }
+              else if (status === 'editFailure') {
+                  alert("프로필 수정 중 문제가 발생했습니다. 다시 시도해주세요.");
+              }
+              else if (status === 'withdrawnSuccess') {
+                  alert("해당 회원을 강제 탈퇴처리하였습니다.");
+              }
+              else if (status === 'withdrawnFailure') {
+                  alert("회원 탈퇴 처리 중 문제가 발생했습니다.");
+              }
           }
-          else if (status === 'editFailure') {
-              alert("프로필 수정 중 문제가 발생했습니다. 다시 시도해주세요.");
-          }
-          else if (status === 'withdrawnSuccess') {
-              alert("해당 회원을 강제 탈퇴처리하였습니다.");
-          }
-          else if (status === 'withdrawnFailure') {
-              alert("회원 탈퇴 처리 중 문제가 발생했습니다.");
-          }
-      }
-</script>
+    </script>
+</div>
 <div th:replace="common/footer.html"></div>
 </body>
 </html>

--- a/src/main/resources/templates/user/admin/userlist.html
+++ b/src/main/resources/templates/user/admin/userlist.html
@@ -105,19 +105,21 @@
   }
 </style>
 <div class="jumbotron">
-    <div class="row">
-        <div class="col-md-3 px-4">
-            <h3>회원 관리</h3>
-        </div>
-        <div class="col-md-9">
-            <nav class="navbar navbar-expand-md">
-                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                    <li><a th:href="@{/user/my}" class="nav-link px-2">마이페이지(테스트용)</a></li>
-                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                </ul>
-            </nav>
+    <div class="container">
+        <div class="row">
+            <div class="col-md-3 px-4">
+                <h3>회원 관리</h3>
+            </div>
+            <div class="col-md-9">
+                <nav class="navbar navbar-expand-md">
+                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                        <li><a th:href="@{/user/my}" class="nav-link px-2">마이페이지(테스트용)</a></li>
+                        <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                        <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                        <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                    </ul>
+                </nav>
+            </div>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/user/admin/userlist.html
+++ b/src/main/resources/templates/user/admin/userlist.html
@@ -107,18 +107,22 @@
 <div class="jumbotron">
     <div class="container">
         <div class="row">
-            <div class="col-md-3 px-4">
-                <h3>회원 관리</h3>
-            </div>
-            <div class="col-md-9">
-                <nav class="navbar navbar-expand-md">
-                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                        <li><a th:href="@{/user/my}" class="nav-link px-2">마이페이지(테스트용)</a></li>
-                        <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                        <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                        <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                    </ul>
-                </nav>
+            <div class="col-9">
+                <div class="row">
+                    <div class="col-md-3 px-4">
+                        <h3>회원 관리</h3>
+                    </div>
+                    <div class="col-md-9">
+                        <nav class="navbar navbar-expand-md">
+                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                <li><a th:href="@{/user/my}" class="nav-link px-2">마이페이지(테스트용)</a></li>
+                                <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                                <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                                <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                            </ul>
+                        </nav>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/user/admin/userlist.html
+++ b/src/main/resources/templates/user/admin/userlist.html
@@ -132,7 +132,7 @@
         <aside class="col-md-3 px-4">
             <div class="row">
                 <div class="col-1"></div>
-                <div class="col-6">
+                <div class="col-8">
                     <div class="panel">
                         <ul class="list-group">
                             <li><a th:href="@{/user/admin/userlist}" class="nav-link px-2" style="color: #03C75A;">회원

--- a/src/main/resources/templates/user/admin/userlist.html
+++ b/src/main/resources/templates/user/admin/userlist.html
@@ -402,6 +402,7 @@
                                     <select class="form-select px-3" name="orderBy" onchange="submitForm()">
                                         <option value="recent" th:selected="${orderBy == 'recent'}">최근가입순</option>
                                         <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>
+                                        <option value="recentUpdated" th:selected="${orderBy == 'recentUpdated'}">최근수정순</option>
                                         <option value="nickname" th:selected="${orderBy == 'nickname'}">닉네임가나다순</option>
                                     </select>
                                 </label>

--- a/src/main/resources/templates/user/admin/userlist.html
+++ b/src/main/resources/templates/user/admin/userlist.html
@@ -503,6 +503,23 @@
         </div>
     </div>
 </div>
+<script>
+
+    //탈퇴 폼 제출 후처리
+    window.onload = function() {
+          const urlParams = new URLSearchParams(window.location.search);
+          const status = urlParams.get('status');
+          if (status === 'editSuccess') {
+              alert("프로필 수정이 완료되었습니다.");
+          }
+          else if (status === 'editFailure') {
+              alert("프로필 수정 중 문제가 발생했습니다. 다시 시도해주세요.");
+          }
+          else if (status === 'withdrawnFailure') {
+              alert("회원 탈퇴 처리 중 문제가 발생했습니다.");
+          }
+      }
+</script>
 <div th:replace="common/footer.html"></div>
 </body>
 </html>

--- a/src/main/resources/templates/user/admin/userlist.html
+++ b/src/main/resources/templates/user/admin/userlist.html
@@ -402,7 +402,7 @@
                                     </div>
                                 </div>
                                 <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">
-                                    창작자
+                                    탈퇴회원
                                 </div>
                             </div>
                         </div>
@@ -514,6 +514,9 @@
           }
           else if (status === 'editFailure') {
               alert("프로필 수정 중 문제가 발생했습니다. 다시 시도해주세요.");
+          }
+          else if (status === 'withdrawnSuccess') {
+              alert("해당 회원을 강제 탈퇴처리하였습니다.");
           }
           else if (status === 'withdrawnFailure') {
               alert("회원 탈퇴 처리 중 문제가 발생했습니다.");

--- a/src/main/resources/templates/user/admin/userlist.html
+++ b/src/main/resources/templates/user/admin/userlist.html
@@ -288,13 +288,68 @@
         <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
               rel="stylesheet">
         <div class="col-md-9">
+            <style>
+                .col-4 select {
+                    border-radius: 50px;
+                    text-align: center;
+                }
+                /* 검색창 스타일 */
+                .search-container {
+                    width: 300px;
+                }
+
+                .search-container select {
+                    position: absolute;
+                    left: 0%;
+                    width: 30%;
+                    height: 50px;
+                    color: #828282;
+                    font-size: 1rem;
+                    border-radius: 50px 0 0 50px;
+                    outline: none;
+                }
+                .search-container input[type="text"] {
+                    position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
+                    left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
+                    width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
+                    height: 50px;
+                    padding: 10px 40px 10px 15px;
+                    font-size: 1rem;
+                    outline: none;
+                    border-radius: 0 50px 50px 0;
+                    transition: border-color 0.3s, background-color 0.3s;
+                    color: #828282; /* 입력 텍스트 색상 변경 */
+                }
+
+                .search-container input[type="text"]::placeholder {
+                    color: #BBBBBB; /* placeholder 색상 변경 */
+                }
+
+
+                .search-container button {
+                    position: absolute;
+                    right: 1rem;
+                    top: 25px;
+                    background: none;
+                    transform: translateY(-50%);
+                    border: none;
+                    cursor: pointer;
+                }
+
+                .search-container button i {
+                    color: #666;
+                }
+
+                .search-container button:hover i {
+                    color: #03C75A;
+                }
+            </style>
                 <form id="filter-and-sort-form" th:action="@{/user/admin/userlist}" method="get">
-                    <div class="row">
-                        <div class="col-7">
+                    <div class="row m-0">
+                        <div class="col-7 p-0">
                             <div class="row justify-content-start m-0">
-                                <div class="col-4">
-                                    <!-- 검색 조건 -->
-                                    <label>
+                                <div class="col-12 p-0">
+                                    <div class="search-container">
                                         <select class="form-select px-3" name="searchBy">
                                             <option value="id" th:selected="${searchBy == 'id'}">아이디</option>
                                             <option value="type" th:selected="${searchBy == 'type'}">가입유형코드</option>
@@ -307,16 +362,12 @@
                                             <option value="dateOfBirth" th:selected="${searchBy == 'dateOfBirth'}">생년월일</option>
                                             <option value="realName" th:selected="${searchBy == 'realName'}">실명</option>
                                         </select>
-                                    </label>
-                                </div>
-                                <div class="col-6">
-                                    <input class="form-control px-3" type="text" name="searchTerm"
-                                           placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
-                                </div>
-                                <div class="col-2">
-                                    <!-- 검색 버튼 -->
-                                    <button id="searchbutton" type="submit" class="btn btn-primary">검색
-                                    </button>
+                                        <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
+                                        <!-- 검색 버튼 -->
+                                        <button type="submit">
+                                            <i class="fas fa-search"></i>
+                                        </button>
+                                    </div>
                                 </div>
                             </div>
                         </div>

--- a/src/main/resources/templates/user/admin/userlist.html
+++ b/src/main/resources/templates/user/admin/userlist.html
@@ -157,63 +157,251 @@
             document.getElementById('filter-and-sort-form').submit();
         }
         </script>
+        <style>
+            .form-select {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
+            }
+            select {
+            color : #828282;
+            }
+            .form-control {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
+            }
+
+
+            .form-control::placeholder {
+            color : #BBBBBB;
+            }
+
+            .date-container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        background-color: #8E4B6E;
+        color: white;
+        border-radius: 10px;
+        text-align:center;
+        font-family: "Work Sans", sans-serif;
+    }
+
+    .month {
+        font-size: 1.1rem; /* M의 크기를 설정 */
+        font-weight: 550;
+        line-height: 1;
+    }
+
+    .year {
+        font-size: 0.65rem; /* yyyy의 크기를 설정 */
+        font-weight: 400;
+    }
+    :root {
+        --background-color-light: #FFFFFF;
+        --text-color-light: #000000;
+        --toggle-background-light: #CCCCCC;
+        --toggle-ball-light: #FFFFFF;
+
+        --background-color-dark: #333333;
+        --text-color-dark: #FFFFFF;
+        --toggle-background-dark: #03C75A;
+        --toggle-ball-dark: #FFFFFF;
+
+        --font-size-base: 32px; /* 기본 텍스트 크기 */
+        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+    }
+
+
+
+    .toggle-switch {
+        position: relative;
+        display: inline-block;
+        width: 62px; /* 너비 조정 */
+        height: 38px; /* 높이 조정 */
+    }
+
+    .toggle-switch .checkbox {
+        opacity: 0;
+        width: 0;
+        height: 0;
+    }
+    #isToggledCheckbox {
+         opacity: 0;
+            width: 0;
+            height: 0;
+    }
+
+    .toggle-switch .label {
+        position: absolute;
+        cursor: pointer;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: var(--toggle-background-light);
+        transition: background-color 0.4s;
+        border-radius: 38px; /* 둥근 모서리 반경 조정 */
+    }
+
+    .toggle-switch .label:before {
+        position: absolute;
+        content: "";
+        height: 30px; /* 내부 원 높이 조정 */
+        width: 30px; /* 내부 원 너비 조정 */
+        left: 2px;
+        bottom: 0px;
+        background-color: var(--toggle-ball-light);
+        transition: transform 0.4s;
+        border-radius: 50%;
+    }
+
+    .toggle-switch input:checked + .label {
+        background-color: var(--toggle-background-dark);
+    }
+
+    .toggle-switch input:checked + .label:before {
+        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+    }
+
+             #absdiv {
+
+                z-index : 1000;
+            }
+
+            #searchbutton {
+                background-color: #828282;
+            }
+            .truncate {
+    max-width: 150px;  /* 원하는 너비에 맞게 조정 */
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+  }
+        </style>
+        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+              rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+              rel="stylesheet">
         <div class="col-md-9">
-            <div class="review-list">
-                <h2>회원 목록</h2>
                 <form id="filter-and-sort-form" th:action="@{/user/admin/userlist}" method="get">
-                    <!-- 검색 조건 -->
-                    <label>
-                        <select name="searchBy">
-                            <option value="id" th:selected="${searchBy == 'id'}">아이디</option>
-                            <option value="type" th:selected="${searchBy == 'type'}">가입유형코드</option>
-                            <option value="auth" th:selected="${searchBy == 'auth'}">권한코드</option>
-                            <option value="nickname" th:selected="${searchBy == 'nickname'}">닉네임</option>
-                            <option value="contactNo" th:selected="${searchBy == 'contactNo'}">연락처</option>
-                            <option value="email" th:selected="${searchBy == 'email'}">이메일</option>
-                            <option value="bio" th:selected="${searchBy == 'bio'}">소개</option>
-                            <option value="gender" th:selected="${searchBy == 'gender'}">성별</option>
-                            <option value="dateOfBirth" th:selected="${searchBy == 'dateOfBirth'}">생년월일</option>
-                            <option value="realName" th:selected="${searchBy == 'realName'}">실명</option>
-                        </select>
-                    </label>
-                    <input type="text logininput" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
-
-                    <!-- 검색 버튼 -->
-                    <button type="submit">검색</button>
-
-                    <!-- 정렬 또는 토글 -->
-                    <label>
-                        <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y"
-                               th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">창작자
-                    </label>
-                    <!--                &lt;!&ndash; Hidden field for boardNo &ndash;&gt;-->
-                    <!--                <input type="hidden" name="page" th:value="${page}" />-->
-                    <label>
-                        <select name="orderBy" onchange="submitForm()">
-                            <option value="recent" th:selected="${orderBy == 'recent'}">최근가입순</option>
-                            <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>
-                            <option value="nickname" th:selected="${orderBy == 'nickname'}">닉네임가나다순</option>
-                        </select>
-                    </label>
+                    <div class="row">
+                        <div class="col-7">
+                            <div class="row justify-content-start m-0">
+                                <div class="col-4">
+                                    <!-- 검색 조건 -->
+                                    <label>
+                                        <select class="form-select px-3" name="searchBy">
+                                            <option value="id" th:selected="${searchBy == 'id'}">아이디</option>
+                                            <option value="type" th:selected="${searchBy == 'type'}">가입유형코드</option>
+                                            <option value="auth" th:selected="${searchBy == 'auth'}">권한코드</option>
+                                            <option value="nickname" th:selected="${searchBy == 'nickname'}">닉네임</option>
+                                            <option value="contactNo" th:selected="${searchBy == 'contactNo'}">연락처</option>
+                                            <option value="email" th:selected="${searchBy == 'email'}">이메일</option>
+                                            <option value="bio" th:selected="${searchBy == 'bio'}">소개</option>
+                                            <option value="gender" th:selected="${searchBy == 'gender'}">성별</option>
+                                            <option value="dateOfBirth" th:selected="${searchBy == 'dateOfBirth'}">생년월일</option>
+                                            <option value="realName" th:selected="${searchBy == 'realName'}">실명</option>
+                                        </select>
+                                    </label>
+                                </div>
+                                <div class="col-6">
+                                    <input class="form-control px-3" type="text" name="searchTerm"
+                                           placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
+                                </div>
+                                <div class="col-2">
+                                    <!-- 검색 버튼 -->
+                                    <button id="searchbutton" type="submit" class="btn btn-primary">검색
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="col-1" style=""></div>
+                        <div class="col-4">
+                            <div class="row justify-content-end">
+                                <!-- 정렬 또는 토글2 -->
+                                <label>
+                                    <select class="form-select px-3" name="orderBy" onchange="submitForm()">
+                                        <option value="recent" th:selected="${orderBy == 'recent'}">최근가입순</option>
+                                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>
+                                        <option value="nickname" th:selected="${orderBy == 'nickname'}">닉네임가나다순</option>
+                                    </select>
+                                </label>
+                            </div>
+                        </div>
+                    </div> <!--검색, 소팅 (토글X)-->
+                    <div class="row justify-content-around">
+                        <div class="col-3" style="padding: 0 1.2rem;"></div>
+                        <div class="col-3" style="padding: 0 1.2rem;"></div>
+                        <div class="col-3" style="padding: 0 1.2rem;">
+                            <div id="absdiv" class="row justify-content-end">
+                                <div class="col-3">
+                                    <div class="toggle-switch">
+                                        <!-- 정렬 또는 토글1 -->
+                                        <input type="checkbox" name="isToggled" id="isToggledCheckbox"
+                                               value="Y" th:checked="${isToggled == 'Y'}"
+                                               onchange="updateCheckboxValueAndSubmit()">
+                                        <label for="isToggledCheckbox" class="label">
+                                            <div class="ball"></div>
+                                        </label>
+                                    </div>
+                                </div>
+                                <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">
+                                    창작자
+                                </div>
+                            </div>
+                        </div>
+                    </div> <!--토글-->
                 </form>
+                <!--수정전 폼-->
+<!--                <form id="filter-and-sort-form" th:action="@{/user/admin/userlist}" method="get">-->
+<!--                    &lt;!&ndash; 검색 조건 &ndash;&gt;-->
+<!--                    <label>-->
+<!--                        <select name="searchBy">-->
+<!--                            <option value="id" th:selected="${searchBy == 'id'}">아이디</option>-->
+<!--                            <option value="type" th:selected="${searchBy == 'type'}">가입유형코드</option>-->
+<!--                            <option value="auth" th:selected="${searchBy == 'auth'}">권한코드</option>-->
+<!--                            <option value="nickname" th:selected="${searchBy == 'nickname'}">닉네임</option>-->
+<!--                            <option value="contactNo" th:selected="${searchBy == 'contactNo'}">연락처</option>-->
+<!--                            <option value="email" th:selected="${searchBy == 'email'}">이메일</option>-->
+<!--                            <option value="bio" th:selected="${searchBy == 'bio'}">소개</option>-->
+<!--                            <option value="gender" th:selected="${searchBy == 'gender'}">성별</option>-->
+<!--                            <option value="dateOfBirth" th:selected="${searchBy == 'dateOfBirth'}">생년월일</option>-->
+<!--                            <option value="realName" th:selected="${searchBy == 'realName'}">실명</option>-->
+<!--                        </select>-->
+<!--                    </label>-->
+<!--                    <input type="text logininput" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>-->
+
+<!--                    &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
+<!--                    <button type="submit">검색</button>-->
+
+<!--                    &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
+<!--                    <label>-->
+<!--                        <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y"-->
+<!--                               th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">창작자-->
+<!--                    </label>-->
+<!--                    &lt;!&ndash;                &lt;!&ndash; Hidden field for boardNo &ndash;&gt;&ndash;&gt;-->
+<!--                    &lt;!&ndash;                <input type="hidden" name="page" th:value="${page}" />&ndash;&gt;-->
+<!--                    <label>-->
+<!--                        <select name="orderBy" onchange="submitForm()">-->
+<!--                            <option value="recent" th:selected="${orderBy == 'recent'}">최근가입순</option>-->
+<!--                            <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
+<!--                            <option value="nickname" th:selected="${orderBy == 'nickname'}">닉네임가나다순</option>-->
+<!--                        </select>-->
+<!--                    </label>-->
+<!--                </form>-->
                 <table>
                     <thead>
-                    <tr>
+                    <tr style="font-size: 0.5 rem;">
                         <th>회원번호</th>
                         <th>유형 코드</th>
                         <th>권한 코드</th>
                         <th>사용자 ID</th>
                         <th>닉네임</th>
-                        <th>연락처</th>
-                        <th>이메일</th>
-                        <th>프로필 이미지 경로</th>
-                        <th>소개</th>
-                        <th>성별</th>
-                        <th>생년월일</th>
-                        <th>실명</th>
-                        <th>약관 동의</th>
-                        <th>약관 동의 시간</th>
-                        <th>등록 시간</th>
                         <th>마지막 수정 시간</th>
                     </tr>
                     </thead>
@@ -223,21 +411,12 @@
                         <td th:text="${user.userNo}">회원번호</td>
                         <td th:text="${user.typeCode}">유형 코드</td>
                         <td th:text="${user.authCode}">권한 코드</td>
-                        <td th:text="${user.userId}">사용자 ID</td>
-                        <td th:text="${user.nickname}">닉네임</td>
-                        <td th:text="${user.contactNumber}">연락처</td>
-                        <td th:text="${user.email}">이메일</td>
-                        <td th:text="${user.profileImagePath}">프로필 이미지 경로</td>
-                        <td th:text="${user.bio}">소개</td>
-                        <td th:text="${user.gender}">성별</td>
-                        <td th:text="${user.dateOfBirth}">생년월일</td>
-                        <td th:text="${user.realName}">실명</td>
-                        <td th:text="${user.termsAgreement}">약관 동의</td>
-                        <td th:text="${user.termsAgreementDatetime}">약관 동의 시간</td>
-                        <td th:text="${user.registrationDatetime}">등록 시간</td>
+                        <td th:text="${user.userId}" class="truncate">사용자 ID</td>
+                        <td th:text="${user.nickname}" class="truncate">닉네임</td>
                         <td th:text="${user.lastModifiedDatetime}">마지막 수정 시간</td>
                     </tr>
                     </tbody>
+
                 </table>
 
                 <!-- 페이징 -->
@@ -270,7 +449,6 @@
                         </div>
                     </div>
                 </th:block>
-            </div>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/user/admin/userlist.html
+++ b/src/main/resources/templates/user/admin/userlist.html
@@ -123,21 +123,23 @@
         </div>
     </div>
 </div>
-<div class="row">
-    <aside class="col-md-3 px-4">
-        <div class="row">
-            <div class="col-3"></div>
-            <div class="col-6">
-                <div class="panel">
-                    <ul class="list-group">
-                        <li><a th:href="@{/user/admin/userlist}" class="nav-link px-2" style="color: #03C75A;">회원 관리</a></li>
-                        <li><a th:href="@{/recruit/free/report/list}" class="nav-link px-2">신고 관리</a></li>
-                    </ul>
+<div class="container" style="padding:0;">
+    <div class="row">
+        <aside class="col-md-3 px-4">
+            <div class="row">
+                <div class="col-3"></div>
+                <div class="col-6">
+                    <div class="panel">
+                        <ul class="list-group">
+                            <li><a th:href="@{/user/admin/userlist}" class="nav-link px-2" style="color: #03C75A;">회원
+                                관리</a></li>
+                            <li><a th:href="@{/recruit/free/report/list}" class="nav-link px-2">신고 관리</a></li>
+                        </ul>
+                    </div>
                 </div>
             </div>
-        </div>
-    </aside>
-    <script> // toggle + sorting
+        </aside>
+        <script> // toggle + sorting
         function updateCheckboxValueAndSubmit() {
             const checkbox = document.getElementById('isToggledCheckbox');
             const form = document.getElementById('filter-and-sort-form');
@@ -150,109 +152,121 @@
         function submitForm() {
             document.getElementById('filter-and-sort-form').submit();
         }
-    </script>
-    <div class="col-md-9">
-        <div class="review-list">
-            <h2>회원 목록</h2>
-            <form id="filter-and-sort-form" th:action="@{/user/admin/userlist}" method="get">
-                <!-- 검색 조건 -->
-                <label>
-                    <select name="searchBy">
-                        <option value="id" th:selected="${searchBy == 'id'}">아이디</option>
-                        <option value="type" th:selected="${searchBy == 'type'}">가입유형코드</option>
-                        <option value="auth" th:selected="${searchBy == 'auth'}">권한코드</option>
-                        <option value="nickname" th:selected="${searchBy == 'nickname'}">닉네임</option>
-                        <option value="contactNo" th:selected="${searchBy == 'contactNo'}">연락처</option>
-                        <option value="email" th:selected="${searchBy == 'email'}">이메일</option>
-                        <option value="bio" th:selected="${searchBy == 'bio'}">소개</option>
-                        <option value="gender" th:selected="${searchBy == 'gender'}">성별</option>
-                        <option value="dateOfBirth" th:selected="${searchBy == 'dateOfBirth'}">생년월일</option>
-                        <option value="realName" th:selected="${searchBy == 'realName'}">실명</option>
-                    </select>
-                </label>
-                <input type="text logininput" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
+        </script>
+        <div class="col-md-9">
+            <div class="review-list">
+                <h2>회원 목록</h2>
+                <form id="filter-and-sort-form" th:action="@{/user/admin/userlist}" method="get">
+                    <!-- 검색 조건 -->
+                    <label>
+                        <select name="searchBy">
+                            <option value="id" th:selected="${searchBy == 'id'}">아이디</option>
+                            <option value="type" th:selected="${searchBy == 'type'}">가입유형코드</option>
+                            <option value="auth" th:selected="${searchBy == 'auth'}">권한코드</option>
+                            <option value="nickname" th:selected="${searchBy == 'nickname'}">닉네임</option>
+                            <option value="contactNo" th:selected="${searchBy == 'contactNo'}">연락처</option>
+                            <option value="email" th:selected="${searchBy == 'email'}">이메일</option>
+                            <option value="bio" th:selected="${searchBy == 'bio'}">소개</option>
+                            <option value="gender" th:selected="${searchBy == 'gender'}">성별</option>
+                            <option value="dateOfBirth" th:selected="${searchBy == 'dateOfBirth'}">생년월일</option>
+                            <option value="realName" th:selected="${searchBy == 'realName'}">실명</option>
+                        </select>
+                    </label>
+                    <input type="text logininput" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
 
-                <!-- 검색 버튼 -->
-                <button type="submit">검색</button>
+                    <!-- 검색 버튼 -->
+                    <button type="submit">검색</button>
 
-                <!-- 정렬 또는 토글 -->
-                <label>
-                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">창작자
-                </label>
-<!--                &lt;!&ndash; Hidden field for boardNo &ndash;&gt;-->
-<!--                <input type="hidden" name="page" th:value="${page}" />-->
-                <label>
-                    <select name="orderBy" onchange="submitForm()">
-                        <option value="recent" th:selected="${orderBy == 'recent'}">최근가입순</option>
-                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>
-                        <option value="nickname" th:selected="${orderBy == 'nickname'}">닉네임가나다순</option>
-                    </select>
-                </label>
-            </form>
-            <table>
-                <thead>
-                <tr>
-                    <th>회원번호</th>
-                    <th>유형 코드</th>
-                    <th>권한 코드</th>
-                    <th>사용자 ID</th>
-                    <th>닉네임</th>
-                    <th>연락처</th>
-                    <th>이메일</th>
-                    <th>프로필 이미지 경로</th>
-                    <th>소개</th>
-                    <th>성별</th>
-                    <th>생년월일</th>
-                    <th>실명</th>
-                    <th>약관 동의</th>
-                    <th>약관 동의 시간</th>
-                    <th>등록 시간</th>
-                    <th>마지막 수정 시간</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr th:each="user : ${users}" class="clickable-row" th:attr="data-href=@{/user/admin/userdetails(userNo=${user.userNo})}">
-                    <td th:text="${user.userNo}">회원번호</td>
-                    <td th:text="${user.typeCode}">유형 코드</td>
-                    <td th:text="${user.authCode}">권한 코드</td>
-                    <td th:text="${user.userId}">사용자 ID</td>
-                    <td th:text="${user.nickname}">닉네임</td>
-                    <td th:text="${user.contactNumber}">연락처</td>
-                    <td th:text="${user.email}">이메일</td>
-                    <td th:text="${user.profileImagePath}">프로필 이미지 경로</td>
-                    <td th:text="${user.bio}">소개</td>
-                    <td th:text="${user.gender}">성별</td>
-                    <td th:text="${user.dateOfBirth}">생년월일</td>
-                    <td th:text="${user.realName}">실명</td>
-                    <td th:text="${user.termsAgreement}">약관 동의</td>
-                    <td th:text="${user.termsAgreementDatetime}">약관 동의 시간</td>
-                    <td th:text="${user.registrationDatetime}">등록 시간</td>
-                    <td th:text="${user.lastModifiedDatetime}">마지막 수정 시간</td>
-                </tr>
-                </tbody>
-            </table>
+                    <!-- 정렬 또는 토글 -->
+                    <label>
+                        <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y"
+                               th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">창작자
+                    </label>
+                    <!--                &lt;!&ndash; Hidden field for boardNo &ndash;&gt;-->
+                    <!--                <input type="hidden" name="page" th:value="${page}" />-->
+                    <label>
+                        <select name="orderBy" onchange="submitForm()">
+                            <option value="recent" th:selected="${orderBy == 'recent'}">최근가입순</option>
+                            <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>
+                            <option value="nickname" th:selected="${orderBy == 'nickname'}">닉네임가나다순</option>
+                        </select>
+                    </label>
+                </form>
+                <table>
+                    <thead>
+                    <tr>
+                        <th>회원번호</th>
+                        <th>유형 코드</th>
+                        <th>권한 코드</th>
+                        <th>사용자 ID</th>
+                        <th>닉네임</th>
+                        <th>연락처</th>
+                        <th>이메일</th>
+                        <th>프로필 이미지 경로</th>
+                        <th>소개</th>
+                        <th>성별</th>
+                        <th>생년월일</th>
+                        <th>실명</th>
+                        <th>약관 동의</th>
+                        <th>약관 동의 시간</th>
+                        <th>등록 시간</th>
+                        <th>마지막 수정 시간</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="user : ${users}" class="clickable-row"
+                        th:attr="data-href=@{/user/admin/userdetails(userNo=${user.userNo})}">
+                        <td th:text="${user.userNo}">회원번호</td>
+                        <td th:text="${user.typeCode}">유형 코드</td>
+                        <td th:text="${user.authCode}">권한 코드</td>
+                        <td th:text="${user.userId}">사용자 ID</td>
+                        <td th:text="${user.nickname}">닉네임</td>
+                        <td th:text="${user.contactNumber}">연락처</td>
+                        <td th:text="${user.email}">이메일</td>
+                        <td th:text="${user.profileImagePath}">프로필 이미지 경로</td>
+                        <td th:text="${user.bio}">소개</td>
+                        <td th:text="${user.gender}">성별</td>
+                        <td th:text="${user.dateOfBirth}">생년월일</td>
+                        <td th:text="${user.realName}">실명</td>
+                        <td th:text="${user.termsAgreement}">약관 동의</td>
+                        <td th:text="${user.termsAgreementDatetime}">약관 동의 시간</td>
+                        <td th:text="${user.registrationDatetime}">등록 시간</td>
+                        <td th:text="${user.lastModifiedDatetime}">마지막 수정 시간</td>
+                    </tr>
+                    </tbody>
+                </table>
 
-            <!-- 페이징 -->
-            <th:block th:if="${pages != null}">
-                <div class="d-flex justify-content-center">
-                    <div class="btn-group">
-                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/admin/userlist(isToggled=${isToggled}, orderBy=${orderBy}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                            </svg>
-                        </button>
-                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">
-                            <button type="button" class="btn btn-sm me-2 pages"
-                                    th:text="${p}" th:onclick="|location.href='@{/user/admin/userlist(isToggled=${isToggled}, orderBy=${orderBy}, page=${p})}'|"></button>
-                        </th:block>
-                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/admin/userlist(isToggled=${isToggled}, orderBy=${orderBy}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">
-                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
-                            </svg>
-                        </button>
+                <!-- 페이징 -->
+                <th:block th:if="${pages != null}">
+                    <div class="d-flex justify-content-center">
+                        <div class="btn-group">
+                            <button type="button" class="btn btn-sm previous"
+                                    th:onclick="|location.href='@{/user/admin/userlist(isToggled=${isToggled}, orderBy=${orderBy}, page=${currentPage - 1})}'|"
+                                    th:disabled="${currentPage == 1}">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
+                                     class="bi bi-chevron-left" viewBox="0 0 16 16">
+                                    <path fill-rule="evenodd"
+                                          d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                                </svg>
+                            </button>
+                            <th:block th:each="p : ${#numbers.sequence(1, pages)}">
+                                <button type="button" class="btn btn-sm me-2 pages"
+                                        th:text="${p}"
+                                        th:onclick="|location.href='@{/user/admin/userlist(isToggled=${isToggled}, orderBy=${orderBy}, page=${p})}'|"></button>
+                            </th:block>
+                            <button type="button" class="btn btn-sm  next"
+                                    th:onclick="|location.href='@{/user/admin/userlist(isToggled=${isToggled}, orderBy=${orderBy}, page=${currentPage + 1})}'|"
+                                    th:disabled="${currentPage == pages}">
+                                <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor"
+                                     class="bi bi-chevron-right" viewBox="0 0 16 16">
+                                    <path fill-rule="evenodd"
+                                          d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                                </svg>
+                            </button>
+                        </div>
                     </div>
-                </div>
-            </th:block>
+                </th:block>
+            </div>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/user/admin/userlist.html
+++ b/src/main/resources/templates/user/admin/userlist.html
@@ -337,7 +337,7 @@
                 }
 
                 .search-container button i {
-                    color: #666;
+                    color: #A6AAB5;
                 }
 
                 .search-container button:hover i {

--- a/src/main/resources/templates/user/admin/userlist.html
+++ b/src/main/resources/templates/user/admin/userlist.html
@@ -131,7 +131,7 @@
     <div class="row">
         <aside class="col-md-3 px-4">
             <div class="row">
-                <div class="col-3"></div>
+                <div class="col-1"></div>
                 <div class="col-6">
                     <div class="panel">
                         <ul class="list-group">

--- a/src/main/resources/templates/user/findid.html
+++ b/src/main/resources/templates/user/findid.html
@@ -108,18 +108,22 @@
 <div class="jumbotron">
     <div class="container">
         <div class="row">
-            <div class="col-md-3 px-4">
-                <h3>로그인</h3>
-            </div>
-            <div class="col-md-9">
-                <nav class="navbar navbar-expand-md">
-                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                        <li>-</li>
-                        <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                        <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                        <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                    </ul>
-                </nav>
+            <div class="col-9">
+                <div class="row">
+                    <div class="col-md-3 px-4">
+                        <h3>로그인</h3>
+                    </div>
+                    <div class="col-md-9">
+                        <nav class="navbar navbar-expand-md">
+                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                <li>-</li>
+                                <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                                <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                                <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                            </ul>
+                        </nav>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/user/findid.html
+++ b/src/main/resources/templates/user/findid.html
@@ -133,7 +133,7 @@
         <aside class="col-md-3 px-4">
             <div class="row">
                 <div class="col-1"></div>
-                <div class="col-6">
+                <div class="col-8">
                     <div class="panel">
                         <ul class="list-group">
                             <li><a th:href="@{/user/login}" class="nav-link px-2" style="color: #03C75A;">로그인</a></li>

--- a/src/main/resources/templates/user/findid.html
+++ b/src/main/resources/templates/user/findid.html
@@ -25,23 +25,6 @@
         }
     </style>
     <script>
-        //VALIDATION 2) 연락처
-        function autoFormatPhoneNumber(input) {
-            let phoneNumber = input.value.replace(/\D/g, ''); // Remove all non-digit characters
-            if (phoneNumber.length > 3 && phoneNumber.length <= 7) {
-                phoneNumber = phoneNumber.substring(0, 3) + '-' + phoneNumber.substring(3);
-            } else if (phoneNumber.length > 7) {
-                phoneNumber = phoneNumber.substring(0, 3) + '-' + phoneNumber.substring(3, 7) + '-' + phoneNumber.substring(7, 11);
-            }
-            input.value = phoneNumber;
-        }
-
-
-        // 연락처를 검증하는 함수
-        function validatePhoneNumber(phoneNumber) {
-            const phonePattern = /^\d{3}-\d{4}-\d{4}$/; // 000-0000-0000 형식
-            return phonePattern.test(phoneNumber);
-        }
 
          function validateEmail(email) {
             // 이메일 형식을 검증하는 정규 표현식
@@ -52,19 +35,34 @@
         // 폼 제출 전 이메일 형식을 검증하는 함수
         function validateForm(event) {
 
-        const phoneNumberInput = document.querySelector('input[name="contactNumber"]');
-        const phoneNumber = phoneNumberInput.value;
+            // (1/2) nickname available check
+            const nickname = document.getElementById('nickname').value;
 
+            if(!nickname) {
+                alert('닉네임을 입력해 주세요.');
+                return;
+            }
 
+            if (nickname.length < 4) {
+                alert('닉네임의 글자수는 최소 4자입니다.');
+                return;
+            }
 
-        // 연락처 검증
-        if (!validatePhoneNumber(phoneNumber)) {
-            alert("연락처 형식이 올바르지 않습니다. 예: 000-0000-0000");
-            event.preventDefault(); // 폼 제출을 막음
-            return;
-        }
+            // (2/2) email available check
+            const email = document.getElementById('email').value;
+
+            if(!email) {
+                alert('이메일을 입력해 주세요.');
+                return;
+            }
+
+            // 이메일 검증
+            if (!validateEmail(email)) {
+                alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
+                event.preventDefault(); // 폼 제출을 막음
+                return;
+            }
     }
-
     </script>
 </head>
 <body>
@@ -163,13 +161,11 @@
                     <form th:action="@{/user/findid}" th:object="${user}" method="post" onsubmit="validateForm(event)">
                         <div class="row px-3">
                             <div class="col-12 mb-3 py-1">
-                                <input type="text" th:field="*{nickname}" class="form-control logininput" maxlength="20"
-                                       minlength="4" placeholder="닉네임"/>
+                                <input type="text" th:field="*{nickname}" class="form-control logininput" maxlength="20" minlength="4" placeholder="닉네임"/>
                             </div>
 
                             <div class="col-12 mb-3 py-1">
-                                <input type="text" th:field="*{contactNumber}" class="form-control logininput"
-                                       oninput="autoFormatPhoneNumber(this)" maxlength="13" placeholder="전화번호"/>
+                                <input type="text" th:field="*{email}" class="form-control logininput" placeholder="이메일"/>
                             </div>
 
                             <div class="col-12 pt-3 pb-4">

--- a/src/main/resources/templates/user/findid.html
+++ b/src/main/resources/templates/user/findid.html
@@ -69,119 +69,143 @@
 
 <div th:replace="~{common/menubar}"></div>
 <style>
-    .jumbotron {
-    position : relative;
-    background-color : #EEEEEE;
+    html, body {
+        height: 100%;
+        margin: 0;
     }
-    .jumbotron .row {
-    position : absolute;
-    width : 100%;
-    bottom: 0%;
+    body {
+        display: flex;
+        flex-direction: column;
     }
-
-    #loginbox {
-    border-radius : 5%;
-    border-color : #F2F2F2;
+    .content-wrapper {
+        flex: 1 0 auto;
     }
-
-    .logininput {
-    background-color : #FCFCFC;
-    border : none;
-    height : 50px;
+    footer {
+        flex-shrink: 0;
     }
-
-    .logininput::placeholder {
-    color : #BBBBBB;
-    }
-
-     .nav-link {
-            color: #828282;
-    }
-    ul {
-  list-style: none;
-  padding-left : 0px;
-  }
 
 </style>
-<div class="jumbotron">
-    <div class="container">
-        <div class="row">
-            <div class="col-9">
-                <div class="row">
-                    <div class="col-md-3 px-4">
-                        <h3>로그인</h3>
-                    </div>
-                    <div class="col-md-9">
-                        <nav class="navbar navbar-expand-md">
-                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                                <li>-</li>
-                                <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                                <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                                <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                            </ul>
-                        </nav>
+<div class="content-wrapper">
+    <style>
+        .jumbotron {
+        position : relative;
+        background-color : #EEEEEE;
+        }
+        .jumbotron .row {
+        position : absolute;
+        width : 100%;
+        bottom: 0%;
+        }
+
+        #loginbox {
+        border-radius : 5%;
+        border-color : #F2F2F2;
+        }
+
+        .logininput {
+        background-color : #FCFCFC;
+        border : none;
+        height : 50px;
+        }
+
+        .logininput::placeholder {
+        color : #BBBBBB;
+        }
+
+         .nav-link {
+                color: #828282;
+        }
+        ul {
+      list-style: none;
+      padding-left : 0px;
+      }
+
+    </style>
+    <div class="jumbotron">
+        <div class="container">
+            <div class="row">
+                <div class="col-9">
+                    <div class="row">
+                        <div class="col-md-3 px-4">
+                            <h3>로그인</h3>
+                        </div>
+                        <div class="col-md-9">
+                            <nav class="navbar navbar-expand-md">
+                                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                    <li>-</li>
+                                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                                </ul>
+                            </nav>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
-<div class="container" style="padding:0;">
-    <div class="row">
-        <aside class="col-md-3 px-4">
-            <div class="row">
-                <div class="col-1"></div>
-                <div class="col-8">
-                    <div class="panel">
-                        <ul class="list-group">
-                            <li><a th:href="@{/user/login}" class="nav-link px-2" style="color: #03C75A;">로그인</a></li>
-                            <li><a th:href="@{/user/signup}" class="nav-link px-2">회원가입</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-        </aside>
-        <div class="col-md-9">
-            <div class="row justify-content-center">
-                <div class="col-6 border" id="loginbox" style="text-align:center;">
-                    <div class="px-3 py-4" style="text-align: center; ">
-                        <h2>아이디 찾기</h2>
-                    </div>
-                    <div class="px-3 py-2" style="text-align:center;">
-                        <a href="/user/findid" style="color: black;">아이디 찾기</a> | <a href="/user/findpw"
-                                                                                     style="color: black;">비밀번호 찾기</a>
-                    </div>
-
-                    <div class="row px-3 py-2">
-                        <div class="col-12">
-                            <hr>
+    <div class="container" style="padding:0;">
+        <div class="row">
+            <aside class="col-md-3 px-4">
+                <div class="row">
+                    <div class="col-1"></div>
+                    <div class="col-8">
+                        <div class="panel">
+                            <ul class="list-group">
+                                <li><a th:href="@{/user/login}" class="nav-link px-2" style="color: #03C75A;">로그인</a>
+                                </li>
+                                <li><a th:href="@{/user/signup}" class="nav-link px-2">회원가입</a></li>
+                            </ul>
                         </div>
                     </div>
-
-                    <form th:action="@{/user/findid}" th:object="${user}" method="post" onsubmit="validateForm(event)">
-                        <div class="row px-3">
-                            <div class="col-12 mb-3 py-1">
-                                <input type="text" th:field="*{nickname}" class="form-control logininput" maxlength="20" minlength="4" placeholder="닉네임"/>
-                            </div>
-
-                            <div class="col-12 mb-3 py-1">
-                                <input type="text" th:field="*{email}" class="form-control logininput" placeholder="이메일"/>
-                            </div>
-
-                            <div class="col-12 pt-3 pb-4">
-                                <button type="submit" class="btn btn-primary btn-block"
-                                        style="background-color:grey; height:50px;">아이디 찾기
-                                </button>
-                            </div>
-
+                </div>
+            </aside>
+            <div class="col-md-9">
+                <div class="row justify-content-center">
+                    <div class="col-6 border" id="loginbox" style="text-align:center;">
+                        <div class="px-3 py-4" style="text-align: center; ">
+                            <h2>아이디 찾기</h2>
+                        </div>
+                        <div class="px-3 py-2" style="text-align:center;">
+                            <a href="/user/findid" style="color: black;">아이디 찾기</a> | <a href="/user/findpw"
+                                                                                         style="color: black;">비밀번호
+                            찾기</a>
                         </div>
 
-                    </form>
+                        <div class="row px-3 py-2">
+                            <div class="col-12">
+                                <hr>
+                            </div>
+                        </div>
+
+                        <form th:action="@{/user/findid}" th:object="${user}" method="post"
+                              onsubmit="validateForm(event)">
+                            <div class="row px-3">
+                                <div class="col-12 mb-3 py-1">
+                                    <input type="text" th:field="*{nickname}" class="form-control logininput"
+                                           maxlength="20" minlength="4" placeholder="닉네임"/>
+                                </div>
+
+                                <div class="col-12 mb-3 py-1">
+                                    <input type="text" th:field="*{email}" class="form-control logininput"
+                                           placeholder="이메일"/>
+                                </div>
+
+                                <div class="col-12 pt-3 pb-4">
+                                    <button type="submit" class="btn btn-primary btn-block"
+                                            style="background-color:grey; height:50px;">아이디 찾기
+                                    </button>
+                                </div>
+
+                            </div>
+
+                        </form>
 
 
+                    </div>
                 </div>
-            </div>
 
+            </div>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/user/findid.html
+++ b/src/main/resources/templates/user/findid.html
@@ -132,7 +132,7 @@
     <div class="row">
         <aside class="col-md-3 px-4">
             <div class="row">
-                <div class="col-3"></div>
+                <div class="col-1"></div>
                 <div class="col-6">
                     <div class="panel">
                         <ul class="list-group">

--- a/src/main/resources/templates/user/findid.html
+++ b/src/main/resources/templates/user/findid.html
@@ -106,19 +106,21 @@
 
 </style>
 <div class="jumbotron">
-    <div class="row">
-        <div class="col-md-3 px-4">
-            <h3>로그인</h3>
-        </div>
-        <div class="col-md-9">
-            <nav class="navbar navbar-expand-md">
-                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                    <li>-</li>
-                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                </ul>
-            </nav>
+    <div class="container">
+        <div class="row">
+            <div class="col-md-3 px-4">
+                <h3>로그인</h3>
+            </div>
+            <div class="col-md-9">
+                <nav class="navbar navbar-expand-md">
+                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                        <li>-</li>
+                        <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                        <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                        <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                    </ul>
+                </nav>
+            </div>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/user/findid.html
+++ b/src/main/resources/templates/user/findid.html
@@ -34,6 +34,7 @@
 
         // 폼 제출 전 이메일 형식을 검증하는 함수
         function validateForm(event) {
+            event.preventDefault();
 
             // (1/2) nickname available check
             const nickname = document.getElementById('nickname').value;

--- a/src/main/resources/templates/user/findid.html
+++ b/src/main/resources/templates/user/findid.html
@@ -124,58 +124,65 @@
         </div>
     </div>
 </div>
-<div class="row">
-    <aside class="col-md-3 px-4">
-        <div class="row">
-            <div class="col-3"></div>
-            <div class="col-6">
-                <div class="panel">
-                    <ul class="list-group">
-                        <li><a th:href="@{/user/login}" class="nav-link px-2" style="color: #03C75A;">로그인</a></li>
-                        <li><a th:href="@{/user/signup}" class="nav-link px-2">회원가입</a></li>
-                    </ul>
+<div class="container" style="padding:0;">
+    <div class="row">
+        <aside class="col-md-3 px-4">
+            <div class="row">
+                <div class="col-3"></div>
+                <div class="col-6">
+                    <div class="panel">
+                        <ul class="list-group">
+                            <li><a th:href="@{/user/login}" class="nav-link px-2" style="color: #03C75A;">로그인</a></li>
+                            <li><a th:href="@{/user/signup}" class="nav-link px-2">회원가입</a></li>
+                        </ul>
+                    </div>
                 </div>
             </div>
-        </div>
-    </aside>
-    <div class="col-md-9">
-        <div class="row justify-content-center">
-            <div class="col-6 border" id="loginbox" style="text-align:center;">
-                <div class="px-3 py-4" style="text-align: center; ">
-                    <h2>아이디 찾기</h2>
-                </div>
-                <div class="px-3 py-2" style="text-align:center;">
-                    <a href="/user/findid" style="color: black;">아이디 찾기</a> | <a href="/user/findpw" style="color: black;">비밀번호 찾기</a>
-                </div>
-
-                <div class="row px-3 py-2">
-                    <div class="col-12"><hr></div>
-                </div>
-
-                <form th:action="@{/user/findid}" th:object="${user}" method="post" onsubmit="validateForm(event)">
-                    <div class="row px-3">
-                        <div class="col-12 mb-3 py-1">
-                            <input type="text" th:field="*{nickname}" class="form-control logininput" maxlength="20" minlength="4" placeholder="닉네임"/>
-                        </div>
-
-                        <div class="col-12 mb-3 py-1">
-                            <input type="text" th:field="*{contactNumber}" class="form-control logininput" oninput="autoFormatPhoneNumber(this)" maxlength="13" placeholder="전화번호"/>
-                        </div>
-
-                        <div class="col-12 pt-3 pb-4">
-                            <button type="submit" class="btn btn-primary btn-block" style="background-color:grey; height:50px;">아이디 찾기</button>
-                        </div>
-
+        </aside>
+        <div class="col-md-9">
+            <div class="row justify-content-center">
+                <div class="col-6 border" id="loginbox" style="text-align:center;">
+                    <div class="px-3 py-4" style="text-align: center; ">
+                        <h2>아이디 찾기</h2>
+                    </div>
+                    <div class="px-3 py-2" style="text-align:center;">
+                        <a href="/user/findid" style="color: black;">아이디 찾기</a> | <a href="/user/findpw"
+                                                                                     style="color: black;">비밀번호 찾기</a>
                     </div>
 
-                </form>
+                    <div class="row px-3 py-2">
+                        <div class="col-12">
+                            <hr>
+                        </div>
+                    </div>
+
+                    <form th:action="@{/user/findid}" th:object="${user}" method="post" onsubmit="validateForm(event)">
+                        <div class="row px-3">
+                            <div class="col-12 mb-3 py-1">
+                                <input type="text" th:field="*{nickname}" class="form-control logininput" maxlength="20"
+                                       minlength="4" placeholder="닉네임"/>
+                            </div>
+
+                            <div class="col-12 mb-3 py-1">
+                                <input type="text" th:field="*{contactNumber}" class="form-control logininput"
+                                       oninput="autoFormatPhoneNumber(this)" maxlength="13" placeholder="전화번호"/>
+                            </div>
+
+                            <div class="col-12 pt-3 pb-4">
+                                <button type="submit" class="btn btn-primary btn-block"
+                                        style="background-color:grey; height:50px;">아이디 찾기
+                                </button>
+                            </div>
+
+                        </div>
+
+                    </form>
 
 
-
-
+                </div>
             </div>
-        </div>
 
+        </div>
     </div>
 </div>
 <div th:replace="common/footer.html"></div>

--- a/src/main/resources/templates/user/findid.html
+++ b/src/main/resources/templates/user/findid.html
@@ -38,30 +38,34 @@
             // (1/2) nickname available check
             const nickname = document.getElementById('nickname').value;
 
+            // (B2) 닉네임 검증 (공란O/형식-/자수O)
             if(!nickname) {
                 alert('닉네임을 입력해 주세요.');
                 return;
             }
-
-            if (nickname.length < 4) {
-                alert('닉네임의 글자수는 최소 4자입니다.');
+            if (nickname.length < 4 || nickname.length >20) {
+                alert('닉네임의 글자수는 4~20자를 허용합니다.');
                 return;
             }
 
             // (2/2) email available check
             const email = document.getElementById('email').value;
 
+            // (B4-1) 이메일 검증 (공란O/형식O/자수O)
             if(!email) {
                 alert('이메일을 입력해 주세요.');
                 return;
             }
-
-            // 이메일 검증
             if (!validateEmail(email)) {
                 alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
                 event.preventDefault(); // 폼 제출을 막음
                 return;
             }
+            if (email.length < 5 || email.length >100) {
+                alert('이메일의 허용범위는 최대 100자입니다.');
+                return;
+            }
+
     }
     </script>
 </head>

--- a/src/main/resources/templates/user/findpw.html
+++ b/src/main/resources/templates/user/findpw.html
@@ -114,7 +114,7 @@
     <div class="row">
         <aside class="col-md-3 px-4">
             <div class="row">
-                <div class="col-3"></div>
+                <div class="col-1"></div>
                 <div class="col-6">
                     <div class="panel">
                         <ul class="list-group">

--- a/src/main/resources/templates/user/findpw.html
+++ b/src/main/resources/templates/user/findpw.html
@@ -37,16 +37,24 @@
 
         // 폼 제출 전 이메일 형식을 검증하는 함수
         function validateForm(event) {
-
+            event.preventDefault();
             // (1/2) userId available check
             // 아이디는 영문과 숫자의 조합만 가능
             const userIdInput = document.querySelector('input[name="userId"]');
             const userId = userIdInput.value;
-
             const validIdPattern = /^[a-zA-Z0-9]+$/;
+
+            // (B0) 아이디 검증 (공란O/형식O/자수O)
+            if(!userId) {
+                alert('아이디를 입력해 주세요.');
+                return;
+            }
             if (!validIdPattern.test(userId)) {
                 alert('아이디는 영문과 숫자의 조합으로만 가능합니다.');
-                event.preventDefault(); // 폼 제출을 막음
+                return;
+            }
+            if (userId.length < 4 || userId.length >20) {
+                alert('아이디의 글자수는 4~20자를 허용합니다.');
                 return;
             }
 
@@ -54,10 +62,18 @@
             const emailInput = document.querySelector('input[name="email"]');
             const email = emailInput.value;
 
-            // 이메일 검증
+            // (B4-1) 이메일 검증 (공란O/형식O/자수O)
+            if(!email) {
+                alert('이메일을 입력해 주세요.');
+                return;
+            }
             if (!validateEmail(email)) {
                 alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
                 event.preventDefault(); // 폼 제출을 막음
+                return;
+            }
+            if (email.length < 5 || email.length >100) {
+                alert('이메일의 허용범위는 최대 100자입니다.');
                 return;
             }
     }

--- a/src/main/resources/templates/user/findpw.html
+++ b/src/main/resources/templates/user/findpw.html
@@ -37,15 +37,29 @@
 
         // 폼 제출 전 이메일 형식을 검증하는 함수
         function validateForm(event) {
-        const emailInput = document.querySelector('input[name="email"]');
-        const email = emailInput.value;
 
-        // 이메일 검증
-        if (!validateEmail(email)) {
-            alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
-            event.preventDefault(); // 폼 제출을 막음
-            return;
-        }
+            // (1/2) userId available check
+            // 아이디는 영문과 숫자의 조합만 가능
+            const userIdInput = document.querySelector('input[name="userId"]');
+            const userId = userIdInput.value;
+
+            const validIdPattern = /^[a-zA-Z0-9]+$/;
+            if (!validIdPattern.test(userId)) {
+                alert('아이디는 영문과 숫자의 조합으로만 가능합니다.');
+                event.preventDefault(); // 폼 제출을 막음
+                return;
+            }
+
+            // (2/2) email available check
+            const emailInput = document.querySelector('input[name="email"]');
+            const email = emailInput.value;
+
+            // 이메일 검증
+            if (!validateEmail(email)) {
+                alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
+                event.preventDefault(); // 폼 제출을 막음
+                return;
+            }
     }
     </script>
 </head>

--- a/src/main/resources/templates/user/findpw.html
+++ b/src/main/resources/templates/user/findpw.html
@@ -67,117 +67,140 @@
 
 <div th:replace="~{common/menubar}"></div>
 <style>
-    .jumbotron {
-    position : relative;
-    background-color : #EEEEEE;
+    html, body {
+        height: 100%;
+        margin: 0;
     }
-    .jumbotron .row {
-    position : absolute;
-    width : 100%;
-    bottom: 0%;
+    body {
+        display: flex;
+        flex-direction: column;
     }
-
-    #loginbox {
-    border-radius : 5%;
-    border-color : #F2F2F2;
+    .content-wrapper {
+        flex: 1 0 auto;
     }
-
-    .logininput {
-    background-color : #FCFCFC;
-    border : none;
-    height : 50px;
+    footer {
+        flex-shrink: 0;
     }
-
-    .logininput::placeholder {
-    color : #BBBBBB;
-    }
-
-     .nav-link {
-            color: #828282;
-    }
-    ul {
-  list-style: none;
-  padding-left : 0px;
-  }
 
 </style>
-<div class="jumbotron">
-    <div class="container">
-        <div class="row">
-            <div class="col-9">
-                <div class="row">
-                    <div class="col-md-3 px-4">
-                        <h3>로그인</h3>
-                    </div>
-                    <div class="col-md-9">
-                        <nav class="navbar navbar-expand-md">
-                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                                <li>-</li>
-                                <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                                <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                                <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                            </ul>
-                        </nav>
+<div class="content-wrapper">
+    <style>
+        .jumbotron {
+        position : relative;
+        background-color : #EEEEEE;
+        }
+        .jumbotron .row {
+        position : absolute;
+        width : 100%;
+        bottom: 0%;
+        }
+
+        #loginbox {
+        border-radius : 5%;
+        border-color : #F2F2F2;
+        }
+
+        .logininput {
+        background-color : #FCFCFC;
+        border : none;
+        height : 50px;
+        }
+
+        .logininput::placeholder {
+        color : #BBBBBB;
+        }
+
+         .nav-link {
+                color: #828282;
+        }
+        ul {
+      list-style: none;
+      padding-left : 0px;
+      }
+
+    </style>
+    <div class="jumbotron">
+        <div class="container">
+            <div class="row">
+                <div class="col-9">
+                    <div class="row">
+                        <div class="col-md-3 px-4">
+                            <h3>로그인</h3>
+                        </div>
+                        <div class="col-md-9">
+                            <nav class="navbar navbar-expand-md">
+                                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                    <li>-</li>
+                                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                                </ul>
+                            </nav>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
-<div class="container" style="padding:0;">
-    <div class="row">
-        <aside class="col-md-3 px-4">
-            <div class="row">
-                <div class="col-1"></div>
-                <div class="col-8">
-                    <div class="panel">
-                        <ul class="list-group">
-                            <li><a th:href="@{/user/login}" class="nav-link px-2" style="color: #03C75A;">로그인</a></li>
-                            <li><a th:href="@{/user/signup}" class="nav-link px-2">회원가입</a></li>
-                        </ul>
+    <div class="container" style="padding:0;">
+        <div class="row">
+            <aside class="col-md-3 px-4">
+                <div class="row">
+                    <div class="col-1"></div>
+                    <div class="col-8">
+                        <div class="panel">
+                            <ul class="list-group">
+                                <li><a th:href="@{/user/login}" class="nav-link px-2" style="color: #03C75A;">로그인</a>
+                                </li>
+                                <li><a th:href="@{/user/signup}" class="nav-link px-2">회원가입</a></li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </aside>
-        <div class="col-md-9">
-            <div class="row justify-content-center">
-                <div class="col-6 border" id="loginbox" style="text-align:center;">
-                    <div class="px-3 py-4" style="text-align: center; ">
-                        <h2>비밀번호 찾기</h2>
-                    </div>
-                    <div class="px-3 py-2" style="text-align:center;">
-                        <a href="/user/findid" style="color: black;">아이디 찾기</a> | <a href="/user/findpw"
-                                                                                     style="color: black;">비밀번호 찾기</a>
-                    </div>
-
-                    <div class="row px-3 py-2">
-                        <div class="col-12">
-                            <hr>
+            </aside>
+            <div class="col-md-9">
+                <div class="row justify-content-center">
+                    <div class="col-6 border" id="loginbox" style="text-align:center;">
+                        <div class="px-3 py-4" style="text-align: center; ">
+                            <h2>비밀번호 찾기</h2>
                         </div>
-                    </div>
-
-                    <form th:action="@{/user/findpw}" th:object="${user}" method="post" onsubmit="validateForm(event)">
-                        <div class="row px-3">
-                            <div class="col-12 mb-3 py-1">
-                                <input type="text" th:field="*{userId}" class="form-control logininput" maxlength="20"
-                                       minlength="4" placeholder="아이디"/>
-                            </div>
-
-                            <div class="col-12 mb-3 py-1">
-                                <input type="text" th:field="*{email}" class="form-control logininput"
-                                       placeholder="이메일"/>
-                            </div>
-
-                            <div class="col-12 pt-3 pb-4">
-                                <button type="submit" class="btn btn-primary btn-block"
-                                        style="background-color:grey; height:50px;">비밀번호 찾기
-                                </button>
-                            </div>
-
+                        <div class="px-3 py-2" style="text-align:center;">
+                            <a href="/user/findid" style="color: black;">아이디 찾기</a> | <a href="/user/findpw"
+                                                                                         style="color: black;">비밀번호
+                            찾기</a>
                         </div>
-                    </form>
+
+                        <div class="row px-3 py-2">
+                            <div class="col-12">
+                                <hr>
+                            </div>
+                        </div>
+
+                        <form th:action="@{/user/findpw}" th:object="${user}" method="post"
+                              onsubmit="validateForm(event)">
+                            <div class="row px-3">
+                                <div class="col-12 mb-3 py-1">
+                                    <input type="text" th:field="*{userId}" class="form-control logininput"
+                                           maxlength="20"
+                                           minlength="4" placeholder="아이디"/>
+                                </div>
+
+                                <div class="col-12 mb-3 py-1">
+                                    <input type="text" th:field="*{email}" class="form-control logininput"
+                                           placeholder="이메일"/>
+                                </div>
+
+                                <div class="col-12 pt-3 pb-4">
+                                    <button type="submit" class="btn btn-primary btn-block"
+                                            style="background-color:grey; height:50px;">비밀번호 찾기
+                                    </button>
+                                </div>
+
+                            </div>
+                        </form>
 
 
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/user/findpw.html
+++ b/src/main/resources/templates/user/findpw.html
@@ -106,54 +106,61 @@
         </div>
     </div>
 </div>
-<div class="row">
-    <aside class="col-md-3 px-4">
-        <div class="row">
-            <div class="col-3"></div>
-            <div class="col-6">
-                <div class="panel">
-                    <ul class="list-group">
-                        <li><a th:href="@{/user/login}" class="nav-link px-2" style="color: #03C75A;">로그인</a></li>
-                        <li><a th:href="@{/user/signup}" class="nav-link px-2">회원가입</a></li>
-                    </ul>
+<div class="container" style="padding:0;">
+    <div class="row">
+        <aside class="col-md-3 px-4">
+            <div class="row">
+                <div class="col-3"></div>
+                <div class="col-6">
+                    <div class="panel">
+                        <ul class="list-group">
+                            <li><a th:href="@{/user/login}" class="nav-link px-2" style="color: #03C75A;">로그인</a></li>
+                            <li><a th:href="@{/user/signup}" class="nav-link px-2">회원가입</a></li>
+                        </ul>
+                    </div>
                 </div>
             </div>
-        </div>
-    </aside>
-    <div class="col-md-9">
-        <div class="row justify-content-center">
-            <div class="col-6 border" id="loginbox" style="text-align:center;">
-                <div class="px-3 py-4" style="text-align: center; ">
-                    <h2>비밀번호 찾기</h2>
-                </div>
-                <div class="px-3 py-2" style="text-align:center;">
-                    <a href="/user/findid" style="color: black;">아이디 찾기</a> | <a href="/user/findpw" style="color: black;">비밀번호 찾기</a>
-                </div>
-
-                <div class="row px-3 py-2">
-                    <div class="col-12"><hr></div>
-                </div>
-
-                <form th:action="@{/user/findpw}" th:object="${user}" method="post" onsubmit="validateForm(event)">
-                    <div class="row px-3">
-                        <div class="col-12 mb-3 py-1">
-                            <input type="text" th:field="*{userId}" class="form-control logininput" maxlength="20" minlength="4" placeholder="아이디"/>
-                        </div>
-
-                        <div class="col-12 mb-3 py-1">
-                            <input type="text" th:field="*{email}" class="form-control logininput" placeholder="이메일"/>
-                        </div>
-
-                        <div class="col-12 pt-3 pb-4">
-                            <button type="submit" class="btn btn-primary btn-block" style="background-color:grey; height:50px;">비밀번호 찾기</button>
-                        </div>
-
+        </aside>
+        <div class="col-md-9">
+            <div class="row justify-content-center">
+                <div class="col-6 border" id="loginbox" style="text-align:center;">
+                    <div class="px-3 py-4" style="text-align: center; ">
+                        <h2>비밀번호 찾기</h2>
                     </div>
-                </form>
+                    <div class="px-3 py-2" style="text-align:center;">
+                        <a href="/user/findid" style="color: black;">아이디 찾기</a> | <a href="/user/findpw"
+                                                                                     style="color: black;">비밀번호 찾기</a>
+                    </div>
+
+                    <div class="row px-3 py-2">
+                        <div class="col-12">
+                            <hr>
+                        </div>
+                    </div>
+
+                    <form th:action="@{/user/findpw}" th:object="${user}" method="post" onsubmit="validateForm(event)">
+                        <div class="row px-3">
+                            <div class="col-12 mb-3 py-1">
+                                <input type="text" th:field="*{userId}" class="form-control logininput" maxlength="20"
+                                       minlength="4" placeholder="아이디"/>
+                            </div>
+
+                            <div class="col-12 mb-3 py-1">
+                                <input type="text" th:field="*{email}" class="form-control logininput"
+                                       placeholder="이메일"/>
+                            </div>
+
+                            <div class="col-12 pt-3 pb-4">
+                                <button type="submit" class="btn btn-primary btn-block"
+                                        style="background-color:grey; height:50px;">비밀번호 찾기
+                                </button>
+                            </div>
+
+                        </div>
+                    </form>
 
 
-
-
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/user/findpw.html
+++ b/src/main/resources/templates/user/findpw.html
@@ -90,18 +90,22 @@
 <div class="jumbotron">
     <div class="container">
         <div class="row">
-            <div class="col-md-3 px-4">
-                <h3>로그인</h3>
-            </div>
-            <div class="col-md-9">
-                <nav class="navbar navbar-expand-md">
-                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                        <li>-</li>
-                        <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                        <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                        <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                    </ul>
-                </nav>
+            <div class="col-9">
+                <div class="row">
+                    <div class="col-md-3 px-4">
+                        <h3>로그인</h3>
+                    </div>
+                    <div class="col-md-9">
+                        <nav class="navbar navbar-expand-md">
+                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                <li>-</li>
+                                <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                                <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                                <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                            </ul>
+                        </nav>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/user/findpw.html
+++ b/src/main/resources/templates/user/findpw.html
@@ -115,7 +115,7 @@
         <aside class="col-md-3 px-4">
             <div class="row">
                 <div class="col-1"></div>
-                <div class="col-6">
+                <div class="col-8">
                     <div class="panel">
                         <ul class="list-group">
                             <li><a th:href="@{/user/login}" class="nav-link px-2" style="color: #03C75A;">로그인</a></li>

--- a/src/main/resources/templates/user/findpw.html
+++ b/src/main/resources/templates/user/findpw.html
@@ -88,19 +88,21 @@
 
 </style>
 <div class="jumbotron">
-    <div class="row">
-        <div class="col-md-3 px-4">
-            <h3>로그인</h3>
-        </div>
-        <div class="col-md-9">
-            <nav class="navbar navbar-expand-md">
-                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                    <li>-</li>
-                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                </ul>
-            </nav>
+    <div class="container">
+        <div class="row">
+            <div class="col-md-3 px-4">
+                <h3>로그인</h3>
+            </div>
+            <div class="col-md-9">
+                <nav class="navbar navbar-expand-md">
+                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                        <li>-</li>
+                        <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                        <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                        <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                    </ul>
+                </nav>
+            </div>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/user/idfound.html
+++ b/src/main/resources/templates/user/idfound.html
@@ -91,7 +91,7 @@
         <aside class="col-md-3 px-4">
             <div class="row">
                 <div class="col-1"></div>
-                <div class="col-6">
+                <div class="col-8">
                     <div class="panel">
                         <ul class="list-group">
                             <li><a th:href="@{/user/login}" class="nav-link px-2" style="color: #03C75A;">로그인</a></li>

--- a/src/main/resources/templates/user/idfound.html
+++ b/src/main/resources/templates/user/idfound.html
@@ -29,125 +29,150 @@
 
 <div th:replace="~{common/menubar}"></div>
 <style>
-    .jumbotron {
-    position : relative;
-    background-color : #EEEEEE;
+    html, body {
+        height: 100%;
+        margin: 0;
     }
-    .jumbotron .row {
-    position : absolute;
-    width : 100%;
-    bottom: 0%;
+    body {
+        display: flex;
+        flex-direction: column;
     }
-
-    #loginbox {
-    border-radius : 5%;
-    border-color : #F2F2F2;
+    .content-wrapper {
+        flex: 1 0 auto;
     }
-
-    .logininput {
-    background-color : #FCFCFC;
-    border : none;
-    height : 50px;
+    footer {
+        flex-shrink: 0;
     }
-
-    .logininput::placeholder {
-    color : #BBBBBB;
-    }
-
-     .nav-link {
-            color: #828282;
-    }
-    ul {
-  list-style: none;
-  padding-left : 0px;
-  }
 
 </style>
-<div class="jumbotron">
-    <div class="container">
-        <div class="row">
-            <div class="col-9">
-                <div class="row">
-                    <div class="col-md-3 px-4">
-                        <h3>로그인</h3>
-                    </div>
-                    <div class="col-md-9">
-                        <nav class="navbar navbar-expand-md">
-                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                                <li>-</li>
-                                <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                                <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                                <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                            </ul>
-                        </nav>
+<div class="content-wrapper">
+    <style>
+        .jumbotron {
+        position : relative;
+        background-color : #EEEEEE;
+        }
+        .jumbotron .row {
+        position : absolute;
+        width : 100%;
+        bottom: 0%;
+        }
+
+        #loginbox {
+        border-radius : 5%;
+        border-color : #F2F2F2;
+        }
+
+        .logininput {
+        background-color : #FCFCFC;
+        border : none;
+        height : 50px;
+        }
+
+        .logininput::placeholder {
+        color : #BBBBBB;
+        }
+
+         .nav-link {
+                color: #828282;
+        }
+        ul {
+      list-style: none;
+      padding-left : 0px;
+      }
+
+    </style>
+    <div class="jumbotron">
+        <div class="container">
+            <div class="row">
+                <div class="col-9">
+                    <div class="row">
+                        <div class="col-md-3 px-4">
+                            <h3>로그인</h3>
+                        </div>
+                        <div class="col-md-9">
+                            <nav class="navbar navbar-expand-md">
+                                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                    <li>-</li>
+                                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                                </ul>
+                            </nav>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
-<div class="container" style="padding:0;">
-    <div class="row">
-        <aside class="col-md-3 px-4">
-            <div class="row">
-                <div class="col-1"></div>
-                <div class="col-8">
-                    <div class="panel">
-                        <ul class="list-group">
-                            <li><a th:href="@{/user/login}" class="nav-link px-2" style="color: #03C75A;">로그인</a></li>
-                            <li><a th:href="@{/user/signup}" class="nav-link px-2">회원가입</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-        </aside>
-        <div class="col-md-9">
-            <div class="row justify-content-center">
-                <div class="col-6 border" id="loginbox" style="text-align:center;">
-                    <div class="px-3 py-4" style="text-align: center; ">
-                        <h2>아이디 찾기</h2>
-                    </div>
-                    <div class="px-3 py-2" style="text-align:center;">
-                        <a href="/user/findid" style="color: black;">아이디 찾기</a> | <a href="/user/findpw" style="color: black;">비밀번호 찾기</a>
-                    </div>
-
-                    <div class="row px-3 py-2">
-                        <div class="col-12">
-                            <hr>
+    <div class="container" style="padding:0;">
+        <div class="row">
+            <aside class="col-md-3 px-4">
+                <div class="row">
+                    <div class="col-1"></div>
+                    <div class="col-8">
+                        <div class="panel">
+                            <ul class="list-group">
+                                <li><a th:href="@{/user/login}" class="nav-link px-2" style="color: #03C75A;">로그인</a>
+                                </li>
+                                <li><a th:href="@{/user/signup}" class="nav-link px-2">회원가입</a></li>
+                            </ul>
                         </div>
                     </div>
+                </div>
+            </aside>
+            <div class="col-md-9">
+                <div class="row justify-content-center">
+                    <div class="col-6 border" id="loginbox" style="text-align:center;">
+                        <div class="px-3 py-4" style="text-align: center; ">
+                            <h2>아이디 찾기</h2>
+                        </div>
+                        <div class="px-3 py-2" style="text-align:center;">
+                            <a href="/user/findid" style="color: black;">아이디 찾기</a> | <a href="/user/findpw"
+                                                                                         style="color: black;">비밀번호
+                            찾기</a>
+                        </div>
 
-                    <div th:if="${userId =='RETURNMESSAGE:ALREADYSIGNEDUPBYKAKAOAPI'}" style="padding: 20px 0;">
-                        회원님은<br>
-                        <span style="font-size: 1.5em;">카카오 로그인</span>을 통해<br>
-                        가입하셨어요.<br>
-                    </div>
-                    <div th:if="${userId =='RETURNMESSAGE:ALREADYSIGNEDUPBYNAVERAPI'}" style="padding: 20px 0;">
-                        회원님은<br>
-                        <span style="font-size: 1.5em;">네이버 로그인</span>을 통해<br>
-                        가입하셨어요.<br>
-                    </div>
-                    <div th:if="${userId != null && !(userId =='RETURNMESSAGE:ALREADYSIGNEDUPBYNAVERAPI' || userId =='RETURNMESSAGE:ALREADYSIGNEDUPBYKAKAOAPI')}" style="padding: 20px 0;">
-                        찾으시는 아이디는<br>
-                        <span th:text="${userId}" style="font-size: 1.5em;"></span><br>
-                        입니다.<br>
-                    </div>
-                    <div th:if="${userId != null}" class="col-12 pt-3 pb-4">
-                        <button type="submit" class="btn btn-primary btn-block" onclick="location.href='/user/login'"
-                                style="background-color:grey; height:50px;">로그인
-                        </button>
-                    </div>
+                        <div class="row px-3 py-2">
+                            <div class="col-12">
+                                <hr>
+                            </div>
+                        </div>
 
-                    <div th:if="${userId == null}" style="padding: 50px 0;">
-                        찾으시는 아이디가 존재하지 않습니다.<br>
-                    </div>
-                    <div th:if="${userId == null}" class="col-12 pt-3 pb-4">
-                        <button type="submit" class="btn btn-primary btn-block" onclick="location.href='/user/findid'"
-                                style="background-color:grey; height:50px;">다시 시도해보기
-                        </button>
-                    </div>
+                        <div th:if="${userId =='RETURNMESSAGE:ALREADYSIGNEDUPBYKAKAOAPI'}" style="padding: 20px 0;">
+                            회원님은<br>
+                            <span style="font-size: 1.5em;">카카오 로그인</span>을 통해<br>
+                            가입하셨어요.<br>
+                        </div>
+                        <div th:if="${userId =='RETURNMESSAGE:ALREADYSIGNEDUPBYNAVERAPI'}" style="padding: 20px 0;">
+                            회원님은<br>
+                            <span style="font-size: 1.5em;">네이버 로그인</span>을 통해<br>
+                            가입하셨어요.<br>
+                        </div>
+                        <div th:if="${userId != null && !(userId =='RETURNMESSAGE:ALREADYSIGNEDUPBYNAVERAPI' || userId =='RETURNMESSAGE:ALREADYSIGNEDUPBYKAKAOAPI')}"
+                             style="padding: 20px 0;">
+                            찾으시는 아이디는<br>
+                            <span th:text="${userId}" style="font-size: 1.5em;"></span><br>
+                            입니다.<br>
+                        </div>
+                        <div th:if="${userId != null}" class="col-12 pt-3 pb-4">
+                            <button type="submit" class="btn btn-primary btn-block"
+                                    onclick="location.href='/user/login'"
+                                    style="background-color:grey; height:50px;">로그인
+                            </button>
+                        </div>
+
+                        <div th:if="${userId == null}" style="padding: 50px 0;">
+                            찾으시는 아이디가 존재하지 않습니다.<br>
+                        </div>
+                        <div th:if="${userId == null}" class="col-12 pt-3 pb-4">
+                            <button type="submit" class="btn btn-primary btn-block"
+                                    onclick="location.href='/user/findid'"
+                                    style="background-color:grey; height:50px;">다시 시도해보기
+                            </button>
+                        </div>
 
 
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/user/idfound.html
+++ b/src/main/resources/templates/user/idfound.html
@@ -117,7 +117,17 @@
                         </div>
                     </div>
 
-                    <div th:if="${userId != null}" style="padding: 20px 0;">
+                    <div th:if="${userId =='RETURNMESSAGE:ALREADYSIGNEDUPBYKAKAOAPI'}" style="padding: 20px 0;">
+                        회원님은<br>
+                        <span style="font-size: 1.5em;">카카오 로그인</span>을 통해<br>
+                        가입하셨어요.<br>
+                    </div>
+                    <div th:if="${userId =='RETURNMESSAGE:ALREADYSIGNEDUPBYNAVERAPI'}" style="padding: 20px 0;">
+                        회원님은<br>
+                        <span style="font-size: 1.5em;">네이버 로그인</span>을 통해<br>
+                        가입하셨어요.<br>
+                    </div>
+                    <div th:if="${userId != null && !(userId =='RETURNMESSAGE:ALREADYSIGNEDUPBYNAVERAPI' || userId =='RETURNMESSAGE:ALREADYSIGNEDUPBYKAKAOAPI')}" style="padding: 20px 0;">
                         찾으시는 아이디는<br>
                         <span th:text="${userId}" style="font-size: 1.5em;"></span><br>
                         입니다.<br>

--- a/src/main/resources/templates/user/idfound.html
+++ b/src/main/resources/templates/user/idfound.html
@@ -82,49 +82,55 @@
         </div>
     </div>
 </div>
-<div class="row">
-    <aside class="col-md-3 px-4">
-        <div class="row">
-            <div class="col-3"></div>
-            <div class="col-6">
-                <div class="panel">
-                    <ul class="list-group">
-                        <li><a th:href="@{/user/login}" class="nav-link px-2" style="color: #03C75A;">로그인</a></li>
-                        <li><a th:href="@{/user/signup}" class="nav-link px-2">회원가입</a></li>
-                    </ul>
+<div class="container" style="padding:0;">
+    <div class="row">
+        <aside class="col-md-3 px-4">
+            <div class="row">
+                <div class="col-3"></div>
+                <div class="col-6">
+                    <div class="panel">
+                        <ul class="list-group">
+                            <li><a th:href="@{/user/login}" class="nav-link px-2" style="color: #03C75A;">로그인</a></li>
+                            <li><a th:href="@{/user/signup}" class="nav-link px-2">회원가입</a></li>
+                        </ul>
+                    </div>
                 </div>
             </div>
-        </div>
-    </aside>
-    <div class="col-md-9">
-        <div class="row justify-content-center">
-            <div class="col-6 border" id="loginbox" style="text-align:center;">
-                <div class="px-3 py-4" style="text-align: center; ">
-                    <h2>아이디 찾기</h2>
-                </div>
-                <div class="px-3 py-2" style="text-align:center;">
-                    <a href="/user/findid" style="color: black;">아이디 찾기</a> | <a href="/user/findpw" style="color: black;">비밀번호 찾기</a>
-                </div>
+        </aside>
+        <div class="col-md-9">
+            <div class="row justify-content-center">
+                <div class="col-6 border" id="loginbox" style="text-align:center;">
+                    <div class="px-3 py-4" style="text-align: center; ">
+                        <h2>아이디 찾기</h2>
+                    </div>
+                    <div class="px-3 py-2" style="text-align:center;">
+                        <a href="/user/findid" style="color: black;">아이디 찾기</a> | <a href="/user/findpw"
+                                                                                     style="color: black;">비밀번호 찾기</a>
+                    </div>
 
-                <div class="row px-3 py-2">
-                    <div class="col-12"><hr></div>
+                    <div class="row px-3 py-2">
+                        <div class="col-12">
+                            <hr>
+                        </div>
+                    </div>
+
+                    <div th:if="${userId != null}">
+                        찾으시는 아이디는<br>
+                        <span th:text="${userId}"></span><br>
+                        입니다.<br>
+                    </div>
+                    <div th:if="${userId == null}">
+                        찾으시는 아이디가 존재하지 않습니다.<br>
+                    </div>
+
+                    <div class="col-12 pt-3 pb-4">
+                        <button type="submit" class="btn btn-primary btn-block" onclick="location.href='/user/login'"
+                                style="background-color:grey; height:50px;">로그인
+                        </button>
+                    </div>
+
+
                 </div>
-
-                <div th:if="${userId != null}">
-                    찾으시는 아이디는<br>
-                    <span th:text="${userId}"></span><br>
-                    입니다.<br>
-                </div>
-                <div th:if="${userId == null}">
-                    찾으시는 아이디가 존재하지 않습니다.<br>
-                </div>
-
-                <div class="col-12 pt-3 pb-4">
-                    <button type="submit" class="btn btn-primary btn-block" onclick="location.href='/user/login'" style="background-color:grey; height:50px;">로그인</button>
-                </div>
-
-
-
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/user/idfound.html
+++ b/src/main/resources/templates/user/idfound.html
@@ -90,7 +90,7 @@
     <div class="row">
         <aside class="col-md-3 px-4">
             <div class="row">
-                <div class="col-3"></div>
+                <div class="col-1"></div>
                 <div class="col-6">
                     <div class="panel">
                         <ul class="list-group">

--- a/src/main/resources/templates/user/idfound.html
+++ b/src/main/resources/templates/user/idfound.html
@@ -108,8 +108,7 @@
                         <h2>아이디 찾기</h2>
                     </div>
                     <div class="px-3 py-2" style="text-align:center;">
-                        <a href="/user/findid" style="color: black;">아이디 찾기</a> | <a href="/user/findpw"
-                                                                                     style="color: black;">비밀번호 찾기</a>
+                        <a href="/user/findid" style="color: black;">아이디 찾기</a> | <a href="/user/findpw" style="color: black;">비밀번호 찾기</a>
                     </div>
 
                     <div class="row px-3 py-2">
@@ -118,18 +117,23 @@
                         </div>
                     </div>
 
-                    <div th:if="${userId != null}">
+                    <div th:if="${userId != null}" style="padding: 20px 0;">
                         찾으시는 아이디는<br>
-                        <span th:text="${userId}"></span><br>
+                        <span th:text="${userId}" style="font-size: 1.5em;"></span><br>
                         입니다.<br>
                     </div>
-                    <div th:if="${userId == null}">
-                        찾으시는 아이디가 존재하지 않습니다.<br>
-                    </div>
-
-                    <div class="col-12 pt-3 pb-4">
+                    <div th:if="${userId != null}" class="col-12 pt-3 pb-4">
                         <button type="submit" class="btn btn-primary btn-block" onclick="location.href='/user/login'"
                                 style="background-color:grey; height:50px;">로그인
+                        </button>
+                    </div>
+
+                    <div th:if="${userId == null}" style="padding: 50px 0;">
+                        찾으시는 아이디가 존재하지 않습니다.<br>
+                    </div>
+                    <div th:if="${userId == null}" class="col-12 pt-3 pb-4">
+                        <button type="submit" class="btn btn-primary btn-block" onclick="location.href='/user/findid'"
+                                style="background-color:grey; height:50px;">다시 시도해보기
                         </button>
                     </div>
 

--- a/src/main/resources/templates/user/idfound.html
+++ b/src/main/resources/templates/user/idfound.html
@@ -66,18 +66,22 @@
 <div class="jumbotron">
     <div class="container">
         <div class="row">
-            <div class="col-md-3 px-4">
-                <h3>로그인</h3>
-            </div>
-            <div class="col-md-9">
-                <nav class="navbar navbar-expand-md">
-                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                        <li>-</li>
-                        <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                        <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                        <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                    </ul>
-                </nav>
+            <div class="col-9">
+                <div class="row">
+                    <div class="col-md-3 px-4">
+                        <h3>로그인</h3>
+                    </div>
+                    <div class="col-md-9">
+                        <nav class="navbar navbar-expand-md">
+                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                <li>-</li>
+                                <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                                <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                                <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                            </ul>
+                        </nav>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/user/idfound.html
+++ b/src/main/resources/templates/user/idfound.html
@@ -64,19 +64,21 @@
 
 </style>
 <div class="jumbotron">
-    <div class="row">
-        <div class="col-md-3 px-4">
-            <h3>로그인</h3>
-        </div>
-        <div class="col-md-9">
-            <nav class="navbar navbar-expand-md">
-                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                    <li>-</li>
-                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                </ul>
-            </nav>
+    <div class="container">
+        <div class="row">
+            <div class="col-md-3 px-4">
+                <h3>로그인</h3>
+            </div>
+            <div class="col-md-9">
+                <nav class="navbar navbar-expand-md">
+                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                        <li>-</li>
+                        <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                        <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                        <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                    </ul>
+                </nav>
+            </div>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/user/insert.html
+++ b/src/main/resources/templates/user/insert.html
@@ -28,86 +28,107 @@
 <body>
 <div th:replace="~{common/menubar}"></div>
 <style>
-    .jumbotron {
-    position : relative;
-    background-color : #EEEEEE;
+    html, body {
+        height: 100%;
+        margin: 0;
     }
-    .jumbotron .row {
-    position : absolute;
-    width : 100%;
-    bottom: 0%;
+    body {
+        display: flex;
+        flex-direction: column;
+    }
+    .content-wrapper {
+        flex: 1 0 auto;
+    }
+    footer {
+        flex-shrink: 0;
     }
 
-     .nav-link {
-            color: #828282;
-    }
-    ul {
-  list-style: none;
-  padding-left : 0px;
-  }
 </style>
-<div class="jumbotron">
-    <div class="container">
-        <div class="row">
-            <div class="col-9">
-                <div class="row">
-                    <div class="col-md-3 px-4">
-                        <h3>회원 가입</h3>
-                    </div>
-                    <div class="col-md-9">
-                        <nav class="navbar navbar-expand-md">
-                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                                <li>-</li>
-                                <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                                <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                                <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                            </ul>
-                        </nav>
+<div class="content-wrapper">
+    <style>
+        .jumbotron {
+        position : relative;
+        background-color : #EEEEEE;
+        }
+        .jumbotron .row {
+        position : absolute;
+        width : 100%;
+        bottom: 0%;
+        }
+
+         .nav-link {
+                color: #828282;
+        }
+        ul {
+      list-style: none;
+      padding-left : 0px;
+      }
+    </style>
+    <div class="jumbotron">
+        <div class="container">
+            <div class="row">
+                <div class="col-9">
+                    <div class="row">
+                        <div class="col-md-3 px-4">
+                            <h3>회원 가입</h3>
+                        </div>
+                        <div class="col-md-9">
+                            <nav class="navbar navbar-expand-md">
+                                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                    <li>-</li>
+                                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                                </ul>
+                            </nav>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
-<div class="container" style="padding:0;">
-    <div class="row">
-        <aside class="col-md-3 px-4">
-            <div class="row">
-                <div class="col-1"></div>
-                <div class="col-8">
-                    <div class="panel">
-                        <ul class="list-group">
-                            <li><a th:href="@{/user/login}" class="nav-link px-2">로그인</a></li>
-                            <li><a th:href="@{/user/signup}" class="nav-link px-2" style="color: #03C75A;">회원가입</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-        </aside>
-        <div class="col-md-9">
-            <div class="row justify-content-center">
-                <div class="col-6 border" id="loginbox" style="text-align:center;">
-                    <div class="px-3 py-4" style="text-align: center; ">
-                        <h2>회원가입 완료</h2>
-                    </div>
-
-                    <div class="row px-3 py-2">
-                        <div class="col-12">
-                            <hr>
+    <div class="container" style="padding:0;">
+        <div class="row">
+            <aside class="col-md-3 px-4">
+                <div class="row">
+                    <div class="col-1"></div>
+                    <div class="col-8">
+                        <div class="panel">
+                            <ul class="list-group">
+                                <li><a th:href="@{/user/login}" class="nav-link px-2">로그인</a></li>
+                                <li><a th:href="@{/user/signup}" class="nav-link px-2" style="color: #03C75A;">회원가입</a>
+                                </li>
+                            </ul>
                         </div>
                     </div>
+                </div>
+            </aside>
+            <div class="col-md-9">
+                <div class="row justify-content-center">
+                    <div class="col-6 border" id="loginbox" style="text-align:center;">
+                        <div class="px-3 py-4" style="text-align: center; ">
+                            <h2>회원가입 완료</h2>
+                        </div>
 
-                    <div>
-                        성공적으로 가입이 완료되었습니다.<br>
-                        로그인하여 다양한 플랫폼을 누려 보세요!<br>
+                        <div class="row px-3 py-2">
+                            <div class="col-12">
+                                <hr>
+                            </div>
+                        </div>
+
+                        <div>
+                            성공적으로 가입이 완료되었습니다.<br>
+                            로그인하여 다양한 플랫폼을 누려 보세요!<br>
+                        </div>
+
+                        <div class="col-12 pt-3 pb-4">
+                            <button type="submit" class="btn btn-primary btn-block"
+                                    onclick="location.href='/user/login'"
+                                    style="background-color:grey; height:50px;">툰게더 로그인하기
+                            </button>
+                        </div>
+
                     </div>
-
-                    <div class="col-12 pt-3 pb-4">
-                        <button type="submit" class="btn btn-primary btn-block" onclick="location.href='/user/login'"
-                                style="background-color:grey; height:50px;">툰게더 로그인하기
-                        </button>
-                    </div>
-
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/user/insert.html
+++ b/src/main/resources/templates/user/insert.html
@@ -47,19 +47,21 @@
   }
 </style>
 <div class="jumbotron">
-    <div class="row">
-        <div class="col-md-3 px-4">
-            <h3>회원 가입</h3>
-        </div>
-        <div class="col-md-9">
-            <nav class="navbar navbar-expand-md">
-                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                    <li>-</li>
-                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                </ul>
-            </nav>
+    <div class="container">
+        <div class="row">
+            <div class="col-md-3 px-4">
+                <h3>회원 가입</h3>
+            </div>
+            <div class="col-md-9">
+                <nav class="navbar navbar-expand-md">
+                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                        <li>-</li>
+                        <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                        <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                        <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                    </ul>
+                </nav>
+            </div>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/user/insert.html
+++ b/src/main/resources/templates/user/insert.html
@@ -73,7 +73,7 @@
     <div class="row">
         <aside class="col-md-3 px-4">
             <div class="row">
-                <div class="col-3"></div>
+                <div class="col-1"></div>
                 <div class="col-6">
                     <div class="panel">
                         <ul class="list-group">

--- a/src/main/resources/templates/user/insert.html
+++ b/src/main/resources/templates/user/insert.html
@@ -74,7 +74,7 @@
         <aside class="col-md-3 px-4">
             <div class="row">
                 <div class="col-1"></div>
-                <div class="col-6">
+                <div class="col-8">
                     <div class="panel">
                         <ul class="list-group">
                             <li><a th:href="@{/user/login}" class="nav-link px-2">로그인</a></li>

--- a/src/main/resources/templates/user/insert.html
+++ b/src/main/resources/templates/user/insert.html
@@ -65,40 +65,46 @@
         </div>
     </div>
 </div>
-<div class="row">
-    <aside class="col-md-3 px-4">
-        <div class="row">
-            <div class="col-3"></div>
-            <div class="col-6">
-                <div class="panel">
-                    <ul class="list-group">
-                        <li><a th:href="@{/user/login}" class="nav-link px-2">로그인</a></li>
-                        <li><a th:href="@{/user/signup}" class="nav-link px-2" style="color: #03C75A;">회원가입</a></li>
-                    </ul>
+<div class="container" style="padding:0;">
+    <div class="row">
+        <aside class="col-md-3 px-4">
+            <div class="row">
+                <div class="col-3"></div>
+                <div class="col-6">
+                    <div class="panel">
+                        <ul class="list-group">
+                            <li><a th:href="@{/user/login}" class="nav-link px-2">로그인</a></li>
+                            <li><a th:href="@{/user/signup}" class="nav-link px-2" style="color: #03C75A;">회원가입</a></li>
+                        </ul>
+                    </div>
                 </div>
             </div>
-        </div>
-    </aside>
-    <div class="col-md-9">
-        <div class="row justify-content-center">
-            <div class="col-6 border" id="loginbox" style="text-align:center;">
-                <div class="px-3 py-4" style="text-align: center; ">
-                    <h2>회원가입 완료</h2>
-                </div>
+        </aside>
+        <div class="col-md-9">
+            <div class="row justify-content-center">
+                <div class="col-6 border" id="loginbox" style="text-align:center;">
+                    <div class="px-3 py-4" style="text-align: center; ">
+                        <h2>회원가입 완료</h2>
+                    </div>
 
-                <div class="row px-3 py-2">
-                    <div class="col-12"><hr></div>
-                </div>
+                    <div class="row px-3 py-2">
+                        <div class="col-12">
+                            <hr>
+                        </div>
+                    </div>
 
-                <div>
-                    성공적으로 가입이 완료되었습니다.<br>
-                    로그인하여 다양한 플랫폼을 누려 보세요!<br>
-                </div>
+                    <div>
+                        성공적으로 가입이 완료되었습니다.<br>
+                        로그인하여 다양한 플랫폼을 누려 보세요!<br>
+                    </div>
 
-                <div class="col-12 pt-3 pb-4">
-                    <button type="submit" class="btn btn-primary btn-block" onclick="location.href='/user/login'" style="background-color:grey; height:50px;">툰게더 로그인하기</button>
-                </div>
+                    <div class="col-12 pt-3 pb-4">
+                        <button type="submit" class="btn btn-primary btn-block" onclick="location.href='/user/login'"
+                                style="background-color:grey; height:50px;">툰게더 로그인하기
+                        </button>
+                    </div>
 
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/user/insert.html
+++ b/src/main/resources/templates/user/insert.html
@@ -49,18 +49,22 @@
 <div class="jumbotron">
     <div class="container">
         <div class="row">
-            <div class="col-md-3 px-4">
-                <h3>회원 가입</h3>
-            </div>
-            <div class="col-md-9">
-                <nav class="navbar navbar-expand-md">
-                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                        <li>-</li>
-                        <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                        <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                        <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                    </ul>
-                </nav>
+            <div class="col-9">
+                <div class="row">
+                    <div class="col-md-3 px-4">
+                        <h3>회원 가입</h3>
+                    </div>
+                    <div class="col-md-9">
+                        <nav class="navbar navbar-expand-md">
+                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                <li>-</li>
+                                <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                                <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                                <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                            </ul>
+                        </nav>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/user/login.html
+++ b/src/main/resources/templates/user/login.html
@@ -91,7 +91,7 @@
         <aside class="col-md-3 px-4">
             <div class="row">
                 <div class="col-1"></div>
-                <div class="col-6">
+                <div class="col-8">
                     <div class="panel">
                         <ul class="list-group">
                             <li><a th:href="@{/user/login}" class="nav-link px-2" style="color: #03C75A;">로그인</a></li>

--- a/src/main/resources/templates/user/login.html
+++ b/src/main/resources/templates/user/login.html
@@ -90,7 +90,7 @@
     <div class="row">
         <aside class="col-md-3 px-4">
             <div class="row">
-                <div class="col-3"></div>
+                <div class="col-1"></div>
                 <div class="col-6">
                     <div class="panel">
                         <ul class="list-group">

--- a/src/main/resources/templates/user/login.html
+++ b/src/main/resources/templates/user/login.html
@@ -64,85 +64,90 @@
 
 </style>
 <div class="jumbotron">
-    <div class="row">
-        <div class="col-md-3 px-4">
-            <h3>로그인</h3>
-        </div>
-        <div class="col-md-9">
-            <nav class="navbar navbar-expand-md">
-                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                    <li>-</li>
-                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                </ul>
-            </nav>
+    <div class="container">
+        <div class="row">
+            <div class="col-md-3 px-4">
+                <h3>로그인</h3>
+            </div>
+            <div class="col-md-9">
+                <nav class="navbar navbar-expand-md">
+                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                        <li>-</li>
+                        <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                        <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                        <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                    </ul>
+                </nav>
+            </div>
         </div>
     </div>
 </div>
-<div class="row">
-    <aside class="col-md-3 px-4">
-        <div class="row">
-            <div class="col-3"></div>
-            <div class="col-6">
-                <div class="panel">
-                    <ul class="list-group">
-                        <li><a th:href="@{/user/login}" class="nav-link px-2" style="color: #03C75A;">로그인</a></li>
-                        <li><a th:href="@{/user/signup}" class="nav-link px-2">회원가입</a></li>
-                    </ul>
+<div class="container" style="padding:0;">
+    <div class="row">
+        <aside class="col-md-3 px-4">
+            <div class="row">
+                <div class="col-3"></div>
+                <div class="col-6">
+                    <div class="panel">
+                        <ul class="list-group">
+                            <li><a th:href="@{/user/login}" class="nav-link px-2" style="color: #03C75A;">로그인</a></li>
+                            <li><a th:href="@{/user/signup}" class="nav-link px-2">회원가입</a></li>
+                        </ul>
+                    </div>
                 </div>
             </div>
-        </div>
-    </aside>
-    <div class="col-md-9">
-        <div class="row justify-content-center">
-            <div class="col-6 border" id="loginbox" style="text-align:center;">
-                <div class="px-3 py-4" style="text-align: center; ">
-                    <h2>로그인</h2>
-                </div>
-                <div class="px-3 py-2">
-                    <a href="https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=74obWxfUMfykv5opH_Xw&redirect_uri=http://localhost:8099/user/auth/naver/callback&state=test"><img src="/images/user/b_naver.png" class="img-fluid"></a>
-                </div>
-                <div class="px-3 py-2">
-                    <a href="https://kauth.kakao.com/oauth/authorize?client_id=87b870e71a148436e9f9c4a2aba3801d&redirect_uri=http://localhost:8099/user/auth/kakao/callback&response_type=code"><img src="/images/user/b_kakao.png" class="img-fluid"></a>
-                </div>
-
-                <div class="row px-3 py-2">
-                    <div class="col-5"><hr></div>
-                    <div class="col-2" style="text-align:center;">또는</div>
-                    <div class="col-5"><hr></div>
-                </div>
-
-                <form th:action="@{/user/login}" method="post">
-                    <div class="row px-3">
-                        <div class="col-12 mb-3 py-1">
-                            <input type="text" name="username" class="form-control logininput" maxlength="20" minlength="4" placeholder="아이디"/>
-                        </div>
-
-                        <div class="col-12 mb-3 py-1">
-                            <input type="password" name="password" class="form-control logininput" maxlength="30" minlength="8" placeholder="비밀번호"/>
-                        </div>
-
-                        <div class="col-12 pt-3 pb-4">
-                            <button type="submit" class="btn btn-primary btn-block" style="background-color:grey; height:50px;">로그인</button>
-                        </div>
-
-                        <div class="col-12 pt-2 pb-5" style="text-align:center;">
-                            <a href="/user/signup" style="color: black;">회원가입</a> | <a href="/user/findid" style="color: black;">ID/PW 찾기</a>
-                        </div>
-
+        </aside>
+        <div class="col-md-9">
+            <div class="row justify-content-center">
+                <div class="col-6 border" id="loginbox" style="text-align:center;">
+                    <div class="px-3 py-4" style="text-align: center; ">
+                        <h2>로그인</h2>
+                    </div>
+                    <div class="px-3 py-2">
+                        <a href="https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=74obWxfUMfykv5opH_Xw&redirect_uri=http://localhost:8099/user/auth/naver/callback&state=test"><img src="/images/user/b_naver.png" class="img-fluid"></a>
+                    </div>
+                    <div class="px-3 py-2">
+                        <a href="https://kauth.kakao.com/oauth/authorize?client_id=87b870e71a148436e9f9c4a2aba3801d&redirect_uri=http://localhost:8099/user/auth/kakao/callback&response_type=code"><img src="/images/user/b_kakao.png" class="img-fluid"></a>
                     </div>
 
+                    <div class="row px-3 py-2">
+                        <div class="col-5"><hr></div>
+                        <div class="col-2" style="text-align:center;">또는</div>
+                        <div class="col-5"><hr></div>
+                    </div>
 
-                </form>
+                    <form th:action="@{/user/login}" method="post">
+                        <div class="row px-3">
+                            <div class="col-12 mb-3 py-1">
+                                <input type="text" name="username" class="form-control logininput" maxlength="20" minlength="4" placeholder="아이디"/>
+                            </div>
+
+                            <div class="col-12 mb-3 py-1">
+                                <input type="password" name="password" class="form-control logininput" maxlength="30" minlength="8" placeholder="비밀번호"/>
+                            </div>
+
+                            <div class="col-12 pt-3 pb-4">
+                                <button type="submit" class="btn btn-primary btn-block" style="background-color:grey; height:50px;">로그인</button>
+                            </div>
+
+                            <div class="col-12 pt-2 pb-5" style="text-align:center;">
+                                <a href="/user/signup" style="color: black;">회원가입</a> | <a href="/user/findid" style="color: black;">ID/PW 찾기</a>
+                            </div>
+
+                        </div>
+
+
+                    </form>
 
 
 
+                </div>
             </div>
-        </div>
 
+        </div>
     </div>
 </div>
+
 <div th:replace="common/footer.html"></div>
 </body>
 </html>

--- a/src/main/resources/templates/user/login.html
+++ b/src/main/resources/templates/user/login.html
@@ -66,18 +66,22 @@
 <div class="jumbotron">
     <div class="container">
         <div class="row">
-            <div class="col-md-3 px-4">
-                <h3>로그인</h3>
-            </div>
-            <div class="col-md-9">
-                <nav class="navbar navbar-expand-md">
-                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                        <li>-</li>
-                        <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                        <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                        <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                    </ul>
-                </nav>
+            <div class="col-9">
+                <div class="row">
+                    <div class="col-md-3 px-4">
+                        <h3>로그인</h3>
+                    </div>
+                    <div class="col-md-9">
+                        <nav class="navbar navbar-expand-md">
+                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                <li>-</li>
+                                <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                                <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                                <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                            </ul>
+                        </nav>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/user/login.html
+++ b/src/main/resources/templates/user/login.html
@@ -29,125 +29,156 @@
 
 <div th:replace="~{common/menubar}"></div>
 <style>
-    .jumbotron {
-    position : relative;
-    background-color : #EEEEEE;
+    html, body {
+        height: 100%;
+        margin: 0;
     }
-    .jumbotron .row {
-    position : absolute;
-    width : 100%;
-    bottom: 0%;
+    body {
+        display: flex;
+        flex-direction: column;
     }
-
-    #loginbox {
-    border-radius : 5%;
-    border-color : #F2F2F2;
+    .content-wrapper {
+        flex: 1 0 auto;
     }
-
-    .logininput {
-    background-color : #FCFCFC;
-    border : none;
-    height : 50px;
+    footer {
+        flex-shrink: 0;
     }
-
-    .logininput::placeholder {
-    color : #BBBBBB;
-    }
-
-    .nav-link {
-            color: #828282;
-    }
-    ul {
-  list-style: none;
-  padding-left : 0px;
-  }
 
 </style>
-<div class="jumbotron">
-    <div class="container">
-        <div class="row">
-            <div class="col-9">
-                <div class="row">
-                    <div class="col-md-3 px-4">
-                        <h3>로그인</h3>
-                    </div>
-                    <div class="col-md-9">
-                        <nav class="navbar navbar-expand-md">
-                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                                <li>-</li>
-                                <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                                <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                                <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                            </ul>
-                        </nav>
+<div class="content-wrapper">
+    <style>
+        .jumbotron {
+        position : relative;
+        background-color : #EEEEEE;
+        }
+        .jumbotron .row {
+        position : absolute;
+        width : 100%;
+        bottom: 0%;
+        }
+
+        #loginbox {
+        border-radius : 5%;
+        border-color : #F2F2F2;
+        }
+
+        .logininput {
+        background-color : #FCFCFC;
+        border : none;
+        height : 50px;
+        }
+
+        .logininput::placeholder {
+        color : #BBBBBB;
+        }
+
+        .nav-link {
+                color: #828282;
+        }
+        ul {
+      list-style: none;
+      padding-left : 0px;
+      }
+
+    </style>
+    <div class="jumbotron">
+        <div class="container">
+            <div class="row">
+                <div class="col-9">
+                    <div class="row">
+                        <div class="col-md-3 px-4">
+                            <h3>로그인</h3>
+                        </div>
+                        <div class="col-md-9">
+                            <nav class="navbar navbar-expand-md">
+                                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                    <li>-</li>
+                                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                                </ul>
+                            </nav>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
-<div class="container" style="padding:0;">
-    <div class="row">
-        <aside class="col-md-3 px-4">
-            <div class="row">
-                <div class="col-1"></div>
-                <div class="col-8">
-                    <div class="panel">
-                        <ul class="list-group">
-                            <li><a th:href="@{/user/login}" class="nav-link px-2" style="color: #03C75A;">로그인</a></li>
-                            <li><a th:href="@{/user/signup}" class="nav-link px-2">회원가입</a></li>
-                        </ul>
+    <div class="container" style="padding:0;">
+        <div class="row">
+            <aside class="col-md-3 px-4">
+                <div class="row">
+                    <div class="col-1"></div>
+                    <div class="col-8">
+                        <div class="panel">
+                            <ul class="list-group">
+                                <li><a th:href="@{/user/login}" class="nav-link px-2" style="color: #03C75A;">로그인</a>
+                                </li>
+                                <li><a th:href="@{/user/signup}" class="nav-link px-2">회원가입</a></li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </aside>
-        <div class="col-md-9">
-            <div class="row justify-content-center">
-                <div class="col-6 border" id="loginbox" style="text-align:center;">
-                    <div class="px-3 py-4" style="text-align: center; ">
-                        <h2>로그인</h2>
-                    </div>
-                    <div class="px-3 py-2">
-                        <a href="https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=74obWxfUMfykv5opH_Xw&redirect_uri=http://localhost:8099/user/auth/naver/callback&state=test"><img src="/images/user/b_naver.png" class="img-fluid"></a>
-                    </div>
-                    <div class="px-3 py-2">
-                        <a href="https://kauth.kakao.com/oauth/authorize?client_id=87b870e71a148436e9f9c4a2aba3801d&redirect_uri=http://localhost:8099/user/auth/kakao/callback&response_type=code"><img src="/images/user/b_kakao.png" class="img-fluid"></a>
-                    </div>
-
-                    <div class="row px-3 py-2">
-                        <div class="col-5"><hr></div>
-                        <div class="col-2" style="text-align:center;">또는</div>
-                        <div class="col-5"><hr></div>
-                    </div>
-
-                    <form th:action="@{/user/login}" method="post">
-                        <div class="row px-3">
-                            <div class="col-12 mb-3 py-1">
-                                <input type="text" name="username" class="form-control logininput" maxlength="20" minlength="4" placeholder="아이디"/>
-                            </div>
-
-                            <div class="col-12 mb-3 py-1">
-                                <input type="password" name="password" class="form-control logininput" maxlength="30" minlength="8" placeholder="비밀번호"/>
-                            </div>
-
-                            <div class="col-12 pt-3 pb-4">
-                                <button type="submit" class="btn btn-primary btn-block" style="background-color:grey; height:50px;">로그인</button>
-                            </div>
-
-                            <div class="col-12 pt-2 pb-5" style="text-align:center;">
-                                <a href="/user/signup" style="color: black;">회원가입</a> | <a href="/user/findid" style="color: black;">ID/PW 찾기</a>
-                            </div>
-
+            </aside>
+            <div class="col-md-9">
+                <div class="row justify-content-center">
+                    <div class="col-6 border" id="loginbox" style="text-align:center;">
+                        <div class="px-3 py-4" style="text-align: center; ">
+                            <h2>로그인</h2>
+                        </div>
+                        <div class="px-3 py-2">
+                            <a href="https://nid.naver.com/oauth2.0/authorize?response_type=code&client_id=74obWxfUMfykv5opH_Xw&redirect_uri=http://localhost:8099/user/auth/naver/callback&state=test"><img
+                                    src="/images/user/b_naver.png" class="img-fluid"></a>
+                        </div>
+                        <div class="px-3 py-2">
+                            <a href="https://kauth.kakao.com/oauth/authorize?client_id=87b870e71a148436e9f9c4a2aba3801d&redirect_uri=http://localhost:8099/user/auth/kakao/callback&response_type=code"><img
+                                    src="/images/user/b_kakao.png" class="img-fluid"></a>
                         </div>
 
+                        <div class="row px-3 py-2">
+                            <div class="col-5">
+                                <hr>
+                            </div>
+                            <div class="col-2" style="text-align:center;">또는</div>
+                            <div class="col-5">
+                                <hr>
+                            </div>
+                        </div>
 
-                    </form>
+                        <form th:action="@{/user/login}" method="post">
+                            <div class="row px-3">
+                                <div class="col-12 mb-3 py-1">
+                                    <input type="text" name="username" class="form-control logininput" maxlength="20"
+                                           minlength="4" placeholder="아이디"/>
+                                </div>
+
+                                <div class="col-12 mb-3 py-1">
+                                    <input type="password" name="password" class="form-control logininput"
+                                           maxlength="30" minlength="8" placeholder="비밀번호"/>
+                                </div>
+
+                                <div class="col-12 pt-3 pb-4">
+                                    <button type="submit" class="btn btn-primary btn-block"
+                                            style="background-color:grey; height:50px;">로그인
+                                    </button>
+                                </div>
+
+                                <div class="col-12 pt-2 pb-5" style="text-align:center;">
+                                    <a href="/user/signup" style="color: black;">회원가입</a> | <a href="/user/findid"
+                                                                                               style="color: black;">ID/PW
+                                    찾기</a>
+                                </div>
+
+                            </div>
 
 
+                        </form>
 
+
+                    </div>
                 </div>
-            </div>
 
+            </div>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/user/mypage_cs.html
+++ b/src/main/resources/templates/user/mypage_cs.html
@@ -134,7 +134,7 @@
         <aside class="col-md-3 px-4">
             <div class="row">
                 <div class="col-1"></div>
-                <div class="col-6">
+                <div class="col-8">
                     <div class="panel">
                         <ul class="list-group">
                             <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>

--- a/src/main/resources/templates/user/mypage_cs.html
+++ b/src/main/resources/templates/user/mypage_cs.html
@@ -300,14 +300,69 @@
             <div class="row" style="color: #828282;">
                 <div class="col-11">
                     <div class="row">
-                        <div class="col-12">
+                        <div class="col-12 p-0">
+                            <style>
+                                .col-4 select {
+                                    border-radius: 50px;
+                                    text-align: center;
+                                }
+                                /* 검색창 스타일 */
+                                .search-container {
+                                    width: 300px;
+                                }
+
+                                .search-container select {
+                                    position: absolute;
+                                    left: 0%;
+                                    width: 30%;
+                                    height: 50px;
+                                    color: #828282;
+                                    font-size: 1rem;
+                                    border-radius: 50px 0 0 50px;
+                                    outline: none;
+                                }
+                                .search-container input[type="text"] {
+                                    position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
+                                    left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
+                                    width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
+                                    height: 50px;
+                                    padding: 10px 40px 10px 15px;
+                                    font-size: 1rem;
+                                    outline: none;
+                                    border-radius: 0 50px 50px 0;
+                                    transition: border-color 0.3s, background-color 0.3s;
+                                    color: #828282; /* 입력 텍스트 색상 변경 */
+                                }
+
+                                .search-container input[type="text"]::placeholder {
+                                    color: #BBBBBB; /* placeholder 색상 변경 */
+                                }
+
+
+                                .search-container button {
+                                    position: absolute;
+                                    right: 1rem;
+                                    top: 25px;
+                                    background: none;
+                                    transform: translateY(-50%);
+                                    border: none;
+                                    cursor: pointer;
+                                }
+
+                                .search-container button i {
+                                    color: #666;
+                                }
+
+                                .search-container button:hover i {
+                                    color: #03C75A;
+                                }
+                            </style>
                             <form id="filter-and-sort-form" th:action="@{/user/my/cs}" method="get">
-                                <div class="row">
-                                    <div class="col-7">
+                                <div class="row m-0">
+                                    <div class="col-7 p-0">
                                         <div class="row justify-content-start m-0">
-                                            <div class="col-4">
-                                                <!-- 검색 조건 -->
-                                                <label>
+                                            <div class="col-12 p-0">
+                                                <div class="search-container">
                                                     <select class="form-select px-3" name="searchBy">
                                                         <option value="title" th:selected="${searchBy == 'title'}">제목
                                                         </option>
@@ -315,16 +370,12 @@
                                                             내용
                                                         </option>
                                                     </select>
-                                                </label>
-                                            </div>
-                                            <div class="col-6">
-                                                <input class="form-control px-3" type="text" name="searchTerm"
-                                                       placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
-                                            </div>
-                                            <div class="col-2">
-                                                <!-- 검색 버튼 -->
-                                                <button id="searchbutton" type="submit" class="btn btn-primary">검색
-                                                </button>
+                                                    <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
+                                                    <!-- 검색 버튼 -->
+                                                    <button type="submit">
+                                                        <i class="fas fa-search"></i>
+                                                    </button>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>

--- a/src/main/resources/templates/user/mypage_cs.html
+++ b/src/main/resources/templates/user/mypage_cs.html
@@ -125,33 +125,34 @@
         </div>
     </div>
 </div>
-<div class="row">
-    <aside class="col-md-3 px-4">
-        <div class="row">
-            <div class="col-3"></div>
-            <div class="col-6">
-                <div class="panel">
-                    <ul class="list-group">
-                        <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
-                        <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-                        <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
-                        <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-                        <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                        <li><a th:href="@{/user/my/cs}" class="nav-link px-2" style="color: #03C75A;">나의 문의</a></li>
-                    </ul>
+<div class="container" style="padding:0;">
+    <div class="row">
+        <aside class="col-md-3 px-4">
+            <div class="row">
+                <div class="col-3"></div>
+                <div class="col-6">
+                    <div class="panel">
+                        <ul class="list-group">
+                            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
+                            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
+                            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2" style="color: #03C75A;">나의 문의</a></li>
+                        </ul>
+                    </div>
                 </div>
             </div>
-        </div>
-    </aside>
-<!--    <script>-->
-<!--        function toggleCheckboxValue() {-->
-<!--            const checkbox = document.getElementById('isToggledCheckbox');-->
-<!--            if(!checkbox.checked) checkbox.value = 'N';-->
-<!--            else checkbox.value = 'Y';-->
-<!--            document.getElementById('filter-form').submit();-->
-<!--        }-->
-<!--    </script>-->
-    <script> // toggle + sorting
+        </aside>
+        <!--    <script>-->
+        <!--        function toggleCheckboxValue() {-->
+        <!--            const checkbox = document.getElementById('isToggledCheckbox');-->
+        <!--            if(!checkbox.checked) checkbox.value = 'N';-->
+        <!--            else checkbox.value = 'Y';-->
+        <!--            document.getElementById('filter-form').submit();-->
+        <!--        }-->
+        <!--    </script>-->
+        <script> // toggle + sorting
         function updateCheckboxValueAndSubmit() {
             const checkbox = document.getElementById('isToggledCheckbox');
             const form = document.getElementById('filter-and-sort-form');
@@ -164,382 +165,448 @@
         function submitForm() {
             document.getElementById('filter-and-sort-form').submit();
         }
-    </script>
-    <style>
-        .form-select {
-        background-color : #FCFCFC;
-        border : none;
-        width : 100%;
-        height : 50px;
-        }
-        select {
-        color : #828282;
-        }
-        .form-control {
-        background-color : #FCFCFC;
-        border : none;
-        width : 100%;
-        height : 50px;
-        }
+        </script>
+        <style>
+            .form-select {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
+            }
+            select {
+            color : #828282;
+            }
+            .form-control {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
+            }
 
 
-        .form-control::placeholder {
-        color : #BBBBBB;
-        }
+            .form-control::placeholder {
+            color : #BBBBBB;
+            }
 
-        .date-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    background-color: #8E4B6E;
-    color: white;
-    border-radius: 10px;
-    text-align:center;
-    font-family: "Work Sans", sans-serif;
-}
+            .date-container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        background-color: #8E4B6E;
+        color: white;
+        border-radius: 10px;
+        text-align:center;
+        font-family: "Work Sans", sans-serif;
+    }
 
-.month {
-    font-size: 1.1rem; /* M의 크기를 설정 */
-    font-weight: 550;
-    line-height: 1;
-}
+    .month {
+        font-size: 1.1rem; /* M의 크기를 설정 */
+        font-weight: 550;
+        line-height: 1;
+    }
 
-.year {
-    font-size: 0.65rem; /* yyyy의 크기를 설정 */
-    font-weight: 400;
-}
-:root {
-    --background-color-light: #FFFFFF;
-    --text-color-light: #000000;
-    --toggle-background-light: #CCCCCC;
-    --toggle-ball-light: #FFFFFF;
+    .year {
+        font-size: 0.65rem; /* yyyy의 크기를 설정 */
+        font-weight: 400;
+    }
+    :root {
+        --background-color-light: #FFFFFF;
+        --text-color-light: #000000;
+        --toggle-background-light: #CCCCCC;
+        --toggle-ball-light: #FFFFFF;
 
-    --background-color-dark: #333333;
-    --text-color-dark: #FFFFFF;
-    --toggle-background-dark: #03C75A;
-    --toggle-ball-dark: #FFFFFF;
+        --background-color-dark: #333333;
+        --text-color-dark: #FFFFFF;
+        --toggle-background-dark: #03C75A;
+        --toggle-ball-dark: #FFFFFF;
 
-    --font-size-base: 32px; /* 기본 텍스트 크기 */
-    --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
-}
+        --font-size-base: 32px; /* 기본 텍스트 크기 */
+        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+    }
 
 
 
-.toggle-switch {
-    position: relative;
-    display: inline-block;
-    width: 62px; /* 너비 조정 */
-    height: 38px; /* 높이 조정 */
-}
+    .toggle-switch {
+        position: relative;
+        display: inline-block;
+        width: 62px; /* 너비 조정 */
+        height: 38px; /* 높이 조정 */
+    }
 
-.toggle-switch .checkbox {
-    opacity: 0;
-    width: 0;
-    height: 0;
-}
-#isToggledCheckbox {
-     opacity: 0;
+    .toggle-switch .checkbox {
+        opacity: 0;
         width: 0;
         height: 0;
-}
+    }
+    #isToggledCheckbox {
+         opacity: 0;
+            width: 0;
+            height: 0;
+    }
 
-.toggle-switch .label {
-    position: absolute;
-    cursor: pointer;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: var(--toggle-background-light);
-    transition: background-color 0.4s;
-    border-radius: 38px; /* 둥근 모서리 반경 조정 */
-}
+    .toggle-switch .label {
+        position: absolute;
+        cursor: pointer;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: var(--toggle-background-light);
+        transition: background-color 0.4s;
+        border-radius: 38px; /* 둥근 모서리 반경 조정 */
+    }
 
-.toggle-switch .label:before {
-    position: absolute;
-    content: "";
-    height: 30px; /* 내부 원 높이 조정 */
-    width: 30px; /* 내부 원 너비 조정 */
-    left: 2px;
-    bottom: 0px;
-    background-color: var(--toggle-ball-light);
-    transition: transform 0.4s;
-    border-radius: 50%;
-}
+    .toggle-switch .label:before {
+        position: absolute;
+        content: "";
+        height: 30px; /* 내부 원 높이 조정 */
+        width: 30px; /* 내부 원 너비 조정 */
+        left: 2px;
+        bottom: 0px;
+        background-color: var(--toggle-ball-light);
+        transition: transform 0.4s;
+        border-radius: 50%;
+    }
 
-.toggle-switch input:checked + .label {
-    background-color: var(--toggle-background-dark);
-}
+    .toggle-switch input:checked + .label {
+        background-color: var(--toggle-background-dark);
+    }
 
-.toggle-switch input:checked + .label:before {
-    transform: translateX(28px); /* 내부 원 이동 거리 조정 */
-}
+    .toggle-switch input:checked + .label:before {
+        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+    }
 
-         #absdiv {
-            position: relative;
-            top: 60px; /* Move down by 20px from its current position */
-            z-index : 1000;
-        }
+             #absdiv {
+                position: relative;
+                top: 60px; /* Move down by 20px from its current position */
+                z-index : 1000;
+            }
 
-        #searchbutton {
-            background-color: #828282;
-        }
-    </style>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+            #searchbutton {
+                background-color: #828282;
+            }
+        </style>
+        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+              rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+              rel="stylesheet">
 
-    <div class="col-md-9">
-        <div class="row" style="color: #828282;">
-            <div class="col-11">
-                <div class="row">
-                    <div class="col-12">
-                        <form id="filter-and-sort-form" th:action="@{/user/my/cs}" method="get">
-                            <div class="row">
-                                <div class="col-7">
-                                    <div class="row justify-content-start m-0">
-                                        <div class="col-4">
-                                            <!-- 검색 조건 -->
+        <div class="col-md-9">
+            <div class="row" style="color: #828282;">
+                <div class="col-11">
+                    <div class="row">
+                        <div class="col-12">
+                            <form id="filter-and-sort-form" th:action="@{/user/my/cs}" method="get">
+                                <div class="row">
+                                    <div class="col-7">
+                                        <div class="row justify-content-start m-0">
+                                            <div class="col-4">
+                                                <!-- 검색 조건 -->
+                                                <label>
+                                                    <select class="form-select px-3" name="searchBy">
+                                                        <option value="title" th:selected="${searchBy == 'title'}">제목
+                                                        </option>
+                                                        <option value="content" th:selected="${searchBy == 'content'}">
+                                                            내용
+                                                        </option>
+                                                    </select>
+                                                </label>
+                                            </div>
+                                            <div class="col-6">
+                                                <input class="form-control px-3" type="text" name="searchTerm"
+                                                       placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
+                                            </div>
+                                            <div class="col-2">
+                                                <!-- 검색 버튼 -->
+                                                <button id="searchbutton" type="submit" class="btn btn-primary">검색
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-1" style=""></div>
+                                    <div class="col-4">
+                                        <div class="row justify-content-end">
+                                            <!-- 정렬 또는 토글2 -->
                                             <label>
-                                                <select class="form-select px-3" name="searchBy">
-                                                    <option value="title" th:selected="${searchBy == 'title'}">제목</option>
-                                                    <option value="content" th:selected="${searchBy == 'content'}">내용</option>
+                                                <select class="form-select px-3" name="orderBy" onchange="submitForm()">
+                                                    <option value="recentedited"
+                                                            th:selected="${orderBy == 'recentedited'}">최근수정순
+                                                    </option>
+
+                                                    <option value="recent" th:selected="${orderBy == 'recent'}">최근작성순
+                                                    </option>
+                                                    <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순
+                                                    </option>
+
+                                                    <option value="views" th:selected="${orderBy == 'views'}">조회수높은순
+                                                    </option>
+                                                    <option value="title" th:selected="${orderBy == 'title'}">제목가나다순
+                                                    </option>
                                                 </select>
                                             </label>
                                         </div>
-                                        <div class="col-6">
-                                            <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
-                                        </div>
-                                        <div class="col-2">
-                                            <!-- 검색 버튼 -->
-                                            <button id="searchbutton" type="submit" class="btn btn-primary">검색</button>
-                                        </div>
                                     </div>
-                                </div>
-                                <div class="col-1" style=""></div>
-                                <div class="col-4">
-                                    <div class="row justify-content-end">
-                                        <!-- 정렬 또는 토글2 -->
-                                        <label>
-                                            <select class="form-select px-3" name="orderBy" onchange="submitForm()">
-                                                <option value="recentedited" th:selected="${orderBy == 'recentedited'}">최근수정순</option>
-
-                                                <option value="recent" th:selected="${orderBy == 'recent'}">최근작성순</option>
-                                                <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>
-
-                                                <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>
-                                                <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>
-                                            </select>
-                                        </label>
-                                    </div>
-                                </div>
-                            </div> <!--검색, 소팅 (토글X)-->
-                            <div class="row justify-content-around">
-                                <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                <div class="col-3" style="padding: 0 1.2rem;">
-                                    <div id="absdiv" class="row justify-content-end">
-                                        <div class="col-3">
-                                            <div class="toggle-switch">
-                                                <!-- 정렬 또는 토글1 -->
-                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">
-                                                <label for="isToggledCheckbox" class="label">
-                                                    <div class="ball"></div>
-                                                </label>
+                                </div> <!--검색, 소팅 (토글X)-->
+                                <div class="row justify-content-around">
+                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                    <div class="col-3" style="padding: 0 1.2rem;">
+                                        <div id="absdiv" class="row justify-content-end">
+                                            <div class="col-3">
+                                                <div class="toggle-switch">
+                                                    <!-- 정렬 또는 토글1 -->
+                                                    <input type="checkbox" name="isToggled" id="isToggledCheckbox"
+                                                           value="Y" th:checked="${isToggled == 'Y'}"
+                                                           onchange="updateCheckboxValueAndSubmit()">
+                                                    <label for="isToggledCheckbox" class="label">
+                                                        <div class="ball"></div>
+                                                    </label>
+                                                </div>
+                                            </div>
+                                            <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">
+                                                답변완료
                                             </div>
                                         </div>
-                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">답변완료</div>
                                     </div>
-                                </div>
-                            </div> <!--토글-->
-                        </form>
-                    </div>
-                </div>
-                <div class="row justify-content-around">
-                    <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
-                        <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
-                            <div class="col-3 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:each="myCsQuestion, iterStat : ${myCsQuestions}" th:attr="data-href=@{/cs/questionDetail/{csQNo}(csQNo=${myCsQuestion.csQNo})}"
-                             th:if="${iterStat.index < 3}">
-                                <div class="row justify-content-center">
-                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                        <div class="date-container px-2 py-1">
-                                            <div class="month" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myCsQuestion.createdDate)}"></div>
-                                            <div class="year" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myCsQuestion.createdDate)}"></div>
-                                        </div>
-                                    </div>
-
-                                    <div class="col-4" style="color: white;" th:text="${myCsQuestion.csQNo}">닉네임</div>
-                                    <div class="col-4" style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD;" th:text="${myCsQuestion.formattedCreatedDate}">시간</div>
-                                </div>
-                                <div class="row justify-content-center">
-                                    <div class="col-10" style="color: white;" th:text="${myCsQuestion.csQNo}">사진</div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" th:text="${myCsQuestion.csQTitle}">이름</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${myCsQuestion.csQContent}">내용</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                </div>
-
-                            </div>
-                            <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
-                            <div class="col-3" th:if="${myCsQuestions.size() == 0}"></div>
-                            <div class="col-3" th:if="${myCsQuestions.size() == 0 || myCsQuestions.size() == 1}"></div>
-                            <div class="col-3" th:if="${myCsQuestions.size() == 0 || myCsQuestions.size() == 1 || myCsQuestions.size() == 2}"></div>
-                        </div>
-                        <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
-                            <div class="col-3 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:each="myCsQuestion, iterStat : ${myCsQuestions}" th:attr="data-href=@{/cs/questionDetail/{csQNo}(csQNo=${myCsQuestion.csQNo})}" th:if="${iterStat.index >= 3}">
-                                <div class="row justify-content-center">
-                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                        <div class="date-container px-2 py-1">
-                                            <div class="month" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myCsQuestion.createdDate)}"></div>
-                                            <div class="year" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myCsQuestion.createdDate)}"></div>
-                                        </div>
-                                    </div>
-
-                                    <div class="col-4" style="color: white;" th:text="${myCsQuestion.csQNo}">닉네임</div>
-                                    <div class="col-4" style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD;" th:text="${myCsQuestion.formattedCreatedDate}">시간</div>
-                                </div>
-                                <div class="row justify-content-center">
-                                    <div class="col-10" style="color: white;" th:text="${myCsQuestion.csQNo}">사진</div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" th:text="${myCsQuestion.csQTitle}">이름</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${myCsQuestion.csQContent}">내용</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                </div>
-
-                            </div>
-
-                            <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
-                            <div class="col-3" th:if="${myCsQuestions.size() <= 3}"></div>
-                            <div class="col-3" th:if="${myCsQuestions.size() <= 3 || myCsQuestions.size() == 4}"></div>
-                            <div class="col-3" th:if="${myCsQuestions.size() <= 3 || myCsQuestions.size() == 4 || myCsQuestions.size() == 5}"></div>
+                                </div> <!--토글-->
+                            </form>
                         </div>
                     </div>
-                </div>
-                <div class="row justify-content-center">
-                    <!-- 페이징 -->
-                    <th:block th:if="${pages != null}">
-                        <div class="d-flex justify-content-center">
-                            <div class="btn-group">
-                                <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/cs(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-                                        <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                                    </svg>
-                                </button>
-                                <th:block th:each="p : ${#numbers.sequence(1, pages)}">
-                                    <button type="button" class="btn btn-sm me-2 pages"
-                                            th:text="${p}" th:onclick="|location.href='@{/user/my/cs(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
-                                </th:block>
-                                <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/cs(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-                                        <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
-                                    </svg>
-                                </button>
+                    <div class="row justify-content-around">
+                        <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
+                            <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
+                                <div class="col-3 clickable-row"
+                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                     th:each="myCsQuestion, iterStat : ${myCsQuestions}"
+                                     th:attr="data-href=@{/cs/questionDetail/{csQNo}(csQNo=${myCsQuestion.csQNo})}"
+                                     th:if="${iterStat.index < 3}">
+                                    <div class="row justify-content-center">
+                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                             style="aspect-ratio: 1; border-radius: 5px;">
+                                            <div class="date-container px-2 py-1">
+                                                <div class="month"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myCsQuestion.createdDate)}"></div>
+                                                <div class="year"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myCsQuestion.createdDate)}"></div>
+                                            </div>
+                                        </div>
+
+                                        <div class="col-4" style="color: white;" th:text="${myCsQuestion.csQNo}">닉네임
+                                        </div>
+                                        <div class="col-4"
+                                             style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD;"
+                                             th:text="${myCsQuestion.formattedCreatedDate}">시간
+                                        </div>
+                                    </div>
+                                    <div class="row justify-content-center">
+                                        <div class="col-10" style="color: white;" th:text="${myCsQuestion.csQNo}">사진
+                                        </div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                             th:text="${myCsQuestion.csQTitle}">이름
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                             th:text="${myCsQuestion.csQContent}">내용
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                    </div>
+
+                                </div>
+                                <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
+                                <div class="col-3" th:if="${myCsQuestions.size() == 0}"></div>
+                                <div class="col-3"
+                                     th:if="${myCsQuestions.size() == 0 || myCsQuestions.size() == 1}"></div>
+                                <div class="col-3"
+                                     th:if="${myCsQuestions.size() == 0 || myCsQuestions.size() == 1 || myCsQuestions.size() == 2}"></div>
+                            </div>
+                            <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
+                                <div class="col-3 clickable-row"
+                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                     th:each="myCsQuestion, iterStat : ${myCsQuestions}"
+                                     th:attr="data-href=@{/cs/questionDetail/{csQNo}(csQNo=${myCsQuestion.csQNo})}"
+                                     th:if="${iterStat.index >= 3}">
+                                    <div class="row justify-content-center">
+                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                             style="aspect-ratio: 1; border-radius: 5px;">
+                                            <div class="date-container px-2 py-1">
+                                                <div class="month"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myCsQuestion.createdDate)}"></div>
+                                                <div class="year"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myCsQuestion.createdDate)}"></div>
+                                            </div>
+                                        </div>
+
+                                        <div class="col-4" style="color: white;" th:text="${myCsQuestion.csQNo}">닉네임
+                                        </div>
+                                        <div class="col-4"
+                                             style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD;"
+                                             th:text="${myCsQuestion.formattedCreatedDate}">시간
+                                        </div>
+                                    </div>
+                                    <div class="row justify-content-center">
+                                        <div class="col-10" style="color: white;" th:text="${myCsQuestion.csQNo}">사진
+                                        </div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                             th:text="${myCsQuestion.csQTitle}">이름
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                             th:text="${myCsQuestion.csQContent}">내용
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                    </div>
+
+                                </div>
+
+                                <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
+                                <div class="col-3" th:if="${myCsQuestions.size() <= 3}"></div>
+                                <div class="col-3"
+                                     th:if="${myCsQuestions.size() <= 3 || myCsQuestions.size() == 4}"></div>
+                                <div class="col-3"
+                                     th:if="${myCsQuestions.size() <= 3 || myCsQuestions.size() == 4 || myCsQuestions.size() == 5}"></div>
                             </div>
                         </div>
-                    </th:block>
-                </div>
-            </div><!--테이블 및 페이징 포함-->
+                    </div>
+                    <div class="row justify-content-center">
+                        <!-- 페이징 -->
+                        <th:block th:if="${pages != null}">
+                            <div class="d-flex justify-content-center">
+                                <div class="btn-group">
+                                    <button type="button" class="btn btn-sm previous"
+                                            th:onclick="|location.href='@{/user/my/cs(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
+                                            th:disabled="${currentPage == 1}">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                             fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+                                            <path fill-rule="evenodd"
+                                                  d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                                        </svg>
+                                    </button>
+                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">
+                                        <button type="button" class="btn btn-sm me-2 pages"
+                                                th:text="${p}"
+                                                th:onclick="|location.href='@{/user/my/cs(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
+                                    </th:block>
+                                    <button type="button" class="btn btn-sm  next"
+                                            th:onclick="|location.href='@{/user/my/cs(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
+                                            th:disabled="${currentPage == pages}">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                             fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+                                            <path fill-rule="evenodd"
+                                                  d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                                        </svg>
+                                    </button>
+                                </div>
+                            </div>
+                        </th:block>
+                    </div>
+                </div><!--테이블 및 페이징 포함-->
+            </div> <!--본화면-->
         </div> <!--본화면-->
-    </div> <!--본화면-->
 
 
-    <!--수정중 -->
-<!--    <div class="col-md-9">-->
-<!--        <div class="review-list">-->
-<!--            <h2>나의 문의</h2>-->
-<!--            <form id="filter-and-sort-form" th:action="@{/user/my/cs}" method="get">-->
-<!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
-<!--                <label>-->
-<!--                    <select name="searchBy">-->
-<!--                        <option value="title" th:selected="${searchBy == 'title'}">제목</option>-->
-<!--                        <option value="content" th:selected="${searchBy == 'content'}">내용</option>-->
-<!--                    </select>-->
-<!--                </label>-->
-<!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
+        <!--수정중 -->
+        <!--    <div class="col-md-9">-->
+        <!--        <div class="review-list">-->
+        <!--            <h2>나의 문의</h2>-->
+        <!--            <form id="filter-and-sort-form" th:action="@{/user/my/cs}" method="get">-->
+        <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
+        <!--                <label>-->
+        <!--                    <select name="searchBy">-->
+        <!--                        <option value="title" th:selected="${searchBy == 'title'}">제목</option>-->
+        <!--                        <option value="content" th:selected="${searchBy == 'content'}">내용</option>-->
+        <!--                    </select>-->
+        <!--                </label>-->
+        <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
 
-<!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
-<!--                <button type="submit">검색</button>-->
+        <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
+        <!--                <button type="submit">검색</button>-->
 
-<!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
-<!--                <label>-->
-<!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">답변완료-->
-<!--                </label>-->
-<!--                <label>-->
-<!--                    <select name="orderBy" onchange="submitForm()">-->
-<!--                        <option value="recentedited" th:selected="${orderBy == 'recentedited'}">최근수정순</option>-->
+        <!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
+        <!--                <label>-->
+        <!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">답변완료-->
+        <!--                </label>-->
+        <!--                <label>-->
+        <!--                    <select name="orderBy" onchange="submitForm()">-->
+        <!--                        <option value="recentedited" th:selected="${orderBy == 'recentedited'}">최근수정순</option>-->
 
-<!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최근작성순</option>-->
-<!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
+        <!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최근작성순</option>-->
+        <!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
 
-<!--                        <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>-->
-<!--                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
-<!--                    </select>-->
-<!--                </label>-->
-<!--            </form>-->
-<!--&lt;!&ndash;            <form id="filter-form" th:action="@{/user/my/cs}" method="get">&ndash;&gt;-->
-<!--&lt;!&ndash;                <label>&ndash;&gt;-->
-<!--&lt;!&ndash;                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="toggleCheckboxValue()">답변완료&ndash;&gt;-->
-<!--&lt;!&ndash;                </label>&ndash;&gt;-->
-<!--&lt;!&ndash;            </form>&ndash;&gt;-->
-<!--            <table>-->
-<!--                <thead>-->
-<!--                <tr>-->
-<!--                    <th>문의글 번호</th>-->
-<!--                    <th>문의글 제목</th>-->
-<!--                    <th>문의글 내용</th>-->
-<!--                    <th>문의글 작성자</th>-->
-<!--                    <th>문의 카테고리 코드</th>-->
-<!--                    <th>문의 상태 코드</th>-->
-<!--                    <th>문의글 조회수</th>-->
-<!--                    <th>문의 작성일자</th>-->
-<!--                    <th>문의 수정일자</th>-->
-<!--                </tr>-->
-<!--                </thead>-->
-<!--                <tbody>-->
-<!--                <tr th:each="myCsQuestion : ${myCsQuestions}" class="clickable-row" th:attr="data-href=@{/cs/questionDetail/{id}(id=${myCsQuestion.csQNo})}">-->
-<!--                    <td th:text="${myCsQuestion.csQNo}">문의글 번호</td>-->
-<!--                    <td th:text="${myCsQuestion.csQTitle}">문의글 제목</td>-->
-<!--                    <td th:text="${myCsQuestion.csQContent}">문의글 내용</td>-->
-<!--                    <td th:text="${myCsQuestion.csQWriterNo}">문의글 작성자</td>-->
-<!--                    <td th:text="${myCsQuestion.csQCategoryCode}">문의 카테고리 코드</td>-->
-<!--                    <td th:text="${myCsQuestion.csQStatusCode}">문의 상태 코드</td>-->
-<!--                    <td th:text="${myCsQuestion.csQViewCount}">문의글 조회수</td>-->
-<!--                    <td th:text="${myCsQuestion.createdDate}">문의 작성일자</td>-->
-<!--                    <td th:text="${myCsQuestion.modifiedDate}">문의 수정일자</td>-->
-<!--                </tr>-->
-<!--                </tbody>-->
-<!--            </table>-->
-<!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
-<!--            <th:block th:if="${pages != null}">-->
-<!--                <div class="d-flex justify-content-center">-->
-<!--                    <div class="btn-group">-->
-<!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/cs(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
-<!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
-<!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
-<!--                            </svg>-->
-<!--                        </button>-->
-<!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
-<!--                            <button type="button" class="btn btn-sm me-2 pages"-->
-<!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/cs(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
-<!--                        </th:block>-->
-<!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/cs(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
-<!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
-<!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
-<!--                            </svg>-->
-<!--                        </button>-->
-<!--                    </div>-->
-<!--                </div>-->
-<!--            </th:block>-->
-<!--        </div>-->
-<!--    </div>-->
+        <!--                        <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>-->
+        <!--                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
+        <!--                    </select>-->
+        <!--                </label>-->
+        <!--            </form>-->
+        <!--&lt;!&ndash;            <form id="filter-form" th:action="@{/user/my/cs}" method="get">&ndash;&gt;-->
+        <!--&lt;!&ndash;                <label>&ndash;&gt;-->
+        <!--&lt;!&ndash;                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="toggleCheckboxValue()">답변완료&ndash;&gt;-->
+        <!--&lt;!&ndash;                </label>&ndash;&gt;-->
+        <!--&lt;!&ndash;            </form>&ndash;&gt;-->
+        <!--            <table>-->
+        <!--                <thead>-->
+        <!--                <tr>-->
+        <!--                    <th>문의글 번호</th>-->
+        <!--                    <th>문의글 제목</th>-->
+        <!--                    <th>문의글 내용</th>-->
+        <!--                    <th>문의글 작성자</th>-->
+        <!--                    <th>문의 카테고리 코드</th>-->
+        <!--                    <th>문의 상태 코드</th>-->
+        <!--                    <th>문의글 조회수</th>-->
+        <!--                    <th>문의 작성일자</th>-->
+        <!--                    <th>문의 수정일자</th>-->
+        <!--                </tr>-->
+        <!--                </thead>-->
+        <!--                <tbody>-->
+        <!--                <tr th:each="myCsQuestion : ${myCsQuestions}" class="clickable-row" th:attr="data-href=@{/cs/questionDetail/{id}(id=${myCsQuestion.csQNo})}">-->
+        <!--                    <td th:text="${myCsQuestion.csQNo}">문의글 번호</td>-->
+        <!--                    <td th:text="${myCsQuestion.csQTitle}">문의글 제목</td>-->
+        <!--                    <td th:text="${myCsQuestion.csQContent}">문의글 내용</td>-->
+        <!--                    <td th:text="${myCsQuestion.csQWriterNo}">문의글 작성자</td>-->
+        <!--                    <td th:text="${myCsQuestion.csQCategoryCode}">문의 카테고리 코드</td>-->
+        <!--                    <td th:text="${myCsQuestion.csQStatusCode}">문의 상태 코드</td>-->
+        <!--                    <td th:text="${myCsQuestion.csQViewCount}">문의글 조회수</td>-->
+        <!--                    <td th:text="${myCsQuestion.createdDate}">문의 작성일자</td>-->
+        <!--                    <td th:text="${myCsQuestion.modifiedDate}">문의 수정일자</td>-->
+        <!--                </tr>-->
+        <!--                </tbody>-->
+        <!--            </table>-->
+        <!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
+        <!--            <th:block th:if="${pages != null}">-->
+        <!--                <div class="d-flex justify-content-center">-->
+        <!--                    <div class="btn-group">-->
+        <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/cs(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
+        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
+        <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
+        <!--                            </svg>-->
+        <!--                        </button>-->
+        <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
+        <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
+        <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/cs(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
+        <!--                        </th:block>-->
+        <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/cs(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
+        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
+        <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
+        <!--                            </svg>-->
+        <!--                        </button>-->
+        <!--                    </div>-->
+        <!--                </div>-->
+        <!--            </th:block>-->
+        <!--        </div>-->
+        <!--    </div>-->
+    </div>
 </div>
 <div th:replace="common/footer.html"></div>
 </body>

--- a/src/main/resources/templates/user/mypage_cs.html
+++ b/src/main/resources/templates/user/mypage_cs.html
@@ -107,19 +107,21 @@
   }
 </style>
 <div class="jumbotron">
-    <div class="row">
-        <div class="col-md-3 px-4">
-            <h3>나의 문의</h3>
-        </div>
-        <div class="col-md-9">
-            <nav class="navbar navbar-expand-md">
-                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                    <li>-</li>
-                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                </ul>
-            </nav>
+    <div class="container">
+        <div class="row">
+            <div class="col-md-3 px-4">
+                <h3>나의 문의</h3>
+            </div>
+            <div class="col-md-9">
+                <nav class="navbar navbar-expand-md">
+                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                        <li>-</li>
+                        <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                        <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                        <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                    </ul>
+                </nav>
+            </div>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/user/mypage_cs.html
+++ b/src/main/resources/templates/user/mypage_cs.html
@@ -109,18 +109,22 @@
 <div class="jumbotron">
     <div class="container">
         <div class="row">
-            <div class="col-md-3 px-4">
-                <h3>나의 문의</h3>
-            </div>
-            <div class="col-md-9">
-                <nav class="navbar navbar-expand-md">
-                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                        <li>-</li>
-                        <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                        <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                        <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                    </ul>
-                </nav>
+            <div class="col-9">
+                <div class="row">
+                    <div class="col-md-3 px-4">
+                        <h3>나의 문의</h3>
+                    </div>
+                    <div class="col-md-9">
+                        <nav class="navbar navbar-expand-md">
+                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                <li>-</li>
+                                <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                                <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                                <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                            </ul>
+                        </nav>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/user/mypage_cs.html
+++ b/src/main/resources/templates/user/mypage_cs.html
@@ -88,579 +88,605 @@
 <body>
 <div th:replace="~{common/menubar}"></div>
 <style>
-    .jumbotron {
-    position : relative;
-    background-color : #EEEEEE;
+    html, body {
+        height: 100%;
+        margin: 0;
     }
-    .jumbotron .row {
-    position : absolute;
-    width : 100%;
-    bottom: 0%;
+    body {
+        display: flex;
+        flex-direction: column;
+    }
+    .content-wrapper {
+        flex: 1 0 auto;
+    }
+    footer {
+        flex-shrink: 0;
     }
 
-    .nav-link {
-            color: #828282;
-    }
-    ul {
-  list-style: none;
-  padding-left : 0px;
-  }
 </style>
-<div class="jumbotron">
-    <div class="container">
-        <div class="row">
-            <div class="col-9">
-                <div class="row">
-                    <div class="col-md-3 px-4">
-                        <h3>나의 문의</h3>
-                    </div>
-                    <div class="col-md-9">
-                        <nav class="navbar navbar-expand-md">
-                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                                <li>-</li>
-                                <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                                <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                                <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                            </ul>
-                        </nav>
+<div class="content-wrapper">
+    <style>
+        .jumbotron {
+        position : relative;
+        background-color : #EEEEEE;
+        }
+        .jumbotron .row {
+        position : absolute;
+        width : 100%;
+        bottom: 0%;
+        }
+
+        .nav-link {
+                color: #828282;
+        }
+        ul {
+      list-style: none;
+      padding-left : 0px;
+      }
+    </style>
+    <div class="jumbotron">
+        <div class="container">
+            <div class="row">
+                <div class="col-9">
+                    <div class="row">
+                        <div class="col-md-3 px-4">
+                            <h3>나의 문의</h3>
+                        </div>
+                        <div class="col-md-9">
+                            <nav class="navbar navbar-expand-md">
+                                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                    <li>-</li>
+                                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                                </ul>
+                            </nav>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
-<div class="container" style="padding:0;">
-    <div class="row">
-        <aside class="col-md-3 px-4">
-            <div class="row">
-                <div class="col-1"></div>
-                <div class="col-8">
-                    <div class="panel">
-                        <ul class="list-group">
-                            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
-                            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-                            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
-                            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2" style="color: #03C75A;">나의 문의</a></li>
-                        </ul>
+    <div class="container" style="padding:0;">
+        <div class="row">
+            <aside class="col-md-3 px-4">
+                <div class="row">
+                    <div class="col-1"></div>
+                    <div class="col-8">
+                        <div class="panel">
+                            <ul class="list-group">
+                                <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
+                                <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
+                                <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                                <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                                <li><a th:href="@{/user/my/cs}" class="nav-link px-2" style="color: #03C75A;">나의 문의</a>
+                                </li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </aside>
-        <!--    <script>-->
-        <!--        function toggleCheckboxValue() {-->
-        <!--            const checkbox = document.getElementById('isToggledCheckbox');-->
-        <!--            if(!checkbox.checked) checkbox.value = 'N';-->
-        <!--            else checkbox.value = 'Y';-->
-        <!--            document.getElementById('filter-form').submit();-->
-        <!--        }-->
-        <!--    </script>-->
-        <script> // toggle + sorting
-        function updateCheckboxValueAndSubmit() {
-            const checkbox = document.getElementById('isToggledCheckbox');
-            const form = document.getElementById('filter-and-sort-form');
-            // 체크박스가 체크된 상태를 확인
-            checkbox.value = checkbox.checked ? 'Y' : 'N';
-            // 폼 제출
-            form.submit();
+            </aside>
+            <!--    <script>-->
+            <!--        function toggleCheckboxValue() {-->
+            <!--            const checkbox = document.getElementById('isToggledCheckbox');-->
+            <!--            if(!checkbox.checked) checkbox.value = 'N';-->
+            <!--            else checkbox.value = 'Y';-->
+            <!--            document.getElementById('filter-form').submit();-->
+            <!--        }-->
+            <!--    </script>-->
+            <script> // toggle + sorting
+            function updateCheckboxValueAndSubmit() {
+                const checkbox = document.getElementById('isToggledCheckbox');
+                const form = document.getElementById('filter-and-sort-form');
+                // 체크박스가 체크된 상태를 확인
+                checkbox.value = checkbox.checked ? 'Y' : 'N';
+                // 폼 제출
+                form.submit();
+            }
+
+            function submitForm() {
+                document.getElementById('filter-and-sort-form').submit();
+            }
+            </script>
+            <style>
+                .form-select {
+                background-color : #FCFCFC;
+                border : none;
+                width : 100%;
+                height : 50px;
+                }
+                select {
+                color : #828282;
+                }
+                .form-control {
+                background-color : #FCFCFC;
+                border : none;
+                width : 100%;
+                height : 50px;
+                }
+
+
+                .form-control::placeholder {
+                color : #BBBBBB;
+                }
+
+                .date-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            background-color: #8E4B6E;
+            color: white;
+            border-radius: 10px;
+            text-align:center;
+            font-family: "Work Sans", sans-serif;
         }
 
-        function submitForm() {
-            document.getElementById('filter-and-sort-form').submit();
+        .month {
+            font-size: 1.1rem; /* M의 크기를 설정 */
+            font-weight: 550;
+            line-height: 1;
         }
-        </script>
-        <style>
-            .form-select {
-            background-color : #FCFCFC;
-            border : none;
-            width : 100%;
-            height : 50px;
-            }
-            select {
-            color : #828282;
-            }
-            .form-control {
-            background-color : #FCFCFC;
-            border : none;
-            width : 100%;
-            height : 50px;
-            }
 
+        .year {
+            font-size: 0.65rem; /* yyyy의 크기를 설정 */
+            font-weight: 400;
+        }
+        :root {
+            --background-color-light: #FFFFFF;
+            --text-color-light: #000000;
+            --toggle-background-light: #CCCCCC;
+            --toggle-ball-light: #FFFFFF;
 
-            .form-control::placeholder {
-            color : #BBBBBB;
-            }
+            --background-color-dark: #333333;
+            --text-color-dark: #FFFFFF;
+            --toggle-background-dark: #03C75A;
+            --toggle-ball-dark: #FFFFFF;
 
-            .date-container {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        background-color: #8E4B6E;
-        color: white;
-        border-radius: 10px;
-        text-align:center;
-        font-family: "Work Sans", sans-serif;
-    }
-
-    .month {
-        font-size: 1.1rem; /* M의 크기를 설정 */
-        font-weight: 550;
-        line-height: 1;
-    }
-
-    .year {
-        font-size: 0.65rem; /* yyyy의 크기를 설정 */
-        font-weight: 400;
-    }
-    :root {
-        --background-color-light: #FFFFFF;
-        --text-color-light: #000000;
-        --toggle-background-light: #CCCCCC;
-        --toggle-ball-light: #FFFFFF;
-
-        --background-color-dark: #333333;
-        --text-color-dark: #FFFFFF;
-        --toggle-background-dark: #03C75A;
-        --toggle-ball-dark: #FFFFFF;
-
-        --font-size-base: 32px; /* 기본 텍스트 크기 */
-        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
-    }
+            --font-size-base: 32px; /* 기본 텍스트 크기 */
+            --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+        }
 
 
 
-    .toggle-switch {
-        position: relative;
-        display: inline-block;
-        width: 62px; /* 너비 조정 */
-        height: 38px; /* 높이 조정 */
-    }
+        .toggle-switch {
+            position: relative;
+            display: inline-block;
+            width: 62px; /* 너비 조정 */
+            height: 38px; /* 높이 조정 */
+        }
 
-    .toggle-switch .checkbox {
-        opacity: 0;
-        width: 0;
-        height: 0;
-    }
-    #isToggledCheckbox {
-         opacity: 0;
+        .toggle-switch .checkbox {
+            opacity: 0;
             width: 0;
             height: 0;
-    }
+        }
+        #isToggledCheckbox {
+             opacity: 0;
+                width: 0;
+                height: 0;
+        }
 
-    .toggle-switch .label {
-        position: absolute;
-        cursor: pointer;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background-color: var(--toggle-background-light);
-        transition: background-color 0.4s;
-        border-radius: 38px; /* 둥근 모서리 반경 조정 */
-    }
+        .toggle-switch .label {
+            position: absolute;
+            cursor: pointer;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: var(--toggle-background-light);
+            transition: background-color 0.4s;
+            border-radius: 38px; /* 둥근 모서리 반경 조정 */
+        }
 
-    .toggle-switch .label:before {
-        position: absolute;
-        content: "";
-        height: 30px; /* 내부 원 높이 조정 */
-        width: 30px; /* 내부 원 너비 조정 */
-        left: 2px;
-        bottom: 0px;
-        background-color: var(--toggle-ball-light);
-        transition: transform 0.4s;
-        border-radius: 50%;
-    }
+        .toggle-switch .label:before {
+            position: absolute;
+            content: "";
+            height: 30px; /* 내부 원 높이 조정 */
+            width: 30px; /* 내부 원 너비 조정 */
+            left: 2px;
+            bottom: 0px;
+            background-color: var(--toggle-ball-light);
+            transition: transform 0.4s;
+            border-radius: 50%;
+        }
 
-    .toggle-switch input:checked + .label {
-        background-color: var(--toggle-background-dark);
-    }
+        .toggle-switch input:checked + .label {
+            background-color: var(--toggle-background-dark);
+        }
 
-    .toggle-switch input:checked + .label:before {
-        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
-    }
+        .toggle-switch input:checked + .label:before {
+            transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+        }
 
-             #absdiv {
-                position: relative;
-                top: 60px; /* Move down by 20px from its current position */
-                z-index : 1000;
-            }
+                 #absdiv {
+                    position: relative;
+                    top: 60px; /* Move down by 20px from its current position */
+                    z-index : 1000;
+                }
 
-            #searchbutton {
-                background-color: #828282;
-            }
-        </style>
-        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
-              rel="stylesheet">
-        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
-              rel="stylesheet">
+                #searchbutton {
+                    background-color: #828282;
+                }
+            </style>
+            <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+                  rel="stylesheet">
+            <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+                  rel="stylesheet">
 
-        <div class="col-md-9">
-            <div class="row" style="color: #828282;">
-                <div class="col-11">
-                    <div class="row">
-                        <div class="col-12 p-0">
-                            <style>
-                                .col-4 select {
-                                    border-radius: 50px;
-                                    text-align: center;
-                                }
-                                /* 검색창 스타일 */
-                                .search-container {
-                                    width: 300px;
-                                }
+            <div class="col-md-9">
+                <div class="row" style="color: #828282;">
+                    <div class="col-11">
+                        <div class="row">
+                            <div class="col-12 p-0">
+                                <style>
+                                    .col-4 select {
+                                        border-radius: 50px;
+                                        text-align: center;
+                                    }
+                                    /* 검색창 스타일 */
+                                    .search-container {
+                                        width: 300px;
+                                    }
 
-                                .search-container select {
-                                    position: absolute;
-                                    left: 0%;
-                                    width: 30%;
-                                    height: 50px;
-                                    color: #828282;
-                                    font-size: 1rem;
-                                    border-radius: 50px 0 0 50px;
-                                    outline: none;
-                                }
-                                .search-container input[type="text"] {
-                                    position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
-                                    left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
-                                    width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
-                                    height: 50px;
-                                    padding: 10px 40px 10px 15px;
-                                    font-size: 1rem;
-                                    outline: none;
-                                    border-radius: 0 50px 50px 0;
-                                    transition: border-color 0.3s, background-color 0.3s;
-                                    color: #828282; /* 입력 텍스트 색상 변경 */
-                                }
+                                    .search-container select {
+                                        position: absolute;
+                                        left: 0%;
+                                        width: 30%;
+                                        height: 50px;
+                                        color: #828282;
+                                        font-size: 1rem;
+                                        border-radius: 50px 0 0 50px;
+                                        outline: none;
+                                    }
+                                    .search-container input[type="text"] {
+                                        position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
+                                        left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
+                                        width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
+                                        height: 50px;
+                                        padding: 10px 40px 10px 15px;
+                                        font-size: 1rem;
+                                        outline: none;
+                                        border-radius: 0 50px 50px 0;
+                                        transition: border-color 0.3s, background-color 0.3s;
+                                        color: #828282; /* 입력 텍스트 색상 변경 */
+                                    }
 
-                                .search-container input[type="text"]::placeholder {
-                                    color: #BBBBBB; /* placeholder 색상 변경 */
-                                }
+                                    .search-container input[type="text"]::placeholder {
+                                        color: #BBBBBB; /* placeholder 색상 변경 */
+                                    }
 
 
-                                .search-container button {
-                                    position: absolute;
-                                    right: 1rem;
-                                    top: 25px;
-                                    background: none;
-                                    transform: translateY(-50%);
-                                    border: none;
-                                    cursor: pointer;
-                                }
+                                    .search-container button {
+                                        position: absolute;
+                                        right: 1rem;
+                                        top: 25px;
+                                        background: none;
+                                        transform: translateY(-50%);
+                                        border: none;
+                                        cursor: pointer;
+                                    }
 
-                                .search-container button i {
-                                    color: #A6AAB5;
-                                }
+                                    .search-container button i {
+                                        color: #A6AAB5;
+                                    }
 
-                                .search-container button:hover i {
-                                    color: #03C75A;
-                                }
-                            </style>
-                            <form id="filter-and-sort-form" th:action="@{/user/my/cs}" method="get">
-                                <div class="row m-0">
-                                    <div class="col-7 p-0">
-                                        <div class="row justify-content-start m-0">
-                                            <div class="col-12 p-0">
-                                                <div class="search-container">
-                                                    <select class="form-select px-3" name="searchBy">
-                                                        <option value="title" th:selected="${searchBy == 'title'}">제목
+                                    .search-container button:hover i {
+                                        color: #03C75A;
+                                    }
+                                </style>
+                                <form id="filter-and-sort-form" th:action="@{/user/my/cs}" method="get">
+                                    <div class="row m-0">
+                                        <div class="col-7 p-0">
+                                            <div class="row justify-content-start m-0">
+                                                <div class="col-12 p-0">
+                                                    <div class="search-container">
+                                                        <select class="form-select px-3" name="searchBy">
+                                                            <option value="title" th:selected="${searchBy == 'title'}">
+                                                                제목
+                                                            </option>
+                                                            <option value="content"
+                                                                    th:selected="${searchBy == 'content'}">
+                                                                내용
+                                                            </option>
+                                                        </select>
+                                                        <input class="form-control px-3" type="text" name="searchTerm"
+                                                               placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
+                                                        <!-- 검색 버튼 -->
+                                                        <button type="submit">
+                                                            <i class="fas fa-search"></i>
+                                                        </button>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="col-1" style=""></div>
+                                        <div class="col-4">
+                                            <div class="row justify-content-end">
+                                                <!-- 정렬 또는 토글2 -->
+                                                <label>
+                                                    <select class="form-select px-3" name="orderBy"
+                                                            onchange="submitForm()">
+                                                        <option value="recentedited"
+                                                                th:selected="${orderBy == 'recentedited'}">최근수정순
                                                         </option>
-                                                        <option value="content" th:selected="${searchBy == 'content'}">
-                                                            내용
+
+                                                        <option value="recent" th:selected="${orderBy == 'recent'}">
+                                                            최근작성순
+                                                        </option>
+                                                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순
+                                                        </option>
+
+                                                        <option value="views" th:selected="${orderBy == 'views'}">조회수높은순
+                                                        </option>
+                                                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순
                                                         </option>
                                                     </select>
-                                                    <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
-                                                    <!-- 검색 버튼 -->
-                                                    <button type="submit">
-                                                        <i class="fas fa-search"></i>
-                                                    </button>
+                                                </label>
+                                            </div>
+                                        </div>
+                                    </div> <!--검색, 소팅 (토글X)-->
+                                    <div class="row justify-content-around">
+                                        <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                        <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                        <div class="col-3" style="padding: 0 1.2rem;">
+                                            <div id="absdiv" class="row justify-content-end">
+                                                <div class="col-3">
+                                                    <div class="toggle-switch">
+                                                        <!-- 정렬 또는 토글1 -->
+                                                        <input type="checkbox" name="isToggled" id="isToggledCheckbox"
+                                                               value="Y" th:checked="${isToggled == 'Y'}"
+                                                               onchange="updateCheckboxValueAndSubmit()">
+                                                        <label for="isToggledCheckbox" class="label">
+                                                            <div class="ball"></div>
+                                                        </label>
+                                                    </div>
+                                                </div>
+                                                <div class="col-8"
+                                                     style="text-align: right; padding: 0px; margin : 0px;">
+                                                    답변완료
                                                 </div>
                                             </div>
                                         </div>
-                                    </div>
-                                    <div class="col-1" style=""></div>
-                                    <div class="col-4">
-                                        <div class="row justify-content-end">
-                                            <!-- 정렬 또는 토글2 -->
-                                            <label>
-                                                <select class="form-select px-3" name="orderBy" onchange="submitForm()">
-                                                    <option value="recentedited"
-                                                            th:selected="${orderBy == 'recentedited'}">최근수정순
-                                                    </option>
-
-                                                    <option value="recent" th:selected="${orderBy == 'recent'}">최근작성순
-                                                    </option>
-                                                    <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순
-                                                    </option>
-
-                                                    <option value="views" th:selected="${orderBy == 'views'}">조회수높은순
-                                                    </option>
-                                                    <option value="title" th:selected="${orderBy == 'title'}">제목가나다순
-                                                    </option>
-                                                </select>
-                                            </label>
-                                        </div>
-                                    </div>
-                                </div> <!--검색, 소팅 (토글X)-->
-                                <div class="row justify-content-around">
-                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                    <div class="col-3" style="padding: 0 1.2rem;">
-                                        <div id="absdiv" class="row justify-content-end">
-                                            <div class="col-3">
-                                                <div class="toggle-switch">
-                                                    <!-- 정렬 또는 토글1 -->
-                                                    <input type="checkbox" name="isToggled" id="isToggledCheckbox"
-                                                           value="Y" th:checked="${isToggled == 'Y'}"
-                                                           onchange="updateCheckboxValueAndSubmit()">
-                                                    <label for="isToggledCheckbox" class="label">
-                                                        <div class="ball"></div>
-                                                    </label>
+                                    </div> <!--토글-->
+                                </form>
+                            </div>
+                        </div>
+                        <div class="row justify-content-around">
+                            <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
+                                <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
+                                    <div class="col-3 clickable-row"
+                                         style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                         th:each="myCsQuestion, iterStat : ${myCsQuestions}"
+                                         th:attr="data-href=@{/cs/questionDetail/{csQNo}(csQNo=${myCsQuestion.csQNo})}"
+                                         th:if="${iterStat.index < 3}">
+                                        <div class="row justify-content-center">
+                                            <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                                 style="aspect-ratio: 1; border-radius: 5px;">
+                                                <div class="date-container px-2 py-1">
+                                                    <div class="month"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myCsQuestion.createdDate)}"></div>
+                                                    <div class="year"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myCsQuestion.createdDate)}"></div>
                                                 </div>
                                             </div>
-                                            <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">
-                                                답변완료
+
+                                            <div class="col-4" style="color: white;" th:text="${myCsQuestion.csQNo}">닉네임
+                                            </div>
+                                            <div class="col-4"
+                                                 style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD;"
+                                                 th:text="${myCsQuestion.formattedCreatedDate}">시간
                                             </div>
                                         </div>
-                                    </div>
-                                </div> <!--토글-->
-                            </form>
-                        </div>
-                    </div>
-                    <div class="row justify-content-around">
-                        <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
-                            <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
-                                <div class="col-3 clickable-row"
-                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
-                                     th:each="myCsQuestion, iterStat : ${myCsQuestions}"
-                                     th:attr="data-href=@{/cs/questionDetail/{csQNo}(csQNo=${myCsQuestion.csQNo})}"
-                                     th:if="${iterStat.index < 3}">
-                                    <div class="row justify-content-center">
-                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
-                                             style="aspect-ratio: 1; border-radius: 5px;">
-                                            <div class="date-container px-2 py-1">
-                                                <div class="month"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myCsQuestion.createdDate)}"></div>
-                                                <div class="year"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myCsQuestion.createdDate)}"></div>
+                                        <div class="row justify-content-center">
+                                            <div class="col-10" style="color: white;" th:text="${myCsQuestion.csQNo}">사진
                                             </div>
                                         </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                                 th:text="${myCsQuestion.csQTitle}">이름
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                                 th:text="${myCsQuestion.csQContent}">내용
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                        </div>
 
-                                        <div class="col-4" style="color: white;" th:text="${myCsQuestion.csQNo}">닉네임
-                                        </div>
-                                        <div class="col-4"
-                                             style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD;"
-                                             th:text="${myCsQuestion.formattedCreatedDate}">시간
-                                        </div>
                                     </div>
-                                    <div class="row justify-content-center">
-                                        <div class="col-10" style="color: white;" th:text="${myCsQuestion.csQNo}">사진
-                                        </div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
-                                             th:text="${myCsQuestion.csQTitle}">이름
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
-                                             th:text="${myCsQuestion.csQContent}">내용
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                    </div>
-
+                                    <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
+                                    <div class="col-3" th:if="${myCsQuestions.size() == 0}"></div>
+                                    <div class="col-3"
+                                         th:if="${myCsQuestions.size() == 0 || myCsQuestions.size() == 1}"></div>
+                                    <div class="col-3"
+                                         th:if="${myCsQuestions.size() == 0 || myCsQuestions.size() == 1 || myCsQuestions.size() == 2}"></div>
                                 </div>
-                                <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
-                                <div class="col-3" th:if="${myCsQuestions.size() == 0}"></div>
-                                <div class="col-3"
-                                     th:if="${myCsQuestions.size() == 0 || myCsQuestions.size() == 1}"></div>
-                                <div class="col-3"
-                                     th:if="${myCsQuestions.size() == 0 || myCsQuestions.size() == 1 || myCsQuestions.size() == 2}"></div>
-                            </div>
-                            <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
-                                <div class="col-3 clickable-row"
-                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
-                                     th:each="myCsQuestion, iterStat : ${myCsQuestions}"
-                                     th:attr="data-href=@{/cs/questionDetail/{csQNo}(csQNo=${myCsQuestion.csQNo})}"
-                                     th:if="${iterStat.index >= 3}">
-                                    <div class="row justify-content-center">
-                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
-                                             style="aspect-ratio: 1; border-radius: 5px;">
-                                            <div class="date-container px-2 py-1">
-                                                <div class="month"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myCsQuestion.createdDate)}"></div>
-                                                <div class="year"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myCsQuestion.createdDate)}"></div>
+                                <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
+                                    <div class="col-3 clickable-row"
+                                         style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                         th:each="myCsQuestion, iterStat : ${myCsQuestions}"
+                                         th:attr="data-href=@{/cs/questionDetail/{csQNo}(csQNo=${myCsQuestion.csQNo})}"
+                                         th:if="${iterStat.index >= 3}">
+                                        <div class="row justify-content-center">
+                                            <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                                 style="aspect-ratio: 1; border-radius: 5px;">
+                                                <div class="date-container px-2 py-1">
+                                                    <div class="month"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myCsQuestion.createdDate)}"></div>
+                                                    <div class="year"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myCsQuestion.createdDate)}"></div>
+                                                </div>
+                                            </div>
+
+                                            <div class="col-4" style="color: white;" th:text="${myCsQuestion.csQNo}">닉네임
+                                            </div>
+                                            <div class="col-4"
+                                                 style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD;"
+                                                 th:text="${myCsQuestion.formattedCreatedDate}">시간
                                             </div>
                                         </div>
+                                        <div class="row justify-content-center">
+                                            <div class="col-10" style="color: white;" th:text="${myCsQuestion.csQNo}">사진
+                                            </div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                                 th:text="${myCsQuestion.csQTitle}">이름
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                                 th:text="${myCsQuestion.csQContent}">내용
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                        </div>
 
-                                        <div class="col-4" style="color: white;" th:text="${myCsQuestion.csQNo}">닉네임
-                                        </div>
-                                        <div class="col-4"
-                                             style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD;"
-                                             th:text="${myCsQuestion.formattedCreatedDate}">시간
-                                        </div>
-                                    </div>
-                                    <div class="row justify-content-center">
-                                        <div class="col-10" style="color: white;" th:text="${myCsQuestion.csQNo}">사진
-                                        </div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
-                                             th:text="${myCsQuestion.csQTitle}">이름
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
-                                             th:text="${myCsQuestion.csQContent}">내용
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
                                     </div>
 
+                                    <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
+                                    <div class="col-3" th:if="${myCsQuestions.size() <= 3}"></div>
+                                    <div class="col-3"
+                                         th:if="${myCsQuestions.size() <= 3 || myCsQuestions.size() == 4}"></div>
+                                    <div class="col-3"
+                                         th:if="${myCsQuestions.size() <= 3 || myCsQuestions.size() == 4 || myCsQuestions.size() == 5}"></div>
                                 </div>
-
-                                <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
-                                <div class="col-3" th:if="${myCsQuestions.size() <= 3}"></div>
-                                <div class="col-3"
-                                     th:if="${myCsQuestions.size() <= 3 || myCsQuestions.size() == 4}"></div>
-                                <div class="col-3"
-                                     th:if="${myCsQuestions.size() <= 3 || myCsQuestions.size() == 4 || myCsQuestions.size() == 5}"></div>
                             </div>
                         </div>
-                    </div>
-                    <div class="row justify-content-center">
-                        <!-- 페이징 -->
-                        <th:block th:if="${pages != null}">
-                            <div class="d-flex justify-content-center">
-                                <div class="btn-group">
-                                    <button type="button" class="btn btn-sm previous"
-                                            th:onclick="|location.href='@{/user/my/cs(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
-                                            th:disabled="${currentPage == 1}">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                             fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-                                            <path fill-rule="evenodd"
-                                                  d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                                        </svg>
-                                    </button>
-                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">
-                                        <button type="button" class="btn btn-sm me-2 pages"
-                                                th:text="${p}"
-                                                th:onclick="|location.href='@{/user/my/cs(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
-                                    </th:block>
-                                    <button type="button" class="btn btn-sm  next"
-                                            th:onclick="|location.href='@{/user/my/cs(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
-                                            th:disabled="${currentPage == pages}">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                             fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-                                            <path fill-rule="evenodd"
-                                                  d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
-                                        </svg>
-                                    </button>
+                        <div class="row justify-content-center">
+                            <!-- 페이징 -->
+                            <th:block th:if="${pages != null}">
+                                <div class="d-flex justify-content-center">
+                                    <div class="btn-group">
+                                        <button type="button" class="btn btn-sm previous"
+                                                th:onclick="|location.href='@{/user/my/cs(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
+                                                th:disabled="${currentPage == 1}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                                 fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+                                                <path fill-rule="evenodd"
+                                                      d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                                            </svg>
+                                        </button>
+                                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">
+                                            <button type="button" class="btn btn-sm me-2 pages"
+                                                    th:text="${p}"
+                                                    th:onclick="|location.href='@{/user/my/cs(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
+                                        </th:block>
+                                        <button type="button" class="btn btn-sm  next"
+                                                th:onclick="|location.href='@{/user/my/cs(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
+                                                th:disabled="${currentPage == pages}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                                 fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+                                                <path fill-rule="evenodd"
+                                                      d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                                            </svg>
+                                        </button>
+                                    </div>
                                 </div>
-                            </div>
-                        </th:block>
-                    </div>
-                </div><!--테이블 및 페이징 포함-->
+                            </th:block>
+                        </div>
+                    </div><!--테이블 및 페이징 포함-->
+                </div> <!--본화면-->
             </div> <!--본화면-->
-        </div> <!--본화면-->
 
 
-        <!--수정중 -->
-        <!--    <div class="col-md-9">-->
-        <!--        <div class="review-list">-->
-        <!--            <h2>나의 문의</h2>-->
-        <!--            <form id="filter-and-sort-form" th:action="@{/user/my/cs}" method="get">-->
-        <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
-        <!--                <label>-->
-        <!--                    <select name="searchBy">-->
-        <!--                        <option value="title" th:selected="${searchBy == 'title'}">제목</option>-->
-        <!--                        <option value="content" th:selected="${searchBy == 'content'}">내용</option>-->
-        <!--                    </select>-->
-        <!--                </label>-->
-        <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
+            <!--수정중 -->
+            <!--    <div class="col-md-9">-->
+            <!--        <div class="review-list">-->
+            <!--            <h2>나의 문의</h2>-->
+            <!--            <form id="filter-and-sort-form" th:action="@{/user/my/cs}" method="get">-->
+            <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
+            <!--                <label>-->
+            <!--                    <select name="searchBy">-->
+            <!--                        <option value="title" th:selected="${searchBy == 'title'}">제목</option>-->
+            <!--                        <option value="content" th:selected="${searchBy == 'content'}">내용</option>-->
+            <!--                    </select>-->
+            <!--                </label>-->
+            <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
 
-        <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
-        <!--                <button type="submit">검색</button>-->
+            <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
+            <!--                <button type="submit">검색</button>-->
 
-        <!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
-        <!--                <label>-->
-        <!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">답변완료-->
-        <!--                </label>-->
-        <!--                <label>-->
-        <!--                    <select name="orderBy" onchange="submitForm()">-->
-        <!--                        <option value="recentedited" th:selected="${orderBy == 'recentedited'}">최근수정순</option>-->
+            <!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
+            <!--                <label>-->
+            <!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">답변완료-->
+            <!--                </label>-->
+            <!--                <label>-->
+            <!--                    <select name="orderBy" onchange="submitForm()">-->
+            <!--                        <option value="recentedited" th:selected="${orderBy == 'recentedited'}">최근수정순</option>-->
 
-        <!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최근작성순</option>-->
-        <!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
+            <!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최근작성순</option>-->
+            <!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
 
-        <!--                        <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>-->
-        <!--                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
-        <!--                    </select>-->
-        <!--                </label>-->
-        <!--            </form>-->
-        <!--&lt;!&ndash;            <form id="filter-form" th:action="@{/user/my/cs}" method="get">&ndash;&gt;-->
-        <!--&lt;!&ndash;                <label>&ndash;&gt;-->
-        <!--&lt;!&ndash;                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="toggleCheckboxValue()">답변완료&ndash;&gt;-->
-        <!--&lt;!&ndash;                </label>&ndash;&gt;-->
-        <!--&lt;!&ndash;            </form>&ndash;&gt;-->
-        <!--            <table>-->
-        <!--                <thead>-->
-        <!--                <tr>-->
-        <!--                    <th>문의글 번호</th>-->
-        <!--                    <th>문의글 제목</th>-->
-        <!--                    <th>문의글 내용</th>-->
-        <!--                    <th>문의글 작성자</th>-->
-        <!--                    <th>문의 카테고리 코드</th>-->
-        <!--                    <th>문의 상태 코드</th>-->
-        <!--                    <th>문의글 조회수</th>-->
-        <!--                    <th>문의 작성일자</th>-->
-        <!--                    <th>문의 수정일자</th>-->
-        <!--                </tr>-->
-        <!--                </thead>-->
-        <!--                <tbody>-->
-        <!--                <tr th:each="myCsQuestion : ${myCsQuestions}" class="clickable-row" th:attr="data-href=@{/cs/questionDetail/{id}(id=${myCsQuestion.csQNo})}">-->
-        <!--                    <td th:text="${myCsQuestion.csQNo}">문의글 번호</td>-->
-        <!--                    <td th:text="${myCsQuestion.csQTitle}">문의글 제목</td>-->
-        <!--                    <td th:text="${myCsQuestion.csQContent}">문의글 내용</td>-->
-        <!--                    <td th:text="${myCsQuestion.csQWriterNo}">문의글 작성자</td>-->
-        <!--                    <td th:text="${myCsQuestion.csQCategoryCode}">문의 카테고리 코드</td>-->
-        <!--                    <td th:text="${myCsQuestion.csQStatusCode}">문의 상태 코드</td>-->
-        <!--                    <td th:text="${myCsQuestion.csQViewCount}">문의글 조회수</td>-->
-        <!--                    <td th:text="${myCsQuestion.createdDate}">문의 작성일자</td>-->
-        <!--                    <td th:text="${myCsQuestion.modifiedDate}">문의 수정일자</td>-->
-        <!--                </tr>-->
-        <!--                </tbody>-->
-        <!--            </table>-->
-        <!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
-        <!--            <th:block th:if="${pages != null}">-->
-        <!--                <div class="d-flex justify-content-center">-->
-        <!--                    <div class="btn-group">-->
-        <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/cs(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
-        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
-        <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
-        <!--                            </svg>-->
-        <!--                        </button>-->
-        <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
-        <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
-        <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/cs(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
-        <!--                        </th:block>-->
-        <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/cs(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
-        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
-        <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
-        <!--                            </svg>-->
-        <!--                        </button>-->
-        <!--                    </div>-->
-        <!--                </div>-->
-        <!--            </th:block>-->
-        <!--        </div>-->
-        <!--    </div>-->
+            <!--                        <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>-->
+            <!--                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
+            <!--                    </select>-->
+            <!--                </label>-->
+            <!--            </form>-->
+            <!--&lt;!&ndash;            <form id="filter-form" th:action="@{/user/my/cs}" method="get">&ndash;&gt;-->
+            <!--&lt;!&ndash;                <label>&ndash;&gt;-->
+            <!--&lt;!&ndash;                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="toggleCheckboxValue()">답변완료&ndash;&gt;-->
+            <!--&lt;!&ndash;                </label>&ndash;&gt;-->
+            <!--&lt;!&ndash;            </form>&ndash;&gt;-->
+            <!--            <table>-->
+            <!--                <thead>-->
+            <!--                <tr>-->
+            <!--                    <th>문의글 번호</th>-->
+            <!--                    <th>문의글 제목</th>-->
+            <!--                    <th>문의글 내용</th>-->
+            <!--                    <th>문의글 작성자</th>-->
+            <!--                    <th>문의 카테고리 코드</th>-->
+            <!--                    <th>문의 상태 코드</th>-->
+            <!--                    <th>문의글 조회수</th>-->
+            <!--                    <th>문의 작성일자</th>-->
+            <!--                    <th>문의 수정일자</th>-->
+            <!--                </tr>-->
+            <!--                </thead>-->
+            <!--                <tbody>-->
+            <!--                <tr th:each="myCsQuestion : ${myCsQuestions}" class="clickable-row" th:attr="data-href=@{/cs/questionDetail/{id}(id=${myCsQuestion.csQNo})}">-->
+            <!--                    <td th:text="${myCsQuestion.csQNo}">문의글 번호</td>-->
+            <!--                    <td th:text="${myCsQuestion.csQTitle}">문의글 제목</td>-->
+            <!--                    <td th:text="${myCsQuestion.csQContent}">문의글 내용</td>-->
+            <!--                    <td th:text="${myCsQuestion.csQWriterNo}">문의글 작성자</td>-->
+            <!--                    <td th:text="${myCsQuestion.csQCategoryCode}">문의 카테고리 코드</td>-->
+            <!--                    <td th:text="${myCsQuestion.csQStatusCode}">문의 상태 코드</td>-->
+            <!--                    <td th:text="${myCsQuestion.csQViewCount}">문의글 조회수</td>-->
+            <!--                    <td th:text="${myCsQuestion.createdDate}">문의 작성일자</td>-->
+            <!--                    <td th:text="${myCsQuestion.modifiedDate}">문의 수정일자</td>-->
+            <!--                </tr>-->
+            <!--                </tbody>-->
+            <!--            </table>-->
+            <!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
+            <!--            <th:block th:if="${pages != null}">-->
+            <!--                <div class="d-flex justify-content-center">-->
+            <!--                    <div class="btn-group">-->
+            <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/cs(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
+            <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
+            <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
+            <!--                            </svg>-->
+            <!--                        </button>-->
+            <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
+            <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
+            <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/cs(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
+            <!--                        </th:block>-->
+            <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/cs(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
+            <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
+            <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
+            <!--                            </svg>-->
+            <!--                        </button>-->
+            <!--                    </div>-->
+            <!--                </div>-->
+            <!--            </th:block>-->
+            <!--        </div>-->
+            <!--    </div>-->
+        </div>
     </div>
 </div>
 <div th:replace="common/footer.html"></div>

--- a/src/main/resources/templates/user/mypage_cs.html
+++ b/src/main/resources/templates/user/mypage_cs.html
@@ -350,7 +350,7 @@
                                 }
 
                                 .search-container button i {
-                                    color: #666;
+                                    color: #A6AAB5;
                                 }
 
                                 .search-container button:hover i {

--- a/src/main/resources/templates/user/mypage_cs.html
+++ b/src/main/resources/templates/user/mypage_cs.html
@@ -133,7 +133,7 @@
     <div class="row">
         <aside class="col-md-3 px-4">
             <div class="row">
-                <div class="col-3"></div>
+                <div class="col-1"></div>
                 <div class="col-6">
                     <div class="panel">
                         <ul class="list-group">

--- a/src/main/resources/templates/user/mypage_dashboard.html
+++ b/src/main/resources/templates/user/mypage_dashboard.html
@@ -355,7 +355,7 @@
                                     <nav class="navbar navbar-expand-md">
                                         <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
                                             <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-                                            <li><a th:href="@{/recruit/creator/choice}" class="nav-link px-2">창작자 등록</a>
+                                            <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보 수정</a>
                                             </li>
                                             <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a>
                                             </li>

--- a/src/main/resources/templates/user/mypage_dashboard.html
+++ b/src/main/resources/templates/user/mypage_dashboard.html
@@ -122,615 +122,776 @@
 <body>
 
 <div id="menubar" th:replace="~{common/menubar}"></div>
-<style>
-    .jumbotron {
-    position : relative;
-    background-color : white;
-    }
-    .jumbotron .row {
-    position : absolute;
-    width : 100%;
-    bottom: 0%;
-    }
-    .nav-link {
-            color: #828282;
-    }
-    ul {
-  list-style: none;
-  padding-left : 0px;
-  }
-
-    .profile-image {
-    width: 100px;
-    height: auto;
-    border-radius: 50%;
-    object-fit: cover;
-    margin-right: 15px;
-    }
-</style>
-<!--<div class="jumbotron mb-0">-->
-<!--        <div class="row justify-content-center m-0" style="color: #828282;">-->
-<!--            <div class="col-11 m-0">-->
-<!--                <div class="row justify-content-center m-0" style="background-color: red;">-->
-<!--                    <div class="col-3">-->
-<!--                        <div class="row p-2">-->
-<!--                            <div class="col-4 m-0 p-0" id="profileimagebox">-->
-<!--                                <img th:if="${user.profileImagePath == null}" th:src="/images/defaultprofileimage.png" style="width: 100px; height: auto;" class="profile-image"/>-->
-<!--                                <img th:if="${user.profileImagePath != null}" th:src="@{/uploadFiles/{fileName}(fileName=${user.profileImagePath})}" style="width: 100px; height: auto;" class="profile-image"/>-->
-<!--                            </div>-->
-<!--                            <div class="col-8">-->
-<!--                                <div class="row">-->
-<!--                                    <div class="col-12"><h3 th:text="${user.getNickname()} + '님의 '"></h3></div>-->
-<!--                                    <div class="col-12"><h3>툰게더 활동내역은?</h3></div>-->
-<!--                                </div>-->
-<!--                            </div>-->
-<!--                        </div>-->
-<!--                    </div>-->
-<!--                    <div class="col-7">-->
-<!--                        <nav class="navbar navbar-expand-md">-->
-<!--                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">-->
-<!--                                <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>-->
-<!--                                <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>-->
-<!--                            </ul>-->
-<!--                        </nav>-->
-<!--                    </div>-->
-<!--                </div>-->
-<!--            </div>-->
-<!--        </div>-->
-<!--</div>-->
-<div class="row m-0">
+<div class="container" style="padding:0;">
     <style>
-        .form-select {
-        background-color : #FCFCFC;
-        border : none;
+        .jumbotron {
+        position : relative;
+        background-color : white;
+        }
+        .jumbotron .row {
+        position : absolute;
         width : 100%;
-        height : 50px;
+        bottom: 0%;
         }
-        select {
-        color : #828282;
+        .nav-link {
+                color: #828282;
         }
-        .form-control {
-        background-color : #FCFCFC;
-        border : none;
-        width : 100%;
-        height : 50px;
+        ul {
+      list-style: none;
+      padding-left : 0px;
+      }
+
+        .profile-image {
+        width: 100px;
+        height: auto;
+        border-radius: 50%;
+        object-fit: cover;
+        margin-right: 15px;
         }
-
-
-        .form-control::placeholder {
-        color : #BBBBBB;
-        }
-
-        .date-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    background-color: #8E4B6E;
-    color: white;
-    border-radius: 10px;
-    text-align:center;
-    font-family: "Work Sans", sans-serif;
-}
-
-.month {
-    font-size: 1.1rem; /* M의 크기를 설정 */
-    font-weight: 550;
-    line-height: 1;
-}
-
-.year {
-    font-size: 0.65rem; /* yyyy의 크기를 설정 */
-    font-weight: 400;
-}
-:root {
-    --background-color-light: #FFFFFF;
-    --text-color-light: #000000;
-    --toggle-background-light: #CCCCCC;
-    --toggle-ball-light: #FFFFFF;
-
-    --background-color-dark: #333333;
-    --text-color-dark: #FFFFFF;
-    --toggle-background-dark: #03C75A;
-    --toggle-ball-dark: #FFFFFF;
-
-    --font-size-base: 32px; /* 기본 텍스트 크기 */
-    --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
-}
-
-
-
-.toggle-switch {
-    position: relative;
-    display: inline-block;
-    width: 62px; /* 너비 조정 */
-    height: 38px; /* 높이 조정 */
-}
-
-.toggle-switch .checkbox {
-    opacity: 0;
-    width: 0;
-    height: 0;
-}
-#isToggledCheckbox {
-     opacity: 0;
-        width: 0;
-        height: 0;
-}
-
-.toggle-switch .label {
-    position: absolute;
-    cursor: pointer;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: var(--toggle-background-light);
-    transition: background-color 0.4s;
-    border-radius: 38px; /* 둥근 모서리 반경 조정 */
-}
-
-.toggle-switch .label:before {
-    position: absolute;
-    content: "";
-    height: 30px; /* 내부 원 높이 조정 */
-    width: 30px; /* 내부 원 너비 조정 */
-    left: 2px;
-    bottom: 0px;
-    background-color: var(--toggle-ball-light);
-    transition: transform 0.4s;
-    border-radius: 50%;
-}
-
-.toggle-switch input:checked + .label {
-    background-color: var(--toggle-background-dark);
-}
-
-.toggle-switch input:checked + .label:before {
-    transform: translateX(28px); /* 내부 원 이동 거리 조정 */
-}
-
-         #absdiv {
-            position: relative;
-            top: 60px; /* Move down by 20px from its current position */
-            z-index : 1000;
-        }
-
-        #searchbutton {
-            background-color: #828282;
-        }
-
-        .card-img-top {
-                width: 100%;
-                height: 100px;
-                object-fit: cover;
+    </style>
+    <!--<div class="jumbotron mb-0">-->
+    <!--        <div class="row justify-content-center m-0" style="color: #828282;">-->
+    <!--            <div class="col-11 m-0">-->
+    <!--                <div class="row justify-content-center m-0" style="background-color: red;">-->
+    <!--                    <div class="col-3">-->
+    <!--                        <div class="row p-2">-->
+    <!--                            <div class="col-4 m-0 p-0" id="profileimagebox">-->
+    <!--                                <img th:if="${user.profileImagePath == null}" th:src="/images/defaultprofileimage.png" style="width: 100px; height: auto;" class="profile-image"/>-->
+    <!--                                <img th:if="${user.profileImagePath != null}" th:src="@{/uploadFiles/{fileName}(fileName=${user.profileImagePath})}" style="width: 100px; height: auto;" class="profile-image"/>-->
+    <!--                            </div>-->
+    <!--                            <div class="col-8">-->
+    <!--                                <div class="row">-->
+    <!--                                    <div class="col-12"><h3 th:text="${user.getNickname()} + '님의 '"></h3></div>-->
+    <!--                                    <div class="col-12"><h3>툰게더 활동내역은?</h3></div>-->
+    <!--                                </div>-->
+    <!--                            </div>-->
+    <!--                        </div>-->
+    <!--                    </div>-->
+    <!--                    <div class="col-7">-->
+    <!--                        <nav class="navbar navbar-expand-md">-->
+    <!--                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">-->
+    <!--                                <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>-->
+    <!--                                <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>-->
+    <!--                            </ul>-->
+    <!--                        </nav>-->
+    <!--                    </div>-->
+    <!--                </div>-->
+    <!--            </div>-->
+    <!--        </div>-->
+    <!--</div>-->
+    <div class="row m-0">
+        <style>
+            .form-select {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
+            }
+            select {
+            color : #828282;
+            }
+            .form-control {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
             }
 
-        #blockA .col-5 {background-color: #EEEEEE;}
-        #blockB .col-5 {background-color: #EEEEEE;}
-        #blockC .col-5 {background-color: #EEEEEE;}
-        #blockD .col-5 {background-color: #EEEEEE;}
-        .fixed-cols {
-  display: flex;
-  flex-wrap: nowrap; /* 줄바꿈 방지 */
-}
-    </style>
-<!--    #blockA .col-12 {background-color: #EEEEEErgb(255,240,245);}-->
-<!--    #blockB .col-12 {background-color: rgb(237,254,223);}-->
-<!--    #blockC .col-12 {background-color: rgb(234,248,255);}-->
-<!--    #blockD .col-12 {background-color: rgb(255,250,227);}-->
 
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
-    <div class="col-md-12 m-0">
-        <div class="row justify-content-center" style="color: #828282;">
-            <div class="col-11 m-0 py-4 px-4">
-                <div class="row justify-content-around fixed-cols my-4" style="">
-                    <div class="col mx-3 py-4 px-4" style="border-radius: 15px; background-color: rgb(255,255,255,0.6)">
-                        <div class="row justify-content-center m-0">
-                            <div class="col-4">
-                                <div class="row p-2">
-                                    <div class="col-4 m-0 p-0" id="profileimagebox">
-                                        <img th:if="${user.profileImagePath == null}" th:src="@{/images/defaultprofileimage.png}" style="width: 100px; height: auto;" class="profile-image"/>
-                                        <img th:if="${user.profileImagePath != null}" th:src="@{/uploadFiles/{fileName}(fileName=${user.profileImagePath})}" style="width: 100px; height: auto;" class="profile-image"/>
-                                    </div>
-                                    <div class="col-8">
-                                        <div class="row">
-                                            <div class="col-12"><h3 th:text="${user.getNickname()} + '님의 '"></h3></div>
-                                            <div class="col-12"><h3>툰게더 활동내역은?</h3></div>
+            .form-control::placeholder {
+            color : #BBBBBB;
+            }
+
+            .date-container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        background-color: #8E4B6E;
+        color: white;
+        border-radius: 10px;
+        text-align:center;
+        font-family: "Work Sans", sans-serif;
+    }
+
+    .month {
+        font-size: 1.1rem; /* M의 크기를 설정 */
+        font-weight: 550;
+        line-height: 1;
+    }
+
+    .year {
+        font-size: 0.65rem; /* yyyy의 크기를 설정 */
+        font-weight: 400;
+    }
+    :root {
+        --background-color-light: #FFFFFF;
+        --text-color-light: #000000;
+        --toggle-background-light: #CCCCCC;
+        --toggle-ball-light: #FFFFFF;
+
+        --background-color-dark: #333333;
+        --text-color-dark: #FFFFFF;
+        --toggle-background-dark: #03C75A;
+        --toggle-ball-dark: #FFFFFF;
+
+        --font-size-base: 32px; /* 기본 텍스트 크기 */
+        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+    }
+
+
+
+    .toggle-switch {
+        position: relative;
+        display: inline-block;
+        width: 62px; /* 너비 조정 */
+        height: 38px; /* 높이 조정 */
+    }
+
+    .toggle-switch .checkbox {
+        opacity: 0;
+        width: 0;
+        height: 0;
+    }
+    #isToggledCheckbox {
+         opacity: 0;
+            width: 0;
+            height: 0;
+    }
+
+    .toggle-switch .label {
+        position: absolute;
+        cursor: pointer;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: var(--toggle-background-light);
+        transition: background-color 0.4s;
+        border-radius: 38px; /* 둥근 모서리 반경 조정 */
+    }
+
+    .toggle-switch .label:before {
+        position: absolute;
+        content: "";
+        height: 30px; /* 내부 원 높이 조정 */
+        width: 30px; /* 내부 원 너비 조정 */
+        left: 2px;
+        bottom: 0px;
+        background-color: var(--toggle-ball-light);
+        transition: transform 0.4s;
+        border-radius: 50%;
+    }
+
+    .toggle-switch input:checked + .label {
+        background-color: var(--toggle-background-dark);
+    }
+
+    .toggle-switch input:checked + .label:before {
+        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+    }
+
+             #absdiv {
+                position: relative;
+                top: 60px; /* Move down by 20px from its current position */
+                z-index : 1000;
+            }
+
+            #searchbutton {
+                background-color: #828282;
+            }
+
+            .card-img-top {
+                    width: 100%;
+                    height: 100px;
+                    object-fit: cover;
+                }
+
+            #blockA .col-5 {background-color: #EEEEEE;}
+            #blockB .col-5 {background-color: #EEEEEE;}
+            #blockC .col-5 {background-color: #EEEEEE;}
+            #blockD .col-5 {background-color: #EEEEEE;}
+            .fixed-cols {
+      display: flex;
+      flex-wrap: nowrap; /* 줄바꿈 방지 */
+    }
+        </style>
+        <!--    #blockA .col-12 {background-color: #EEEEEErgb(255,240,245);}-->
+        <!--    #blockB .col-12 {background-color: rgb(237,254,223);}-->
+        <!--    #blockC .col-12 {background-color: rgb(234,248,255);}-->
+        <!--    #blockD .col-12 {background-color: rgb(255,250,227);}-->
+
+        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+              rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+              rel="stylesheet">
+        <div class="col-md-12 m-0">
+            <div class="row justify-content-center" style="color: #828282;">
+                <div class="col-12 m-0 py-4 px-4">
+                    <div class="row justify-content-around fixed-cols my-4" style="">
+                        <div class="col mx-3 py-4 px-4"
+                             style="border-radius: 15px; background-color: rgb(255,255,255,0.6)">
+                            <div class="row justify-content-center m-0">
+                                <div class="col-4">
+                                    <div class="row p-2">
+                                        <div class="col-4 m-0 p-0" id="profileimagebox">
+                                            <img th:if="${user.profileImagePath == null}"
+                                                 th:src="@{/images/defaultprofileimage.png}"
+                                                 style="width: 100px; height: auto;" class="profile-image"/>
+                                            <img th:if="${user.profileImagePath != null}"
+                                                 th:src="@{/uploadFiles/{fileName}(fileName=${user.profileImagePath})}"
+                                                 style="width: 100px; height: auto;" class="profile-image"/>
+                                        </div>
+                                        <div class="col-8">
+                                            <div class="row">
+                                                <div class="col-12"><h3 th:text="${user.getNickname()} + '님의 '"></h3>
+                                                </div>
+                                                <div class="col-12"><h3>툰게더 활동내역은?</h3></div>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>
-                            </div>
-                            <div class="col-6">
-                                <nav class="navbar navbar-expand-md">
-                                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                                        <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-                                        <li><a th:href="@{/recruit/creator/choice}" class="nav-link px-2">창작자 등록</a></li>
-                                        <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                                    </ul>
-                                </nav>
+                                <div class="col-6">
+                                    <nav class="navbar navbar-expand-md">
+                                        <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+                                            <li><a th:href="@{/recruit/creator/choice}" class="nav-link px-2">창작자 등록</a>
+                                            </li>
+                                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a>
+                                            </li>
+                                        </ul>
+                                    </nav>
+                                </div>
                             </div>
                         </div>
                     </div>
+                    <div class="row justify-content-around fixed-cols" style="">
+                        <div class="col mx-3 py-4 px-4"
+                             style="border-radius: 15px; background-color: rgb(255,255,255,0.6);">
+                            <div class="row justify-content-around m-0" style="text-align: center;">
+                                <h3>나의 웹툰</h3>
+                            </div>
+                            <div class="col-12 clickable-row my-4" th:attr="data-href=@{/user/my/wt/webtoon}"
+                                 th:style="|background-color: white; border-radius: 15px; padding: 1.5rem 1.2rem; background-image: url(${myWtWebtoons != null && !myWtWebtoons.isEmpty() ? myWtWebtoons.get(0).thumbnailUrl : ''}); background-size: cover; background-position: center; background-color: rgba(0,0,0,0.4); background-blend-mode: multiply;|">
+                                <div class="row justify-content-center">
+                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                         style="opacity:0; aspect-ratio: 1; border-radius: 5px;">
+                                        <div class="date-container px-2 py-1">
+                                            <div class="month">8</div>
+                                            <div class="year">2024</div>
+                                        </div>
+                                    </div>
+                                    <div class="col-5"
+                                         style="opacity:0; color: #333333; font-size: 0.8rem; font-weight: 530;">닉네임
+                                    </div>
+
+                                    <div class="col-3"
+                                         style=" padding: 0; font-size: 0.8rem; text-align: right; color: #FFFFFF;">더보기
+                                    </div>
+                                </div>
+                                <div class="row justify-content-center">
+                                    <div class="col-12 my-3" style="">
+                                        <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                        <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                        <!-- 썸네일 이미지 있을때  -->
+                                        <!--                                        <img th:if="${#lists.size(myInEvent.eventFiles) > 0}" th:src="@{/uploadFiles/{fileName}(fileName=${myInEvent.eventFiles.get(0).fileName})}" class="card-img-top" alt="썸네일 이미지">-->
+                                    </div>
+                                </div>
+                                <div class="row" style="padding: 0; margin: 0;">
+                                    <div class="col-11"
+                                         style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: white; font-size: 1.05rem; font-weight: 530;">
+                                        북마크한 웹툰
+                                    </div>
+                                    <div class="col-1" style="padding: 0; text-align: right;"></div>
+                                </div>
+                                <div class="row" style="padding: 0; margin: 0;">
+                                    <div class="col-9"
+                                         style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color: white; font-size: 0.8rem; "
+                                         th:text="${dashboard.wtWebtoon} + '개'"></div>
+                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                </div>
+                                <div class="row" style="padding: 0; margin: 0;">
+                                    <div class="col-9"
+                                         style="opacity:0; padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color: white; font-size: 0.8rem; ">
+                                        2개
+                                    </div>
+                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                </div>
+                            </div>
+
+                            <div class="col-12 clickable-row my-4" th:attr="data-href=@{/user/my/wt/comment}"
+                                 th:style="|background-color: white; border-radius: 15px; padding: 1.5rem 1.2rem; background-image: url(${myWtComments != null && !myWtComments.isEmpty() ? myWtComments.get(0).thumbnailUrl : ''});background-size: cover; background-position: center; background-color: rgba(0,0,0,0.4); background-blend-mode: multiply;|">
+                                <div class="row justify-content-center">
+                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                         style="opacity: 0; aspect-ratio: 1; border-radius: 5px;">
+                                        <div class="date-container px-2 py-1">
+                                            <div class="month">8</div>
+                                            <div class="year">2024</div>
+                                        </div>
+                                    </div>
+                                    <div class="col-5"
+                                         style="opacity:0; color: #333333; font-size: 0.8rem; font-weight: 530;">닉네임
+                                    </div>
+
+                                    <div class="col-3"
+                                         style="padding: 0; font-size: 0.8rem; text-align: right; color: #FFFFFF;">더보기
+                                    </div>
+                                </div>
+                                <div class="row justify-content-center">
+                                    <div class="col-12 my-3" style="">
+                                        <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                        <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                        <!-- 썸네일 이미지 있을때  -->
+                                        <!--                                        <img th:if="${#lists.size(myInEvent.eventFiles) > 0}" th:src="@{/uploadFiles/{fileName}(fileName=${myInEvent.eventFiles.get(0).fileName})}" class="card-img-top" alt="썸네일 이미지">-->
+                                    </div>
+                                </div>
+                                <div class="row" style="padding: 0; margin: 0;">
+                                    <div class="col-11"
+                                         style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: white; font-size: 1.05rem; font-weight: 530;">
+                                        남긴 코멘트
+                                    </div>
+                                    <div class="col-1" style="padding: 0; text-align: right;"></div>
+                                </div>
+                                <div class="row" style="padding: 0; margin: 0;">
+                                    <div class="col-9"
+                                         style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color: white; font-size: 0.8rem; "
+                                         th:text="${dashboard.wtComment} + '개'"></div>
+                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                </div>
+                                <div class="row" style="padding: 0; margin: 0;">
+                                    <div class="col-9"
+                                         style="opacity:0; padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color: white; font-size: 0.8rem; ">
+                                        2개
+                                    </div>
+                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                </div>
+
+                            </div>
+                        </div>
+                        <div class="col mx-3 py-4 px-4"
+                             style="border-radius: 15px; background-color: rgb(255,255,255,0.6);">
+                            <div class="row justify-content-around m-0" style="text-align: center;">
+                                <h3>나의 소셜</h3>
+                            </div>
+                            <div class="col-12 clickable-row my-4" th:attr="data-href=@{/user/my/so/review}"
+                                 th:style="|background-color: white; border-radius: 15px; padding: 1.5rem 1.2rem; background-image: url(${mySoReviews != null && !mySoReviews.isEmpty() ? mySoReviews.get(0).thumbnailUrl : ''});background-size: cover; background-position: center; background-color: rgba(0,0,0,0.4); background-blend-mode: multiply;|">
+                                <div class="row justify-content-center">
+                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                         style="opacity: 0; aspect-ratio: 1; border-radius: 5px;">
+                                        <div class="date-container px-2 py-1">
+                                            <div class="month">8</div>
+                                            <div class="year">2024</div>
+                                        </div>
+                                    </div>
+                                    <div class="col-5"
+                                         style="opacity:0; color: #333333; font-size: 0.8rem; font-weight: 530;">닉네임
+                                    </div>
+
+                                    <div class="col-3"
+                                         style=" padding: 0; font-size: 0.8rem; text-align: right; color: #FFFFFF;">더보기
+                                    </div>
+                                </div>
+                                <div class="row justify-content-center">
+                                    <div class="col-12 my-3" style="">
+                                        <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                        <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                        <!-- 썸네일 이미지 있을때  -->
+                                        <!--                                        <img th:if="${#lists.size(myInEvent.eventFiles) > 0}" th:src="@{/uploadFiles/{fileName}(fileName=${myInEvent.eventFiles.get(0).fileName})}" class="card-img-top" alt="썸네일 이미지">-->
+                                    </div>
+                                </div>
+                                <div class="row" style="padding: 0; margin: 0;">
+                                    <div class="col-11"
+                                         style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: white; font-size: 1.05rem; font-weight: 530;">
+                                        좋아요한 리뷰
+                                    </div>
+                                    <div class="col-1" style="padding: 0; text-align: right;"></div>
+                                </div>
+                                <div class="row" style="padding: 0; margin: 0;">
+                                    <div class="col-9"
+                                         style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color: white; font-size: 0.8rem; "
+                                         th:text="${dashboard.soReview} + '개'"></div>
+                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                </div>
+                                <div class="row" style="padding: 0; margin: 0;">
+                                    <div class="col-9"
+                                         style="opacity:0; padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color: white; font-size: 0.8rem; ">
+                                        2개
+                                    </div>
+                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                </div>
+                            </div>
+
+                            <div class="col-12 clickable-row my-4" th:attr="data-href=@{/user/my/so/diary}"
+                                 th:style="|background-color: white; border-radius: 15px; padding: 1.5rem 1.2rem; background-image: url(${mySoDiaries != null && !mySoDiaries.isEmpty() ? mySoDiaries.get(0).thumbnailUrl : ''}); background-size: cover; background-position: center; background-color: rgba(0,0,0,0.4); background-blend-mode: multiply;|">
+                                <div class="row justify-content-center">
+                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                         style="opacity: 0; aspect-ratio: 1; border-radius: 5px;">
+                                        <div class="date-container px-2 py-1">
+                                            <div class="month">8</div>
+                                            <div class="year">2024</div>
+                                        </div>
+                                    </div>
+                                    <div class="col-5"
+                                         style="opacity:0; color: #333333; font-size: 0.8rem; font-weight: 530;">닉네임
+                                    </div>
+
+                                    <div class="col-3"
+                                         style="padding: 0; font-size: 0.8rem; text-align: right; color: #FFFFFF;">더보기
+                                    </div>
+                                </div>
+                                <div class="row justify-content-center">
+                                    <div class="col-12 my-3" style="">
+                                        <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                        <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                        <!-- 썸네일 이미지 있을때  -->
+                                        <!--                                        <img th:if="${#lists.size(myInEvent.eventFiles) > 0}" th:src="@{/uploadFiles/{fileName}(fileName=${myInEvent.eventFiles.get(0).fileName})}" class="card-img-top" alt="썸네일 이미지">-->
+                                    </div>
+                                </div>
+                                <div class="row" style="padding: 0; margin: 0;">
+                                    <div class="col-11"
+                                         style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: white; font-size: 1.05rem; font-weight: 530;">
+                                        다이어리 댓글
+                                    </div>
+                                    <div class="col-1" style="padding: 0; text-align: right;"></div>
+                                </div>
+                                <div class="row" style="padding: 0; margin: 0;">
+                                    <div class="col-9"
+                                         style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color: white; font-size: 0.8rem; "
+                                         th:text="${dashboard.soDiary} + '개'"></div>
+                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                </div>
+                                <div class="row" style="padding: 0; margin: 0;">
+                                    <div class="col-9"
+                                         style="opacity:0; padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color: white; font-size: 0.8rem; ">
+                                        2개
+                                    </div>
+                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                </div>
+
+                            </div>
+                        </div>
+                        <div class="col mx-3 py-4 px-4"
+                             style="border-radius: 15px; background-color: rgb(255,255,255,0.6);"
+                             th:if="${tempAuthCode == 'C' || tempAuthCode == 'A'}">
+                            <div class="row justify-content-around m-0" style="text-align: center;">
+                                <h3>나의 채용</h3>
+                            </div>
+                            <div class="col-12 clickable-row my-4"
+                                 style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                 th:attr="data-href=@{/user/my/rct/job}">
+                                <div class="row justify-content-center">
+                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                         style="aspect-ratio: 1; border-radius: 5px;">
+                                        <div class="date-container px-2 py-1">
+                                            <div class="month">8</div>
+                                            <div class="year">2024</div>
+                                        </div>
+                                    </div>
+                                    <div class="col-5"
+                                         style="opacity:0; color: #333333; font-size: 0.8rem; font-weight: 530;">닉네임
+                                    </div>
+
+                                    <div class="col-3"
+                                         style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;">더보기
+                                    </div>
+                                </div>
+                                <div class="row justify-content-center">
+                                    <div class="col-12 my-3" style="">
+                                        <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                        <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                        <!-- 썸네일 이미지 있을때  -->
+                                        <!--                                        <img th:if="${#lists.size(myInEvent.eventFiles) > 0}" th:src="@{/uploadFiles/{fileName}(fileName=${myInEvent.eventFiles.get(0).fileName})}" class="card-img-top" alt="썸네일 이미지">-->
+                                    </div>
+                                </div>
+                                <div class="row" style="padding: 0; margin: 0;">
+                                    <div class="col-11"
+                                         style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;">
+                                        내가 올린 공고
+                                    </div>
+                                    <div class="col-1" style="padding: 0; text-align: right;"></div>
+                                </div>
+                                <div class="row" style="padding: 0; margin: 0;">
+                                    <div class="col-9"
+                                         style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                         th:text="${dashboard.rctJob} + '건'">내용
+                                    </div>
+                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                </div>
+                                <div class="row" style="padding: 0; margin: 0;">
+                                    <div class="col-9"
+                                         style="opacity: 0; padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; ">
+                                        내용2
+                                    </div>
+                                    <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                </div>
+
+                            </div>
+                            <div class="col-12 clickable-row"
+                                 style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                 th:attr="data-href=@{/user/my/rct/free}">
+                                <div class="row justify-content-center">
+                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                         style="aspect-ratio: 1; border-radius: 5px;">
+                                        <div class="date-container px-2 py-1">
+                                            <div class="month">8</div>
+                                            <div class="year">2024</div>
+                                        </div>
+                                    </div>
+                                    <div class="col-5"
+                                         style="opacity:0; color: #333333; font-size: 0.8rem; font-weight: 530;">닉네임
+                                    </div>
+
+                                    <div class="col-3"
+                                         style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;">더보기
+                                    </div>
+                                </div>
+                                <div class="row justify-content-center">
+                                    <div class="col-12 my-3" style="">
+                                        <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                        <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                        <!-- 썸네일 이미지 있을때  -->
+                                        <!--                                        <img th:if="${#lists.size(myInEvent.eventFiles) > 0}" th:src="@{/uploadFiles/{fileName}(fileName=${myInEvent.eventFiles.get(0).fileName})}" class="card-img-top" alt="썸네일 이미지">-->
+                                    </div>
+                                </div>
+                                <div class="row" style="padding: 0; margin: 0;">
+                                    <div class="col-11"
+                                         style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;">
+                                        프리랜서 게시글
+                                    </div>
+                                    <div class="col-1" style="padding: 0; text-align: right;"></div>
+                                </div>
+                                <div class="row" style="padding: 0; margin: 0;">
+                                    <div class="col-9"
+                                         style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                         th:text="${dashboard.rctFree} + '건'">내용
+                                    </div>
+                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                </div>
+                                <div class="row" style="padding: 0; margin: 0;">
+                                    <div class="col-9"
+                                         style="opacity: 0; padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; ">
+                                        내용2
+                                    </div>
+                                    <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                </div>
+
+                            </div>
+                        </div>
+                        <div class="col mx-3 py-4 px-4"
+                             style="border-radius: 15px; background-color: rgb(255,255,255,0.6);"
+                             th:if="${tempAuthCode == 'B'}">
+                            <div class="row justify-content-around m-0" style="text-align: center;">
+                                <h3>나의 지원서</h3>
+                            </div>
+                            <div class="col-12 clickable-row my-4"
+                                 style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                 th:attr="data-href=@{/user/my/rct/apply}">
+                                <div class="row justify-content-center">
+                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                         style="aspect-ratio: 1; border-radius: 5px;">
+                                        <div class="date-container px-2 py-1">
+                                            <div class="month">8</div>
+                                            <div class="year">2024</div>
+                                        </div>
+                                    </div>
+                                    <div class="col-5"
+                                         style="opacity:0; color: #333333; font-size: 0.8rem; font-weight: 530;">닉네임
+                                    </div>
+
+                                    <div class="col-3"
+                                         style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;">더보기
+                                    </div>
+                                </div>
+                                <div class="row justify-content-center">
+                                    <div class="col-12 my-3" style="">
+                                        <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                        <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                        <!-- 썸네일 이미지 있을때  -->
+                                        <!--                                        <img th:if="${#lists.size(myInEvent.eventFiles) > 0}" th:src="@{/uploadFiles/{fileName}(fileName=${myInEvent.eventFiles.get(0).fileName})}" class="card-img-top" alt="썸네일 이미지">-->
+                                    </div>
+                                </div>
+                                <div class="row" style="padding: 0; margin: 0;">
+                                    <div class="col-11"
+                                         style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;">
+                                        제출한 지원서
+                                    </div>
+                                    <div class="col-1" style="padding: 0; text-align: right;"></div>
+                                </div>
+                                <div class="row" style="padding: 0; margin: 0;">
+                                    <div class="col-9"
+                                         style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                         th:text="${dashboard.rctApplication} + '건'">내용
+                                    </div>
+                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                </div>
+                                <div class="row" style="padding: 0; margin: 0;">
+                                    <div class="col-9"
+                                         style="opacity: 0; padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; ">
+                                        내용2
+                                    </div>
+                                    <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                </div>
+
+                            </div>
+                            <div class="col-12 clickable-row"
+                                 style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                 th:attr="data-href=@{/user/my/rct/order}">
+                                <div class="row justify-content-center">
+                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                         style="aspect-ratio: 1; border-radius: 5px;">
+                                        <div class="date-container px-2 py-1">
+                                            <div class="month">8</div>
+                                            <div class="year">2024</div>
+                                        </div>
+                                    </div>
+                                    <div class="col-5"
+                                         style="opacity:0; color: #333333; font-size: 0.8rem; font-weight: 530;">닉네임
+                                    </div>
+
+                                    <div class="col-3"
+                                         style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;">더보기
+                                    </div>
+                                </div>
+                                <div class="row justify-content-center">
+                                    <div class="col-12 my-3" style="">
+                                        <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                        <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                        <!-- 썸네일 이미지 있을때  -->
+                                        <!--                                        <img th:if="${#lists.size(myInEvent.eventFiles) > 0}" th:src="@{/uploadFiles/{fileName}(fileName=${myInEvent.eventFiles.get(0).fileName})}" class="card-img-top" alt="썸네일 이미지">-->
+                                    </div>
+                                </div>
+                                <div class="row" style="padding: 0; margin: 0;">
+                                    <div class="col-11"
+                                         style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;">
+                                        프리랜서 아이템
+                                    </div>
+                                    <div class="col-1" style="padding: 0; text-align: right;"></div>
+                                </div>
+                                <div class="row" style="padding: 0; margin: 0;">
+                                    <div class="col-9"
+                                         style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                         th:text="${dashboard.rctOrder} + '건'">내용
+                                    </div>
+                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                </div>
+                                <div class="row" style="padding: 0; margin: 0;">
+                                    <div class="col-9"
+                                         style="opacity: 0; padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; ">
+                                        내용2
+                                    </div>
+                                    <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                </div>
+
+                            </div>
+                        </div>
+                        <div class="col mx-3 py-4 px-4"
+                             style="border-radius: 15px; background-color: rgb(255,255,255,0.6);">
+                            <div class="row justify-content-around m-0" style="text-align: center;">
+                                <h3>나의 소식</h3>
+                            </div>
+                            <div class="col-12 clickable-row my-4"
+                                 style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                 th:attr="data-href=@{/user/my/in/journal}">
+                                <div class="row justify-content-center">
+                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                         style="aspect-ratio: 1; border-radius: 5px;">
+                                        <div class="date-container px-2 py-1">
+                                            <div class="month">8</div>
+                                            <div class="year">2024</div>
+                                        </div>
+                                    </div>
+                                    <div class="col-5"
+                                         style="opacity:0; color: #333333; font-size: 0.8rem; font-weight: 530;">닉네임
+                                    </div>
+
+                                    <div class="col-3"
+                                         style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;">더보기
+                                    </div>
+                                </div>
+                                <div class="row justify-content-center">
+                                    <div class="col-12 my-3" style="">
+                                        <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                        <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                        <!-- 썸네일 이미지 있을때  -->
+                                        <!--                                        <img th:if="${#lists.size(myInEvent.eventFiles) > 0}" th:src="@{/uploadFiles/{fileName}(fileName=${myInEvent.eventFiles.get(0).fileName})}" class="card-img-top" alt="썸네일 이미지">-->
+                                    </div>
+                                </div>
+                                <div class="row" style="padding: 0; margin: 0;">
+                                    <div class="col-11"
+                                         style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;">
+                                        좋아요한 소식
+                                    </div>
+                                    <div class="col-1" style="padding: 0; text-align: right;"></div>
+                                </div>
+                                <div class="row" style="padding: 0; margin: 0;">
+                                    <div class="col-9"
+                                         style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                         th:text="${dashboard.inJournal} + '개'">내용
+                                    </div>
+                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                </div>
+                                <div class="row" style="padding: 0; margin: 0;">
+                                    <div class="col-9"
+                                         style="opacity: 0; padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; ">
+                                        내용2
+                                    </div>
+                                    <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                </div>
+
+                            </div>
+                            <div class="col-12 clickable-row"
+                                 style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                 th:attr="data-href=@{/user/my/in/event}">
+                                <div class="row justify-content-center">
+                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                         style="aspect-ratio: 1; border-radius: 5px;">
+                                        <div class="date-container px-2 py-1">
+                                            <div class="month">8</div>
+                                            <div class="year">2024</div>
+                                        </div>
+                                    </div>
+                                    <div class="col-5"
+                                         style="opacity:0; color: #333333; font-size: 0.8rem; font-weight: 530;">닉네임
+                                    </div>
+
+                                    <div class="col-3"
+                                         style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;">더보기
+                                    </div>
+                                </div>
+                                <div class="row justify-content-center">
+                                    <div class="col-12 my-3" style="">
+                                        <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                        <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                        <!-- 썸네일 이미지 있을때  -->
+                                        <!--                                        <img th:if="${#lists.size(myInEvent.eventFiles) > 0}" th:src="@{/uploadFiles/{fileName}(fileName=${myInEvent.eventFiles.get(0).fileName})}" class="card-img-top" alt="썸네일 이미지">-->
+                                    </div>
+                                </div>
+                                <div class="row" style="padding: 0; margin: 0;">
+                                    <div class="col-11"
+                                         style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;">
+                                        좋아요한 행사
+                                    </div>
+                                    <div class="col-1" style="padding: 0; text-align: right;"></div>
+                                </div>
+                                <div class="row" style="padding: 0; margin: 0;">
+                                    <div class="col-9"
+                                         style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                         th:text="${dashboard.inEvent} + '개'">내용
+                                    </div>
+                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                </div>
+                                <div class="row" style="padding: 0; margin: 0;">
+                                    <div class="col-9"
+                                         style="opacity: 0; padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; ">
+                                        내용2
+                                    </div>
+                                    <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                </div>
+
+                            </div>
+                        </div>
+                    </div> <!-- A ROW -->
                 </div>
-                <div class="row justify-content-around fixed-cols" style="">
-                    <div class="col mx-3 py-4 px-4" style="border-radius: 15px; background-color: rgb(255,255,255,0.6);">
-                        <div class="row justify-content-around m-0" style="text-align: center;">
-                            <h3>나의 웹툰</h3>
-                        </div>
-                        <div class="col-12 clickable-row my-4" th:attr="data-href=@{/user/my/wt/webtoon}" th:style="|background-color: white; border-radius: 15px; padding: 1.5rem 1.2rem; background-image: url(${myWtWebtoons != null && !myWtWebtoons.isEmpty() ? myWtWebtoons.get(0).thumbnailUrl : ''}); background-size: cover; background-position: center; background-color: rgba(0,0,0,0.4); background-blend-mode: multiply;|">
-                            <div class="row justify-content-center">
-                                <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="opacity:0; aspect-ratio: 1; border-radius: 5px;">
-                                    <div class="date-container px-2 py-1">
-                                        <div class="month">8</div>
-                                        <div class="year" >2024</div>
-                                    </div>
-                                </div>
-                                <div class="col-5" style="opacity:0; color: #333333; font-size: 0.8rem; font-weight: 530;">닉네임
-                                </div>
-
-                                <div class="col-3" style=" padding: 0; font-size: 0.8rem; text-align: right; color: #FFFFFF;">더보기</div>
-                            </div>
-                            <div class="row justify-content-center">
-                                <div class="col-12 my-3" style="">
-                                    <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                    <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                    <!-- 썸네일 이미지 있을때  -->
-                                    <!--                                        <img th:if="${#lists.size(myInEvent.eventFiles) > 0}" th:src="@{/uploadFiles/{fileName}(fileName=${myInEvent.eventFiles.get(0).fileName})}" class="card-img-top" alt="썸네일 이미지">-->
-                                </div>
-                            </div>
-                            <div class="row" style="padding: 0; margin: 0;">
-                                <div class="col-11" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: white; font-size: 1.05rem; font-weight: 530;" >북마크한 웹툰</div>
-                                <div class="col-1" style="padding: 0; text-align: right;"></div>
-                            </div>
-                            <div class="row" style="padding: 0; margin: 0;">
-                                <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color: white; font-size: 0.8rem; " th:text="${dashboard.wtWebtoon} + '개'"></div>
-                                <div class="col-3" style="padding: 0; text-align: right;"></div>
-                            </div>
-                            <div class="row" style="padding: 0; margin: 0;">
-                                <div class="col-9" style="opacity:0; padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color: white; font-size: 0.8rem; " >2개</div>
-                                <div class="col-3" style="padding: 0; text-align: right;"></div>
-                            </div>
-                        </div>
-
-                        <div class="col-12 clickable-row my-4" th:attr="data-href=@{/user/my/wt/comment}" th:style="|background-color: white; border-radius: 15px; padding: 1.5rem 1.2rem; background-image: url(${myWtComments != null && !myWtComments.isEmpty() ? myWtComments.get(0).thumbnailUrl : ''});background-size: cover; background-position: center; background-color: rgba(0,0,0,0.4); background-blend-mode: multiply;|">
-                            <div class="row justify-content-center">
-                                <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="opacity: 0; aspect-ratio: 1; border-radius: 5px;">
-                                    <div class="date-container px-2 py-1">
-                                        <div class="month">8</div>
-                                        <div class="year" >2024</div>
-                                    </div>
-                                </div>
-                                <div class="col-5" style="opacity:0; color: #333333; font-size: 0.8rem; font-weight: 530;">닉네임
-                                </div>
-
-                                <div class="col-3" style="padding: 0; font-size: 0.8rem; text-align: right; color: #FFFFFF;">더보기</div>
-                            </div>
-                            <div class="row justify-content-center">
-                                <div class="col-12 my-3" style="">
-                                    <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                    <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                    <!-- 썸네일 이미지 있을때  -->
-                                    <!--                                        <img th:if="${#lists.size(myInEvent.eventFiles) > 0}" th:src="@{/uploadFiles/{fileName}(fileName=${myInEvent.eventFiles.get(0).fileName})}" class="card-img-top" alt="썸네일 이미지">-->
-                                </div>
-                            </div>
-                            <div class="row" style="padding: 0; margin: 0;">
-                                <div class="col-11" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: white; font-size: 1.05rem; font-weight: 530;" >남긴 코멘트</div>
-                                <div class="col-1" style="padding: 0; text-align: right;"></div>
-                            </div>
-                            <div class="row" style="padding: 0; margin: 0;">
-                                <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color: white; font-size: 0.8rem; "  th:text="${dashboard.wtComment} + '개'"></div>
-                                <div class="col-3" style="padding: 0; text-align: right;"></div>
-                            </div>
-                            <div class="row" style="padding: 0; margin: 0;">
-                                <div class="col-9" style="opacity:0; padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color: white; font-size: 0.8rem; " >2개</div>
-                                <div class="col-3" style="padding: 0; text-align: right;"></div>
-                            </div>
-
-                        </div>
-                    </div>
-                    <div class="col mx-3 py-4 px-4" style="border-radius: 15px; background-color: rgb(255,255,255,0.6);">
-                        <div class="row justify-content-around m-0" style="text-align: center;">
-                            <h3>나의 소셜</h3>
-                        </div>
-                        <div class="col-12 clickable-row my-4" th:attr="data-href=@{/user/my/so/review}" th:style="|background-color: white; border-radius: 15px; padding: 1.5rem 1.2rem; background-image: url(${mySoReviews != null && !mySoReviews.isEmpty() ? mySoReviews.get(0).thumbnailUrl : ''});background-size: cover; background-position: center; background-color: rgba(0,0,0,0.4); background-blend-mode: multiply;|">
-                            <div class="row justify-content-center">
-                                <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="opacity: 0; aspect-ratio: 1; border-radius: 5px;">
-                                    <div class="date-container px-2 py-1">
-                                        <div class="month">8</div>
-                                        <div class="year" >2024</div>
-                                    </div>
-                                </div>
-                                <div class="col-5" style="opacity:0; color: #333333; font-size: 0.8rem; font-weight: 530;">닉네임
-                                </div>
-
-                                <div class="col-3" style=" padding: 0; font-size: 0.8rem; text-align: right; color: #FFFFFF;">더보기</div>
-                            </div>
-                            <div class="row justify-content-center">
-                                <div class="col-12 my-3" style="">
-                                    <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                    <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                    <!-- 썸네일 이미지 있을때  -->
-                                    <!--                                        <img th:if="${#lists.size(myInEvent.eventFiles) > 0}" th:src="@{/uploadFiles/{fileName}(fileName=${myInEvent.eventFiles.get(0).fileName})}" class="card-img-top" alt="썸네일 이미지">-->
-                                </div>
-                            </div>
-                            <div class="row" style="padding: 0; margin: 0;">
-                                <div class="col-11" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: white; font-size: 1.05rem; font-weight: 530;" >좋아요한 리뷰</div>
-                                <div class="col-1" style="padding: 0; text-align: right;"></div>
-                            </div>
-                            <div class="row" style="padding: 0; margin: 0;">
-                                <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color: white; font-size: 0.8rem; " th:text="${dashboard.soReview} + '개'"></div>
-                                <div class="col-3" style="padding: 0; text-align: right;"></div>
-                            </div>
-                            <div class="row" style="padding: 0; margin: 0;">
-                                <div class="col-9" style="opacity:0; padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color: white; font-size: 0.8rem; " >2개</div>
-                                <div class="col-3" style="padding: 0; text-align: right;"></div>
-                            </div>
-                        </div>
-
-                        <div class="col-12 clickable-row my-4" th:attr="data-href=@{/user/my/so/diary}" th:style="|background-color: white; border-radius: 15px; padding: 1.5rem 1.2rem; background-image: url(${mySoDiaries != null && !mySoDiaries.isEmpty() ? mySoDiaries.get(0).thumbnailUrl : ''}); background-size: cover; background-position: center; background-color: rgba(0,0,0,0.4); background-blend-mode: multiply;|">
-                            <div class="row justify-content-center">
-                                <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="opacity: 0; aspect-ratio: 1; border-radius: 5px;">
-                                    <div class="date-container px-2 py-1">
-                                        <div class="month">8</div>
-                                        <div class="year" >2024</div>
-                                    </div>
-                                </div>
-                                <div class="col-5" style="opacity:0; color: #333333; font-size: 0.8rem; font-weight: 530;">닉네임
-                                </div>
-
-                                <div class="col-3" style="padding: 0; font-size: 0.8rem; text-align: right; color: #FFFFFF;">더보기</div>
-                            </div>
-                            <div class="row justify-content-center">
-                                <div class="col-12 my-3" style="">
-                                    <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                    <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                    <!-- 썸네일 이미지 있을때  -->
-                                    <!--                                        <img th:if="${#lists.size(myInEvent.eventFiles) > 0}" th:src="@{/uploadFiles/{fileName}(fileName=${myInEvent.eventFiles.get(0).fileName})}" class="card-img-top" alt="썸네일 이미지">-->
-                                </div>
-                            </div>
-                            <div class="row" style="padding: 0; margin: 0;">
-                                <div class="col-11" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: white; font-size: 1.05rem; font-weight: 530;" >다이어리 댓글</div>
-                                <div class="col-1" style="padding: 0; text-align: right;"></div>
-                            </div>
-                            <div class="row" style="padding: 0; margin: 0;">
-                                <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color: white; font-size: 0.8rem; "  th:text="${dashboard.soDiary} + '개'"></div>
-                                <div class="col-3" style="padding: 0; text-align: right;"></div>
-                            </div>
-                            <div class="row" style="padding: 0; margin: 0;">
-                                <div class="col-9" style="opacity:0; padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color: white; font-size: 0.8rem; " >2개</div>
-                                <div class="col-3" style="padding: 0; text-align: right;"></div>
-                            </div>
-
-                        </div>
-                    </div>
-                    <div class="col mx-3 py-4 px-4" style="border-radius: 15px; background-color: rgb(255,255,255,0.6);" th:if="${tempAuthCode == 'C' || tempAuthCode == 'A'}">
-                        <div class="row justify-content-around m-0" style="text-align: center;">
-                            <h3>나의 채용</h3>
-                        </div>
-                        <div class="col-12 clickable-row my-4" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:attr="data-href=@{/user/my/rct/job}" >
-                            <div class="row justify-content-center">
-                                <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                    <div class="date-container px-2 py-1">
-                                        <div class="month">8</div>
-                                        <div class="year" >2024</div>
-                                    </div>
-                                </div>
-                                <div class="col-5" style="opacity:0; color: #333333; font-size: 0.8rem; font-weight: 530;">닉네임
-                                </div>
-
-                                <div class="col-3" style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;">더보기</div>
-                            </div>
-                            <div class="row justify-content-center">
-                                <div class="col-12 my-3" style="">
-                                    <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                    <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                    <!-- 썸네일 이미지 있을때  -->
-                                    <!--                                        <img th:if="${#lists.size(myInEvent.eventFiles) > 0}" th:src="@{/uploadFiles/{fileName}(fileName=${myInEvent.eventFiles.get(0).fileName})}" class="card-img-top" alt="썸네일 이미지">-->
-                                </div>
-                            </div>
-                            <div class="row" style="padding: 0; margin: 0;">
-                                <div class="col-11" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" >내가 올린 공고</div>
-                                <div class="col-1" style="padding: 0; text-align: right;"></div>
-                            </div>
-                            <div class="row" style="padding: 0; margin: 0;">
-                                <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${dashboard.rctJob} + '건'">내용</div>
-                                <div class="col-3" style="padding: 0; text-align: right;"></div>
-                            </div>
-                            <div class="row" style="padding: 0; margin: 0;">
-                                <div class="col-9" style="opacity: 0; padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " >내용2</div>
-                                <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                            </div>
-
-                        </div>
-                        <div class="col-12 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:attr="data-href=@{/user/my/rct/free}" >
-                            <div class="row justify-content-center">
-                                <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                    <div class="date-container px-2 py-1">
-                                        <div class="month">8</div>
-                                        <div class="year" >2024</div>
-                                    </div>
-                                </div>
-                                <div class="col-5" style="opacity:0; color: #333333; font-size: 0.8rem; font-weight: 530;">닉네임
-                                </div>
-
-                                <div class="col-3" style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;">더보기</div>
-                            </div>
-                            <div class="row justify-content-center">
-                                <div class="col-12 my-3" style="">
-                                    <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                    <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                    <!-- 썸네일 이미지 있을때  -->
-                                    <!--                                        <img th:if="${#lists.size(myInEvent.eventFiles) > 0}" th:src="@{/uploadFiles/{fileName}(fileName=${myInEvent.eventFiles.get(0).fileName})}" class="card-img-top" alt="썸네일 이미지">-->
-                                </div>
-                            </div>
-                            <div class="row" style="padding: 0; margin: 0;">
-                                <div class="col-11" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" >프리랜서 게시글</div>
-                                <div class="col-1" style="padding: 0; text-align: right;"></div>
-                            </div>
-                            <div class="row" style="padding: 0; margin: 0;">
-                                <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${dashboard.rctFree} + '건'">내용</div>
-                                <div class="col-3" style="padding: 0; text-align: right;"></div>
-                            </div>
-                            <div class="row" style="padding: 0; margin: 0;">
-                                <div class="col-9" style="opacity: 0; padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " >내용2</div>
-                                <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                            </div>
-
-                        </div>
-                    </div>
-                    <div class="col mx-3 py-4 px-4" style="border-radius: 15px; background-color: rgb(255,255,255,0.6);" th:if="${tempAuthCode == 'B'}">
-                        <div class="row justify-content-around m-0" style="text-align: center;">
-                            <h3>나의 지원서</h3>
-                        </div>
-                        <div class="col-12 clickable-row my-4" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:attr="data-href=@{/user/my/rct/apply}" >
-                            <div class="row justify-content-center">
-                                <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                    <div class="date-container px-2 py-1">
-                                        <div class="month">8</div>
-                                        <div class="year" >2024</div>
-                                    </div>
-                                </div>
-                                <div class="col-5" style="opacity:0; color: #333333; font-size: 0.8rem; font-weight: 530;">닉네임
-                                </div>
-
-                                <div class="col-3" style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;">더보기</div>
-                            </div>
-                            <div class="row justify-content-center">
-                                <div class="col-12 my-3" style="">
-                                    <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                    <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                    <!-- 썸네일 이미지 있을때  -->
-                                    <!--                                        <img th:if="${#lists.size(myInEvent.eventFiles) > 0}" th:src="@{/uploadFiles/{fileName}(fileName=${myInEvent.eventFiles.get(0).fileName})}" class="card-img-top" alt="썸네일 이미지">-->
-                                </div>
-                            </div>
-                            <div class="row" style="padding: 0; margin: 0;">
-                                <div class="col-11" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" >제출한 지원서</div>
-                                <div class="col-1" style="padding: 0; text-align: right;"></div>
-                            </div>
-                            <div class="row" style="padding: 0; margin: 0;">
-                                <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${dashboard.rctApplication} + '건'">내용</div>
-                                <div class="col-3" style="padding: 0; text-align: right;"></div>
-                            </div>
-                            <div class="row" style="padding: 0; margin: 0;">
-                                <div class="col-9" style="opacity: 0; padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " >내용2</div>
-                                <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                            </div>
-
-                        </div>
-                        <div class="col-12 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:attr="data-href=@{/user/my/rct/order}" >
-                            <div class="row justify-content-center">
-                                <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                    <div class="date-container px-2 py-1">
-                                        <div class="month">8</div>
-                                        <div class="year" >2024</div>
-                                    </div>
-                                </div>
-                                <div class="col-5" style="opacity:0; color: #333333; font-size: 0.8rem; font-weight: 530;">닉네임
-                                </div>
-
-                                <div class="col-3" style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;">더보기</div>
-                            </div>
-                            <div class="row justify-content-center">
-                                <div class="col-12 my-3" style="">
-                                    <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                    <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                    <!-- 썸네일 이미지 있을때  -->
-                                    <!--                                        <img th:if="${#lists.size(myInEvent.eventFiles) > 0}" th:src="@{/uploadFiles/{fileName}(fileName=${myInEvent.eventFiles.get(0).fileName})}" class="card-img-top" alt="썸네일 이미지">-->
-                                </div>
-                            </div>
-                            <div class="row" style="padding: 0; margin: 0;">
-                                <div class="col-11" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" >프리랜서 아이템</div>
-                                <div class="col-1" style="padding: 0; text-align: right;"></div>
-                            </div>
-                            <div class="row" style="padding: 0; margin: 0;">
-                                <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${dashboard.rctOrder} + '건'">내용</div>
-                                <div class="col-3" style="padding: 0; text-align: right;"></div>
-                            </div>
-                            <div class="row" style="padding: 0; margin: 0;">
-                                <div class="col-9" style="opacity: 0; padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " >내용2</div>
-                                <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                            </div>
-
-                        </div>
-                    </div>
-                    <div class="col mx-3 py-4 px-4" style="border-radius: 15px; background-color: rgb(255,255,255,0.6);" >
-                        <div class="row justify-content-around m-0" style="text-align: center;">
-                            <h3>나의 소식</h3>
-                        </div>
-                        <div class="col-12 clickable-row my-4" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:attr="data-href=@{/user/my/in/journal}" >
-                            <div class="row justify-content-center">
-                                <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                    <div class="date-container px-2 py-1">
-                                        <div class="month">8</div>
-                                        <div class="year" >2024</div>
-                                    </div>
-                                </div>
-                                <div class="col-5" style="opacity:0; color: #333333; font-size: 0.8rem; font-weight: 530;">닉네임
-                                </div>
-
-                                <div class="col-3" style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;">더보기</div>
-                            </div>
-                            <div class="row justify-content-center">
-                                <div class="col-12 my-3" style="">
-                                    <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                    <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                    <!-- 썸네일 이미지 있을때  -->
-                                    <!--                                        <img th:if="${#lists.size(myInEvent.eventFiles) > 0}" th:src="@{/uploadFiles/{fileName}(fileName=${myInEvent.eventFiles.get(0).fileName})}" class="card-img-top" alt="썸네일 이미지">-->
-                                </div>
-                            </div>
-                            <div class="row" style="padding: 0; margin: 0;">
-                                <div class="col-11" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" >좋아요한 소식</div>
-                                <div class="col-1" style="padding: 0; text-align: right;"></div>
-                            </div>
-                            <div class="row" style="padding: 0; margin: 0;">
-                                <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${dashboard.inJournal} + '개'">내용</div>
-                                <div class="col-3" style="padding: 0; text-align: right;"></div>
-                            </div>
-                            <div class="row" style="padding: 0; margin: 0;">
-                                <div class="col-9" style="opacity: 0; padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " >내용2</div>
-                                <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                            </div>
-
-                        </div>
-                        <div class="col-12 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:attr="data-href=@{/user/my/in/event}" >
-                            <div class="row justify-content-center">
-                                <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                    <div class="date-container px-2 py-1">
-                                        <div class="month">8</div>
-                                        <div class="year" >2024</div>
-                                    </div>
-                                </div>
-                                <div class="col-5" style="opacity:0; color: #333333; font-size: 0.8rem; font-weight: 530;">닉네임
-                                </div>
-
-                                <div class="col-3" style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;">더보기</div>
-                            </div>
-                            <div class="row justify-content-center">
-                                <div class="col-12 my-3" style="">
-                                    <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                    <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                    <!-- 썸네일 이미지 있을때  -->
-                                    <!--                                        <img th:if="${#lists.size(myInEvent.eventFiles) > 0}" th:src="@{/uploadFiles/{fileName}(fileName=${myInEvent.eventFiles.get(0).fileName})}" class="card-img-top" alt="썸네일 이미지">-->
-                                </div>
-                            </div>
-                            <div class="row" style="padding: 0; margin: 0;">
-                                <div class="col-11" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" >좋아요한 행사</div>
-                                <div class="col-1" style="padding: 0; text-align: right;"></div>
-                            </div>
-                            <div class="row" style="padding: 0; margin: 0;">
-                                <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${dashboard.inEvent} + '개'">내용</div>
-                                <div class="col-3" style="padding: 0; text-align: right;"></div>
-                            </div>
-                            <div class="row" style="padding: 0; margin: 0;">
-                                <div class="col-9" style="opacity: 0; padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; ">내용2</div>
-                                <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                            </div>
-
-                        </div>
-                    </div>
-                </div> <!-- A ROW -->
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/user/mypage_editprofile.html
+++ b/src/main/resources/templates/user/mypage_editprofile.html
@@ -228,18 +228,22 @@
 <div class="jumbotron">
   <div class="container">
     <div class="row">
-      <div class="col-md-3 px-4">
-        <h3>프로필 수정</h3>
-      </div>
-      <div class="col-md-9">
-        <nav class="navbar navbar-expand-md">
-          <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-            <li>-</li>
-            <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-            <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-            <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-          </ul>
-        </nav>
+      <div class="col-9">
+        <div class="row">
+          <div class="col-md-3 px-4">
+            <h3>프로필 수정</h3>
+          </div>
+          <div class="col-md-9">
+            <nav class="navbar navbar-expand-md">
+              <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                <li>-</li>
+                <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+              </ul>
+            </nav>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/src/main/resources/templates/user/mypage_editprofile.html
+++ b/src/main/resources/templates/user/mypage_editprofile.html
@@ -545,8 +545,13 @@
   window.onload = function() {
         const urlParams = new URLSearchParams(window.location.search);
         const status = urlParams.get('status');
-
-        if (status === 'failure') {
+        if (status === 'editSuccess') {
+            alert("프로필 수정이 완료되었습니다.");
+        }
+        else if (status === 'editFailure') {
+            alert("프로필 수정 중 문제가 발생했습니다. 다시 시도해주세요.");
+        }
+        else if (status === 'withdrawnFailure') {
             alert("회원 탈퇴 처리 중 문제가 발생했습니다.");
         }
     }

--- a/src/main/resources/templates/user/mypage_editprofile.html
+++ b/src/main/resources/templates/user/mypage_editprofile.html
@@ -244,269 +244,287 @@
     </div>
   </div>
 </div>
-<div class="row">
-  <aside class="col-md-3 px-4">
-    <div class="row">
-      <div class="col-3"></div>
-      <div class="col-6">
-        <div class="panel">
-          <ul class="list-group">
-            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
-            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
-            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2" style="color: #03C75A;">프로필 수정</a></li>
-            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-          </ul>
+<div class="container" style="padding:0;">
+  <div class="row">
+    <aside class="col-md-3 px-4">
+      <div class="row">
+        <div class="col-3"></div>
+        <div class="col-6">
+          <div class="panel">
+            <ul class="list-group">
+              <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
+              <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+              <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
+              <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+              <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2" style="color: #03C75A;">프로필 수정</a></li>
+              <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+            </ul>
+          </div>
         </div>
       </div>
-    </div>
-  </aside>
-  <script>
-    // nickname available check
-        function checkNicknameDuplicate() {
-            const nickname = document.getElementById('nickname').value;
+    </aside>
+    <script>
+      // nickname available check
+          function checkNicknameDuplicate() {
+              const nickname = document.getElementById('nickname').value;
 
-            if(!nickname) {
-                alert('닉네임을 입력해 주세요.');
-                return;
-            }
+              if(!nickname) {
+                  alert('닉네임을 입력해 주세요.');
+                  return;
+              }
 
-            if (nickname.length < 4) {
-                alert('닉네임의 글자수는 최소 4자입니다.');
-                return;
-            }
+              if (nickname.length < 4) {
+                  alert('닉네임의 글자수는 최소 4자입니다.');
+                  return;
+              }
 
-            fetch(`/user/checkNicknameDuplicate?nickname=${encodeURIComponent(nickname)}`)
-                .then(response => response.json())
-                .then(data => {
-                    if (data.isDuplicate) alert('이미 사용 중인 닉네임입니다.');
-                    else alert('사용 가능한 닉네임입니다.');
-                })
-                .catch(error => {
-                    console.error('Error: ', error);
-                });
-        } //checkNicknameDuplicate()
+              fetch(`/user/checkNicknameDuplicate?nickname=${encodeURIComponent(nickname)}`)
+                  .then(response => response.json())
+                  .then(data => {
+                      if (data.isDuplicate) alert('이미 사용 중인 닉네임입니다.');
+                      else alert('사용 가능한 닉네임입니다.');
+                  })
+                  .catch(error => {
+                      console.error('Error: ', error);
+                  });
+          } //checkNicknameDuplicate()
 
-        // email available check
-        function checkEmailDuplicate() {
-            const email = document.getElementById('email').value;
+          // email available check
+          function checkEmailDuplicate() {
+              const email = document.getElementById('email').value;
 
-            if(!email) {
-                alert('이메일을 입력해 주세요.');
-                return;
-            }
+              if(!email) {
+                  alert('이메일을 입력해 주세요.');
+                  return;
+              }
 
-            // 이메일 검증
-            if (!validateEmail(email)) {
-                alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
-                return;
-            }
+              // 이메일 검증
+              if (!validateEmail(email)) {
+                  alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
+                  return;
+              }
 
-            fetch(`/user/checkEmailDuplicate?email=${encodeURIComponent(email)}`)
-                .then(response => response.json())
-                .then(data => {
-                    if (data.isDuplicate) alert('이미 등록된 이메일입니다.');
-                    else alert('등록 가능한 이메일입니다.');
-                })
-                .catch(error => {
-                    console.error('Error: ', error);
-                });
-        } //checkEmailDuplicate()
-  </script>
-
+              fetch(`/user/checkEmailDuplicate?email=${encodeURIComponent(email)}`)
+                  .then(response => response.json())
+                  .then(data => {
+                      if (data.isDuplicate) alert('이미 등록된 이메일입니다.');
+                      else alert('등록 가능한 이메일입니다.');
+                  })
+                  .catch(error => {
+                      console.error('Error: ', error);
+                  });
+          } //checkEmailDuplicate()
+    </script>
 
 
-
-  <div class="col-md-9">
-    <div class="row justify-content-start" style="color: #828282;">
-      <div class="col-8 p-3" id="loginbox">
-        <form th:action="@{/user/my/editprofile}" th:object="${user}" method="post" enctype="multipart/form-data" onsubmit="validateForm(event)" id="editProfileForm">
-          <div class="row p-2">
-            <div class="col-3 m-0 p-0" id="profileimagebox">
-              <img th:if="${user.profileImagePath == null}" src="/images/defaultprofileimage.png" style="width: 100px; height: auto;" class="profile-image"/>
-              <img th:if="${user.profileImagePath != null}" th:src="@{/uploadFiles/{fileName}(fileName=${user.profileImagePath})}" style="width: 100px; height: auto;" class="profile-image"/>
-              <div id="profileuploadbutton">
-                <label for="image">
-                  <div class="btn-upload" style="width: 30px; height: 30px; background-color: #828282; border-radius: 50%; display: flex; align-items: center; justify-content: center;">
-                    <div style="z-index:100;">
-                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#FFFFFF" class="bi bi-camera-fill" viewBox="0 0 16 16">
-                        <path d="M10.5 8.5a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0"/>
-                        <path d="M2 4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2h-1.172a2 2 0 0 1-1.414-.586l-.828-.828A2 2 0 0 0 9.172 2H6.828a2 2 0 0 0-1.414.586l-.828.828A2 2 0 0 1 3.172 4zm.5 2a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1m9 2.5a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0"/>
-                      </svg>
-<!--                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#FFFFFF" class="bi bi-plus" viewBox="0 0 16 16">-->
-<!--                        <path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4"/>-->
-<!--                      </svg>-->
+    <div class="col-md-9">
+      <div class="row justify-content-start" style="color: #828282;">
+        <div class="col-8 p-3" id="loginbox">
+          <form th:action="@{/user/my/editprofile}" th:object="${user}" method="post" enctype="multipart/form-data"
+                onsubmit="validateForm(event)" id="editProfileForm">
+            <div class="row p-2">
+              <div class="col-3 m-0 p-0" id="profileimagebox">
+                <img th:if="${user.profileImagePath == null}" src="/images/defaultprofileimage.png"
+                     style="width: 100px; height: auto;" class="profile-image"/>
+                <img th:if="${user.profileImagePath != null}"
+                     th:src="@{/uploadFiles/{fileName}(fileName=${user.profileImagePath})}"
+                     style="width: 100px; height: auto;" class="profile-image"/>
+                <div id="profileuploadbutton">
+                  <label for="image">
+                    <div class="btn-upload"
+                         style="width: 30px; height: 30px; background-color: #828282; border-radius: 50%; display: flex; align-items: center; justify-content: center;">
+                      <div style="z-index:100;">
+                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#FFFFFF"
+                             class="bi bi-camera-fill" viewBox="0 0 16 16">
+                          <path d="M10.5 8.5a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0"/>
+                          <path d="M2 4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2h-1.172a2 2 0 0 1-1.414-.586l-.828-.828A2 2 0 0 0 9.172 2H6.828a2 2 0 0 0-1.414.586l-.828.828A2 2 0 0 1 3.172 4zm.5 2a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1m9 2.5a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0"/>
+                        </svg>
+                        <!--                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#FFFFFF" class="bi bi-plus" viewBox="0 0 16 16">-->
+                        <!--                        <path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4"/>-->
+                        <!--                      </svg>-->
+                      </div>
                     </div>
+                  </label>
+                  <input type="file" name="image" id="image">
+                </div>
+              </div>
+              <div class="col-9"></div>
+            </div>
+            <div class="row p-2">
+              <div class="col-3">
+                아이디 <span class="required-star">*</span>
+              </div>
+              <div class="col-6">
+                <input class="form-control px-3" type="text" th:field="*{userId}" maxlength="20" minlength="4"
+                       readonly/>
+              </div>
+              <div class="col-3">
+              </div>
+            </div>
+            <div class="row p-2">
+              <div class="col-3">
+                비밀번호 <span class="required-star">*</span>
+              </div>
+              <div class="col-6">
+                <input class="form-control px-3 logininput" type="password" th:field="*{password}" maxlength="30"
+                       minlength="8" placeholder="회원정보 수정을 위해 비밀번호를 입력해주세요."/>
+              </div>
+              <div class="col-3">
+              </div>
+            </div>
+            <div class="row p-2">
+              <div class="col-3">
+                비밀번호 확인 <span class="required-star">*</span>
+              </div>
+              <div class="col-6">
+                <input class="form-control px-3 logininput" type="password" th:field="*{confirmPassword}" maxlength="30"
+                       minlength="8" placeholder="회원정보 수정을 위해 비밀번호를 입력해주세요."/>
+              </div>
+              <div class="col-3">
+              </div>
+            </div>
+            <div class="row p-2">
+              <div class="col-3">
+                닉네임 <span class="required-star">*</span>
+              </div>
+              <div class="col-6">
+                <input class="form-control px-3" type="text" th:field="*{nickname}" maxlength="20" minlength="4"/>
+              </div>
+              <div class="col-3">
+                <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;"
+                        onclick="checkNicknameDuplicate()">중복확인
+                </button>
+              </div>
+            </div>
+            <div class="row p-2">
+              <div class="col-3">
+                연락처
+              </div>
+              <div class="col-6">
+                <input class="form-control px-3 logininput" type="text" th:field="*{contactNumber}"
+                       oninput="autoFormatPhoneNumber(this)" placeholder="000-0000-0000"/>
+              </div>
+              <div class="col-3">
+              </div>
+            </div>
+            <div class="row p-2">
+              <div class="col-3">
+                성별
+              </div>
+              <div class="col-6">
+                <select class="form-select px-3" th:field="*{gender}">
+                  <option value="P">성별을 공개하지 않습니다</option>
+                  <option value="F">여</option>
+                  <option value="M">남</option>
+                </select>
+              </div>
+              <div class="col-3">
+              </div>
+            </div>
+            <div class="row p-2">
+              <div class="col-3">
+                <!-- 생년월일을 연도, 월, 일로 나누어 드롭다운 박스 형태로 입력 -->
+                생년월일
+              </div>
+              <div class="col-6">
+                <div class="row">
+                  <div class="col-4">
+                    <select class="form-select" id="year" name="year" th:field="*{year}" style="text-align:center;">
+                      <option th:each="y : ${years}" th:value="${y}" th:text="${y}">연도</option>
+                    </select>
                   </div>
-                </label>
-                <input type="file" name="image" id="image">
-              </div>
-            </div>
-            <div class="col-9"></div>
-          </div>
-          <div class="row p-2">
-            <div class="col-3">
-              아이디 <span class="required-star">*</span>
-            </div>
-            <div class="col-6">
-              <input class="form-control px-3" type="text" th:field="*{userId}" maxlength="20" minlength="4" readonly/>
-            </div>
-            <div class="col-3">
-            </div>
-          </div>
-          <div class="row p-2">
-            <div class="col-3">
-              비밀번호 <span class="required-star">*</span>
-            </div>
-            <div class="col-6">
-              <input class="form-control px-3 logininput" type="password" th:field="*{password}" maxlength="30" minlength="8" placeholder="회원정보 수정을 위해 비밀번호를 입력해주세요."/>
-            </div>
-            <div class="col-3">
-            </div>
-          </div>
-          <div class="row p-2">
-            <div class="col-3">
-              비밀번호 확인 <span class="required-star">*</span>
-            </div>
-            <div class="col-6">
-              <input class="form-control px-3 logininput" type="password" th:field="*{confirmPassword}" maxlength="30" minlength="8" placeholder="회원정보 수정을 위해 비밀번호를 입력해주세요."/>
-            </div>
-            <div class="col-3">
-            </div>
-          </div>
-          <div class="row p-2">
-            <div class="col-3">
-              닉네임 <span class="required-star">*</span>
-            </div>
-            <div class="col-6">
-              <input class="form-control px-3" type="text" th:field="*{nickname}" maxlength="20" minlength="4"/>
-            </div>
-            <div class="col-3">
-              <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;" onclick="checkNicknameDuplicate()">중복확인</button>
-            </div>
-          </div>
-          <div class="row p-2">
-            <div class="col-3">
-              연락처
-            </div>
-            <div class="col-6">
-              <input class="form-control px-3 logininput" type="text" th:field="*{contactNumber}" oninput="autoFormatPhoneNumber(this)" placeholder="000-0000-0000"/>
-            </div>
-            <div class="col-3">
-            </div>
-          </div>
-          <div class="row p-2">
-            <div class="col-3">
-              성별
-            </div>
-            <div class="col-6">
-              <select class="form-select px-3" th:field="*{gender}">
-                <option value="P">성별을 공개하지 않습니다</option>
-                <option value="F">여</option>
-                <option value="M">남</option>
-              </select>
-            </div>
-            <div class="col-3">
-            </div>
-          </div>
-          <div class="row p-2">
-            <div class="col-3">
-              <!-- 생년월일을 연도, 월, 일로 나누어 드롭다운 박스 형태로 입력 -->
-              생년월일
-            </div>
-            <div class="col-6">
-              <div class="row">
-                <div class="col-4">
-                  <select class="form-select" id="year" name="year" th:field="*{year}" style="text-align:center;">
-                    <option th:each="y : ${years}" th:value="${y}" th:text="${y}">연도</option>
-                  </select>
-                </div>
-                <div class="col-4">
-                  <select class="form-select" id="month" name="month" th:field="*{month}" style="text-align:center;">
-                    <option th:each="m : ${months}" th:value="${m}" th:text="${m}">월</option>
-                  </select>
-                </div>
-                <div class="col-4">
-                  <select class="form-select" id="day" name="day" th:field="*{day}" style="text-align:center;">
-                    <option th:each="d : ${days}" th:value="${d}" th:text="${d}">일</option>
-                  </select>
+                  <div class="col-4">
+                    <select class="form-select" id="month" name="month" th:field="*{month}" style="text-align:center;">
+                      <option th:each="m : ${months}" th:value="${m}" th:text="${m}">월</option>
+                    </select>
+                  </div>
+                  <div class="col-4">
+                    <select class="form-select" id="day" name="day" th:field="*{day}" style="text-align:center;">
+                      <option th:each="d : ${days}" th:value="${d}" th:text="${d}">일</option>
+                    </select>
+                  </div>
                 </div>
               </div>
+              <div class="col-3">
+              </div>
             </div>
-            <div class="col-3">
+            <div class="row p-2">
+              <div class="col-3">
+                실명
+              </div>
+              <div class="col-6">
+                <input class="form-control" type="text" th:field="*{realName}" maxlength="10"/>
+              </div>
+              <div class="col-3">
+              </div>
             </div>
-          </div>
-          <div class="row p-2">
-            <div class="col-3">
-              실명
+            <div class="row p-2">
+              <div class="col-3">
+                이메일 <span class="required-star">*</span>
+              </div>
+              <div class="col-6">
+                <input class="form-control" type="text" th:field="*{email}"/>
+              </div>
+              <div class="col-3">
+                <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;"
+                        onclick="checkEmailDuplicate()">중복확인
+                </button>
+              </div>
             </div>
-            <div class="col-6">
-              <input class="form-control" type="text" th:field="*{realName}" maxlength="10"/>
+            <div class="row p-2">
+              <div class="col-6">
+                자기소개(선택사항)
+              </div>
+              <div class="col-6">
+              </div>
+              <div class="col-12">
+                <textarea class="form-control logininput" rows="3" maxlength="150" th:field="*{bio}"
+                          placeholder="본인을 자유롭게 표현해주세요.&#13;&#10;소개 내용은 소셜 페이지에 활용됩니다!"></textarea>
+              </div>
             </div>
-            <div class="col-3">
+            <div class="col-12 p-2">
             </div>
-          </div>
-          <div class="row p-2">
-            <div class="col-3">
-              이메일 <span class="required-star">*</span>
+            <div class="row">
+              <div class="col-3 p-2">
+                <button type="submit" class="btn btn-primary btn-block" style="background-color:#03C75A; height:50px;">
+                  수정하기
+                </button>
+              </div>
             </div>
-            <div class="col-6">
-              <input class="form-control" type="text" th:field="*{email}"/>
-            </div>
-            <div class="col-3">
-              <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;" onclick="checkEmailDuplicate()">중복확인</button>
-            </div>
-          </div>
-          <div class="row p-2">
-            <div class="col-6">
-              자기소개(선택사항)
-            </div>
-            <div class="col-6">
-            </div>
-            <div class="col-12">
-              <textarea class="form-control logininput" rows="3" maxlength="150" th:field="*{bio}" placeholder="본인을 자유롭게 표현해주세요.&#13;&#10;소개 내용은 소셜 페이지에 활용됩니다!"></textarea>
-            </div>
-          </div>
-          <div class="col-12 p-2">
-          </div>
-          <div class="row">
-            <div class="col-3 p-2">
-              <button type="submit" class="btn btn-primary btn-block" style="background-color:#03C75A; height:50px;">수정하기</button>
-            </div>
-          </div>
-        </form>
+          </form>
+        </div>
       </div>
-    </div>
 
-    <div class="row justify-content-start" style="color: #828282;">
-      <div class="col-6" id="loginbox2">
-            <form id="deleteUserForm" th:action="@{/user/my/deleteprofile}" method="post">
-                <div class="row px-3">
-                    <a href="javascript:void(0);" onclick="document.getElementById('deleteUserForm').submit();" style="color: #828282;">탈퇴하기</a>
-                </div>
-            </form>
+      <div class="row justify-content-start" style="color: #828282;">
+        <div class="col-6" id="loginbox2">
+          <form id="deleteUserForm" th:action="@{/user/my/deleteprofile}" method="post">
+            <div class="row px-3">
+              <a href="javascript:void(0);" onclick="document.getElementById('deleteUserForm').submit();"
+                 style="color: #828282;">탈퇴하기</a>
+            </div>
+          </form>
+        </div>
       </div>
+
+
+      <!--    <form th:action="@{/user/signup}" th:object="${user}" method="post">-->
+      <!--        아이디 : <input type="text" name="userId"><br>-->
+      <!--        비밀번호 : <input type="password" name="password"><br>-->
+      <!--        비밀번호 확인 : <br>-->
+      <!--        닉네임 : <input type="text" name="nickname"><br>-->
+      <!--        연락처 : <input type="text" name="contactNumber"><br>-->
+      <!--        성별 : <select name="gender">-->
+      <!--        <option>성별을 공개하지 않습니다-->
+      <!--        <option>여-->
+      <!--        <option>남</select><br>-->
+      <!--        생년월일 : <input type="text" name="dateOfBirth"><br>-->
+      <!--        이메일 : <input type="text" name="email"><br>-->
+      <!--        자기소개(선택사항) : <input type="text" name="bio"><br>-->
+      <!--        <input type="checkbox" name="termsAgreement">본인은 툰게더 회원 약관에 동의합니다.<br>-->
+
+      <!--        <input type="submit">가입하기-->
+      <!--    </form>-->
     </div>
-
-
-  <!--    <form th:action="@{/user/signup}" th:object="${user}" method="post">-->
-  <!--        아이디 : <input type="text" name="userId"><br>-->
-  <!--        비밀번호 : <input type="password" name="password"><br>-->
-  <!--        비밀번호 확인 : <br>-->
-  <!--        닉네임 : <input type="text" name="nickname"><br>-->
-  <!--        연락처 : <input type="text" name="contactNumber"><br>-->
-  <!--        성별 : <select name="gender">-->
-  <!--        <option>성별을 공개하지 않습니다-->
-  <!--        <option>여-->
-  <!--        <option>남</select><br>-->
-  <!--        생년월일 : <input type="text" name="dateOfBirth"><br>-->
-  <!--        이메일 : <input type="text" name="email"><br>-->
-  <!--        자기소개(선택사항) : <input type="text" name="bio"><br>-->
-  <!--        <input type="checkbox" name="termsAgreement">본인은 툰게더 회원 약관에 동의합니다.<br>-->
-
-  <!--        <input type="submit">가입하기-->
-  <!--    </form>-->
   </div>
 </div>
 <div th:replace="common/footer.html"></div>

--- a/src/main/resources/templates/user/mypage_editprofile.html
+++ b/src/main/resources/templates/user/mypage_editprofile.html
@@ -20,6 +20,11 @@
 
 
   <style>
+    .container {
+            max-width: 1000px;
+            margin: 0 auto;
+            padding: 20px;
+        }
     .navbar {
       position: fixed;
       z-index: 1000;

--- a/src/main/resources/templates/user/mypage_editprofile.html
+++ b/src/main/resources/templates/user/mypage_editprofile.html
@@ -146,381 +146,404 @@
 
 <div th:replace="~{common/menubar}"></div>
 <style>
-  .jumbotron {
-    position : relative;
-    background-color : #EEEEEE;
-    }
-    .jumbotron .row {
-    position : absolute;
-    width : 100%;
-    bottom: 0%;
-    }
-
-    .nav-link {
-            color: #828282;
-    }
-
-    #loginbox {
-    border-radius : 5%;
-    border-color : #F2F2F2;
-    }
-
-    #loginbox2 {
-    border-radius : 5%;
-    border-color : #F2F2F2;
-    }
-
-    .form-control {
-    background-color : #FCFCFC;
-    border : none;
-    width : 100%;
-    height : 50px;
-    }
-
-    .logininput {
-    background-color : #FCFCFC;
-    border : none;
-    height : 50px;
-    }
-
-    .logininput::placeholder {
-    color : #BBBBBB;
-    }
-
-    button {
-    background-color : #03C75A;
-    }
-
-    #ban {
-    background-color : red;
-    }
-
-    .form-select {
-    background-color : #FCFCFC;
-    border : none;
-    width : 100%;
-    height : 50px;
-    }
-
-    .form-check-input {
-    accent-color: #03C75A;
-    }
-
-    .profile-image {
-    width: 100px;
-    height: auto;
-    border-radius: 50%;
-    object-fit: cover;
-    margin-right: 15px;
-    }
-
-  ul {
-  list-style: none;
-  padding-left : 0px;
+  html, body {
+      height: 100%;
+      margin: 0;
+  }
+  body {
+      display: flex;
+      flex-direction: column;
+  }
+  .content-wrapper {
+      flex: 1 0 auto;
+  }
+  footer {
+      flex-shrink: 0;
   }
 
-   .required-star {
-        color: #03C75A;
-    }
-
-  #image {
-    display: none;
-  }
-
-  #profileimagebox {
-    position : relative;
-  }
-  #profileuploadbutton {
-    position : absolute;
-    bottom : -10%;
-    right : 25%;
-  }
 </style>
-<div class="jumbotron">
-  <div class="container">
-    <div class="row">
-      <div class="col-9">
-        <div class="row">
-          <div class="col-md-3 px-4">
-            <h3>프로필 수정</h3>
-          </div>
-          <div class="col-md-9">
-            <nav class="navbar navbar-expand-md">
-              <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                <li>-</li>
-                <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-              </ul>
-            </nav>
+<div class="content-wrapper">
+  <style>
+    .jumbotron {
+      position : relative;
+      background-color : #EEEEEE;
+      }
+      .jumbotron .row {
+      position : absolute;
+      width : 100%;
+      bottom: 0%;
+      }
+
+      .nav-link {
+              color: #828282;
+      }
+
+      #loginbox {
+      border-radius : 5%;
+      border-color : #F2F2F2;
+      }
+
+      #loginbox2 {
+      border-radius : 5%;
+      border-color : #F2F2F2;
+      }
+
+      .form-control {
+      background-color : #FCFCFC;
+      border : none;
+      width : 100%;
+      height : 50px;
+      }
+
+      .logininput {
+      background-color : #FCFCFC;
+      border : none;
+      height : 50px;
+      }
+
+      .logininput::placeholder {
+      color : #BBBBBB;
+      }
+
+      button {
+      background-color : #03C75A;
+      }
+
+      #ban {
+      background-color : red;
+      }
+
+      .form-select {
+      background-color : #FCFCFC;
+      border : none;
+      width : 100%;
+      height : 50px;
+      }
+
+      .form-check-input {
+      accent-color: #03C75A;
+      }
+
+      .profile-image {
+      width: 100px;
+      height: auto;
+      border-radius: 50%;
+      object-fit: cover;
+      margin-right: 15px;
+      }
+
+    ul {
+    list-style: none;
+    padding-left : 0px;
+    }
+
+     .required-star {
+          color: #03C75A;
+      }
+
+    #image {
+      display: none;
+    }
+
+    #profileimagebox {
+      position : relative;
+    }
+    #profileuploadbutton {
+      position : absolute;
+      bottom : -10%;
+      right : 25%;
+    }
+  </style>
+  <div class="jumbotron">
+    <div class="container">
+      <div class="row">
+        <div class="col-9">
+          <div class="row">
+            <div class="col-md-3 px-4">
+              <h3>프로필 수정</h3>
+            </div>
+            <div class="col-md-9">
+              <nav class="navbar navbar-expand-md">
+                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                  <li>-</li>
+                  <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                  <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                  <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                </ul>
+              </nav>
+            </div>
           </div>
         </div>
       </div>
     </div>
   </div>
-</div>
-<div class="container" style="padding:0;">
-  <div class="row">
-    <aside class="col-md-3 px-4">
-      <div class="row">
-        <div class="col-1"></div>
-        <div class="col-8">
-          <div class="panel">
-            <ul class="list-group">
-              <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
-              <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-              <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
-              <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-              <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2" style="color: #03C75A;">프로필 수정</a></li>
-              <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-            </ul>
+  <div class="container" style="padding:0;">
+    <div class="row">
+      <aside class="col-md-3 px-4">
+        <div class="row">
+          <div class="col-1"></div>
+          <div class="col-8">
+            <div class="panel">
+              <ul class="list-group">
+                <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
+                <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
+                <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2" style="color: #03C75A;">프로필 수정</a></li>
+                <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+              </ul>
+            </div>
           </div>
         </div>
-      </div>
-    </aside>
-    <script>
-      // nickname available check
-          function checkNicknameDuplicate() {
-              const nickname = document.getElementById('nickname').value;
+      </aside>
+      <script>
+        // nickname available check
+            function checkNicknameDuplicate() {
+                const nickname = document.getElementById('nickname').value;
 
-              if(!nickname) {
-                  alert('닉네임을 입력해 주세요.');
-                  return;
-              }
+                if(!nickname) {
+                    alert('닉네임을 입력해 주세요.');
+                    return;
+                }
 
-              if (nickname.length < 4) {
-                  alert('닉네임의 글자수는 최소 4자입니다.');
-                  return;
-              }
+                if (nickname.length < 4) {
+                    alert('닉네임의 글자수는 최소 4자입니다.');
+                    return;
+                }
 
-              fetch(`/user/checkNicknameDuplicate?nickname=${encodeURIComponent(nickname)}`)
-                  .then(response => response.json())
-                  .then(data => {
-                      if (data.isDuplicate) alert('이미 사용 중인 닉네임입니다.');
-                      else alert('사용 가능한 닉네임입니다.');
-                  })
-                  .catch(error => {
-                      console.error('Error: ', error);
-                  });
-          } //checkNicknameDuplicate()
+                fetch(`/user/checkNicknameDuplicate?nickname=${encodeURIComponent(nickname)}`)
+                    .then(response => response.json())
+                    .then(data => {
+                        if (data.isDuplicate) alert('이미 사용 중인 닉네임입니다.');
+                        else alert('사용 가능한 닉네임입니다.');
+                    })
+                    .catch(error => {
+                        console.error('Error: ', error);
+                    });
+            } //checkNicknameDuplicate()
 
-          // email available check
-          function checkEmailDuplicate() {
-              const email = document.getElementById('email').value;
+            // email available check
+            function checkEmailDuplicate() {
+                const email = document.getElementById('email').value;
 
-              if(!email) {
-                  alert('이메일을 입력해 주세요.');
-                  return;
-              }
+                if(!email) {
+                    alert('이메일을 입력해 주세요.');
+                    return;
+                }
 
-              // 이메일 검증
-              if (!validateEmail(email)) {
-                  alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
-                  return;
-              }
+                // 이메일 검증
+                if (!validateEmail(email)) {
+                    alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
+                    return;
+                }
 
-              fetch(`/user/checkEmailDuplicate?email=${encodeURIComponent(email)}`)
-                  .then(response => response.json())
-                  .then(data => {
-                      if (data.isDuplicate) alert('이미 등록된 이메일입니다.');
-                      else alert('등록 가능한 이메일입니다.');
-                  })
-                  .catch(error => {
-                      console.error('Error: ', error);
-                  });
-          } //checkEmailDuplicate()
-    </script>
+                fetch(`/user/checkEmailDuplicate?email=${encodeURIComponent(email)}`)
+                    .then(response => response.json())
+                    .then(data => {
+                        if (data.isDuplicate) alert('이미 등록된 이메일입니다.');
+                        else alert('등록 가능한 이메일입니다.');
+                    })
+                    .catch(error => {
+                        console.error('Error: ', error);
+                    });
+            } //checkEmailDuplicate()
+      </script>
 
 
-    <div class="col-md-9" style="position:relative; top:-110px; z-index:1000;">
-      <div class="row justify-content-start" style="color: #828282;">
-        <div class="col-8 p-3" id="loginbox">
-          <form th:object="${user}" method="post" enctype="multipart/form-data"
-                onsubmit="validateForm(event)" id="editProfileForm">
-            <div class="row p-2">
-              <div class="col-3 m-0 p-0" id="profileimagebox">
-                <div id="imagePreview">
-                  <img th:if="${user.profileImagePath == null}" src="/images/defaultprofileimage.png"
-                       style="width: 100px; height: auto;" class="profile-image"/>
-                  <img th:if="${user.profileImagePath != null}"
-                       th:src="@{/uploadFiles/{fileName}(fileName=${user.profileImagePath})}"
-                       style="width: 100px; height: auto;" class="profile-image"/>
-                </div>
-                <div id="profileuploadbutton">
-                  <label for="image">
-                    <div class="btn-upload"
-                         style="width: 30px; height: 30px; background-color: #828282; border-radius: 50%; display: flex; align-items: center; justify-content: center;">
-                      <div style="z-index:100;">
-                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#FFFFFF"
-                             class="bi bi-camera-fill" viewBox="0 0 16 16">
-                          <path d="M10.5 8.5a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0"/>
-                          <path d="M2 4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2h-1.172a2 2 0 0 1-1.414-.586l-.828-.828A2 2 0 0 0 9.172 2H6.828a2 2 0 0 0-1.414.586l-.828.828A2 2 0 0 1 3.172 4zm.5 2a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1m9 2.5a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0"/>
-                        </svg>
-                        <!--                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#FFFFFF" class="bi bi-plus" viewBox="0 0 16 16">-->
-                        <!--                        <path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4"/>-->
-                        <!--                      </svg>-->
+      <div class="col-md-9" style="position:relative; top:-110px; z-index:1000;">
+        <div class="row justify-content-start" style="color: #828282;">
+          <div class="col-8 p-3" id="loginbox">
+            <form th:object="${user}" method="post" enctype="multipart/form-data"
+                  onsubmit="validateForm(event)" id="editProfileForm">
+              <div class="row p-2">
+                <div class="col-3 m-0 p-0" id="profileimagebox">
+                  <div id="imagePreview">
+                    <img th:if="${user.profileImagePath == null}" src="/images/defaultprofileimage.png"
+                         style="width: 100px; height: auto;" class="profile-image"/>
+                    <img th:if="${user.profileImagePath != null}"
+                         th:src="@{/uploadFiles/{fileName}(fileName=${user.profileImagePath})}"
+                         style="width: 100px; height: auto;" class="profile-image"/>
+                  </div>
+                  <div id="profileuploadbutton">
+                    <label for="image">
+                      <div class="btn-upload"
+                           style="width: 30px; height: 30px; background-color: #828282; border-radius: 50%; display: flex; align-items: center; justify-content: center;">
+                        <div style="z-index:100;">
+                          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#FFFFFF"
+                               class="bi bi-camera-fill" viewBox="0 0 16 16">
+                            <path d="M10.5 8.5a2.5 2.5 0 1 1-5 0 2.5 2.5 0 0 1 5 0"/>
+                            <path d="M2 4a2 2 0 0 0-2 2v6a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V6a2 2 0 0 0-2-2h-1.172a2 2 0 0 1-1.414-.586l-.828-.828A2 2 0 0 0 9.172 2H6.828a2 2 0 0 0-1.414.586l-.828.828A2 2 0 0 1 3.172 4zm.5 2a.5.5 0 1 1 0-1 .5.5 0 0 1 0 1m9 2.5a3.5 3.5 0 1 1-7 0 3.5 3.5 0 0 1 7 0"/>
+                          </svg>
+                          <!--                      <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="#FFFFFF" class="bi bi-plus" viewBox="0 0 16 16">-->
+                          <!--                        <path d="M8 4a.5.5 0 0 1 .5.5v3h3a.5.5 0 0 1 0 1h-3v3a.5.5 0 0 1-1 0v-3h-3a.5.5 0 0 1 0-1h3v-3A.5.5 0 0 1 8 4"/>-->
+                          <!--                      </svg>-->
+                        </div>
                       </div>
+                    </label>
+                    <input type="file" name="image" id="image">
+                  </div>
+                </div>
+                <div class="col-9"></div>
+              </div>
+              <div class="row p-2">
+                <div class="col-3">
+                  아이디 <span class="required-star">*</span>
+                </div>
+                <div class="col-6">
+                  <input class="form-control px-3" type="text" th:field="*{userId}" maxlength="20" minlength="4"
+                         readonly/>
+                </div>
+                <div class="col-3">
+                </div>
+              </div>
+              <div class="row p-2">
+                <div class="col-3">
+                  비밀번호 <span class="required-star">*</span>
+                </div>
+                <div class="col-6">
+                  <input class="form-control px-3 logininput" type="password" th:field="*{password}" maxlength="30"
+                         minlength="8" placeholder="회원정보 수정을 위해 비밀번호를 입력해주세요."/>
+                </div>
+                <div class="col-3">
+                </div>
+              </div>
+              <div class="row p-2">
+                <div class="col-3">
+                  비밀번호 확인 <span class="required-star">*</span>
+                </div>
+                <div class="col-6">
+                  <input class="form-control px-3 logininput" type="password" th:field="*{confirmPassword}"
+                         maxlength="30"
+                         minlength="8" placeholder="회원정보 수정을 위해 비밀번호를 입력해주세요."/>
+                </div>
+                <div class="col-3">
+                </div>
+              </div>
+              <div class="row p-2">
+                <div class="col-3">
+                  닉네임 <span class="required-star">*</span>
+                </div>
+                <div class="col-6">
+                  <input class="form-control px-3" type="text" th:field="*{nickname}" maxlength="20" minlength="4"/>
+                </div>
+                <div class="col-3">
+                  <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;"
+                          onclick="checkNicknameDuplicate()">중복확인
+                  </button>
+                </div>
+              </div>
+              <div class="row p-2">
+                <div class="col-3">
+                  연락처
+                </div>
+                <div class="col-6">
+                  <input class="form-control px-3 logininput" type="text" th:field="*{contactNumber}"
+                         oninput="autoFormatPhoneNumber(this)" placeholder="000-0000-0000"/>
+                </div>
+                <div class="col-3">
+                </div>
+              </div>
+              <div class="row p-2">
+                <div class="col-3">
+                  성별
+                </div>
+                <div class="col-6">
+                  <select class="form-select px-3" th:field="*{gender}">
+                    <option value="P">성별을 공개하지 않습니다</option>
+                    <option value="F">여</option>
+                    <option value="M">남</option>
+                  </select>
+                </div>
+                <div class="col-3">
+                </div>
+              </div>
+              <div class="row p-2">
+                <div class="col-3">
+                  <!-- 생년월일을 연도, 월, 일로 나누어 드롭다운 박스 형태로 입력 -->
+                  생년월일
+                </div>
+                <div class="col-6">
+                  <div class="row">
+                    <div class="col-4">
+                      <select class="form-select" id="year" name="year" th:field="*{year}" style="text-align:center;">
+                        <option th:each="y : ${years}" th:value="${y}" th:text="${y}">연도</option>
+                      </select>
                     </div>
-                  </label>
-                  <input type="file" name="image" id="image">
-                </div>
-              </div>
-              <div class="col-9"></div>
-            </div>
-            <div class="row p-2">
-              <div class="col-3">
-                아이디 <span class="required-star">*</span>
-              </div>
-              <div class="col-6">
-                <input class="form-control px-3" type="text" th:field="*{userId}" maxlength="20" minlength="4"
-                       readonly/>
-              </div>
-              <div class="col-3">
-              </div>
-            </div>
-            <div class="row p-2">
-              <div class="col-3">
-                비밀번호 <span class="required-star">*</span>
-              </div>
-              <div class="col-6">
-                <input class="form-control px-3 logininput" type="password" th:field="*{password}" maxlength="30"
-                       minlength="8" placeholder="회원정보 수정을 위해 비밀번호를 입력해주세요."/>
-              </div>
-              <div class="col-3">
-              </div>
-            </div>
-            <div class="row p-2">
-              <div class="col-3">
-                비밀번호 확인 <span class="required-star">*</span>
-              </div>
-              <div class="col-6">
-                <input class="form-control px-3 logininput" type="password" th:field="*{confirmPassword}" maxlength="30"
-                       minlength="8" placeholder="회원정보 수정을 위해 비밀번호를 입력해주세요."/>
-              </div>
-              <div class="col-3">
-              </div>
-            </div>
-            <div class="row p-2">
-              <div class="col-3">
-                닉네임 <span class="required-star">*</span>
-              </div>
-              <div class="col-6">
-                <input class="form-control px-3" type="text" th:field="*{nickname}" maxlength="20" minlength="4"/>
-              </div>
-              <div class="col-3">
-                <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;"
-                        onclick="checkNicknameDuplicate()">중복확인
-                </button>
-              </div>
-            </div>
-            <div class="row p-2">
-              <div class="col-3">
-                연락처
-              </div>
-              <div class="col-6">
-                <input class="form-control px-3 logininput" type="text" th:field="*{contactNumber}"
-                       oninput="autoFormatPhoneNumber(this)" placeholder="000-0000-0000"/>
-              </div>
-              <div class="col-3">
-              </div>
-            </div>
-            <div class="row p-2">
-              <div class="col-3">
-                성별
-              </div>
-              <div class="col-6">
-                <select class="form-select px-3" th:field="*{gender}">
-                  <option value="P">성별을 공개하지 않습니다</option>
-                  <option value="F">여</option>
-                  <option value="M">남</option>
-                </select>
-              </div>
-              <div class="col-3">
-              </div>
-            </div>
-            <div class="row p-2">
-              <div class="col-3">
-                <!-- 생년월일을 연도, 월, 일로 나누어 드롭다운 박스 형태로 입력 -->
-                생년월일
-              </div>
-              <div class="col-6">
-                <div class="row">
-                  <div class="col-4">
-                    <select class="form-select" id="year" name="year" th:field="*{year}" style="text-align:center;">
-                      <option th:each="y : ${years}" th:value="${y}" th:text="${y}">연도</option>
-                    </select>
-                  </div>
-                  <div class="col-4">
-                    <select class="form-select" id="month" name="month" th:field="*{month}" style="text-align:center;">
-                      <option th:each="m : ${months}" th:value="${m}" th:text="${m}">월</option>
-                    </select>
-                  </div>
-                  <div class="col-4">
-                    <select class="form-select" id="day" name="day" th:field="*{day}" style="text-align:center;">
-                      <option th:each="d : ${days}" th:value="${d}" th:text="${d}">일</option>
-                    </select>
+                    <div class="col-4">
+                      <select class="form-select" id="month" name="month" th:field="*{month}"
+                              style="text-align:center;">
+                        <option th:each="m : ${months}" th:value="${m}" th:text="${m}">월</option>
+                      </select>
+                    </div>
+                    <div class="col-4">
+                      <select class="form-select" id="day" name="day" th:field="*{day}" style="text-align:center;">
+                        <option th:each="d : ${days}" th:value="${d}" th:text="${d}">일</option>
+                      </select>
+                    </div>
                   </div>
                 </div>
+                <div class="col-3">
+                </div>
               </div>
-              <div class="col-3">
+              <div class="row p-2">
+                <div class="col-3">
+                  실명
+                </div>
+                <div class="col-6">
+                  <input class="form-control" type="text" th:field="*{realName}" maxlength="10"/>
+                </div>
+                <div class="col-3">
+                </div>
               </div>
-            </div>
-            <div class="row p-2">
-              <div class="col-3">
-                실명
+              <div class="row p-2">
+                <div class="col-3">
+                  이메일 <span class="required-star">*</span>
+                </div>
+                <div class="col-6">
+                  <input class="form-control" type="text" th:field="*{email}"/>
+                </div>
+                <div class="col-3">
+                  <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;"
+                          onclick="checkEmailDuplicate()">중복확인
+                  </button>
+                </div>
               </div>
-              <div class="col-6">
-                <input class="form-control" type="text" th:field="*{realName}" maxlength="10"/>
+              <div class="row p-2">
+                <div class="col-6">
+                  자기소개(선택사항)
+                </div>
+                <div class="col-6">
+                </div>
+                <div class="col-12">
+                    <textarea class="form-control logininput" rows="3" maxlength="150" th:field="*{bio}"
+                              placeholder="본인을 자유롭게 표현해주세요.&#13;&#10;소개 내용은 소셜 페이지에 활용됩니다!"></textarea>
+                </div>
               </div>
-              <div class="col-3">
+              <div class="col-12 p-2">
               </div>
-            </div>
-            <div class="row p-2">
-              <div class="col-3">
-                이메일 <span class="required-star">*</span>
+              <div class="row">
+                <div class="col-3 p-2">
+                  <button type="submit" class="btn btn-primary btn-block" style="background-color:#03C75A; height:50px;"
+                          th:attr="formaction=@{/user/my/editprofile}">
+                    수정하기
+                  </button>
+                  <button id="deleteUserForm" type="submit" style="display: none;"
+                          th:attr="formaction=@{/user/my/deleteprofile}">
+                    탈퇴하기
+                  </button>
+                </div>
               </div>
-              <div class="col-6">
-                <input class="form-control" type="text" th:field="*{email}"/>
-              </div>
-              <div class="col-3">
-                <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;"
-                        onclick="checkEmailDuplicate()">중복확인
-                </button>
-              </div>
-            </div>
-            <div class="row p-2">
-              <div class="col-6">
-                자기소개(선택사항)
-              </div>
-              <div class="col-6">
-              </div>
-              <div class="col-12">
-                <textarea class="form-control logininput" rows="3" maxlength="150" th:field="*{bio}"
-                          placeholder="본인을 자유롭게 표현해주세요.&#13;&#10;소개 내용은 소셜 페이지에 활용됩니다!"></textarea>
-              </div>
-            </div>
-            <div class="col-12 p-2">
-            </div>
-            <div class="row">
-              <div class="col-3 p-2">
-                <button type="submit" class="btn btn-primary btn-block" style="background-color:#03C75A; height:50px;" th:attr="formaction=@{/user/my/editprofile}">
-                  수정하기
-                </button>
-                <button id="deleteUserForm" type="submit" style="display: none;" th:attr="formaction=@{/user/my/deleteprofile}">
-                  탈퇴하기
-                </button>
-              </div>
-            </div>
-          </form>
+            </form>
+          </div>
         </div>
-      </div>
 
-      <div class="row justify-content-start" style="color: #828282;">
-        <div class="col-6" id="loginbox2">
+        <div class="row justify-content-start" style="color: #828282;">
+          <div class="col-6" id="loginbox2">
             <div class="row px-3">
               <a href="javascript:void(0);" onclick="confirmAndValidateDeletion(event);"
                  style="color: #828282;">탈퇴하기</a>
             </div>
+          </div>
         </div>
       </div>
     </div>

--- a/src/main/resources/templates/user/mypage_editprofile.html
+++ b/src/main/resources/templates/user/mypage_editprofile.html
@@ -18,6 +18,9 @@
   <!-- Latest compiled JavaScript -->
   <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
 
+  <!--KHG USER VALIDATION JS-->
+  <script src="/js/uservalidation2.js"></script>
+
 
   <style>
     .container {
@@ -30,117 +33,6 @@
       z-index: 1000;
     }
   </style>
-  <script>
-    //VALIDATION 1) 생년월일
-        function autoFormatDate(input) {
-            // Remove all non-digit characters
-            let date = input.value.replace(/\D/g, '');
-
-            // Apply the formatting based on the length of the input
-            if (date.length > 4 && date.length <= 6) {
-                date = date.substring(0, 4) + '-' + date.substring(4);
-            } else if (date.length > 6) {
-                date = date.substring(0, 4) + '-' + date.substring(4, 6) + '-' + date.substring(6, 8);
-            }
-
-            // Update the input value
-            input.value = date;
-        }
-
-        // 생년월일을 검증하는 함수
-        function validateDateOfBirth(dateOfBirth) {
-            const datePattern = /^\d{4}-\d{2}-\d{2}$/; // yyyy-mm-dd 형식
-            return datePattern.test(dateOfBirth);
-        }
-
-    //VALIDATION 2) 연락처
-        function autoFormatPhoneNumber(input) {
-            let phoneNumber = input.value.replace(/\D/g, ''); // Remove all non-digit characters
-            if (phoneNumber.length > 3 && phoneNumber.length <= 7) {
-                phoneNumber = phoneNumber.substring(0, 3) + '-' + phoneNumber.substring(3);
-            } else if (phoneNumber.length > 7) {
-                phoneNumber = phoneNumber.substring(0, 3) + '-' + phoneNumber.substring(3, 7) + '-' + phoneNumber.substring(7, 11);
-            }
-            input.value = phoneNumber;
-        }
-
-
-        // 연락처를 검증하는 함수
-        function validatePhoneNumber(phoneNumber) {
-            const phonePattern = /^\d{3}-\d{4}-\d{4}$/; // 000-0000-0000 형식
-            return phonePattern.test(phoneNumber);
-        }
-
-    // 폼 제출 전에 모든 필드를 검증하는 함수
-
-    //VALIDATION 3) 이메일
-        // 이메일 형식을 확인하는 함수
-        function validateEmail(email) {
-            // 이메일 형식을 검증하는 정규 표현식
-            const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-            return emailPattern.test(email);
-        }
-
-        // 폼 제출 전 이메일 형식을 검증하는 함수
-       function validateForm(event) {
-        const emailInput = document.querySelector('input[name="email"]');
-        const email = emailInput.value;
-
-        //const dateOfBirthInput = document.querySelector('input[name="dateOfBirth"]');
-        //const dateOfBirth = dateOfBirthInput.value;
-
-        const phoneNumberInput = document.querySelector('input[name="contactNumber"]');
-        const phoneNumber = phoneNumberInput.value;
-
-        // 연락처 검증
-            if (phoneNumber.length > 0 && !validatePhoneNumber(phoneNumber)) {
-                alert("연락처 형식이 올바르지 않습니다. 예: 000-0000-0000");
-                event.preventDefault(); // 폼 제출을 막음
-                return;
-            }
-
-        // 이메일 검증
-        if (!validateEmail(email)) {
-            alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
-            event.preventDefault(); // 폼 제출을 막음
-            return;
-        }
-
-        // 생년월일 검증
-        //if (!validateDateOfBirth(dateOfBirth)) {
-        //    alert("생년월일 형식이 올바르지 않습니다. 예: yyyy-mm-dd");
-        //    event.preventDefault(); // 폼 제출을 막음
-        //    return;
-        //}
-
-         // 비밀번호 일치 여부 검증
-        if (!validatePasswordMatch()) {
-            event.preventDefault(); // 비밀번호 불일치 시 폼 제출을 막음
-            return;
-        }
-
-    } //validateForm(event)
-
-    // 비밀번호 일치 여부를 검증하는 함수
-    function validatePasswordMatch() {
-      const password = document.querySelector('input[name="password"]').value;
-      const confirmPassword = document.querySelector('input[name="confirmPassword"]').value;
-
-      if (!password || !confirmPassword) {
-          alert('회원정보 수정을 위해 비밀번호와 비밀번호 확인란 모두 입력해 주세요.');
-          return false; // 비밀번호가 입력되지 않으면 폼 제출을 막음
-      }
-
-      if (password !== confirmPassword) {
-          alert('비밀번호를 다시 확인해주세요.');
-          return false; // 비밀번호가 일치하지 않으면 폼 제출을 막음
-      }
-
-      return true; // 비밀번호가 일치하고 둘 다 입력되었으면 폼 제출을 진행
-    }
-
-
-  </script>
 </head>
 <body>
 
@@ -296,59 +188,6 @@
           </div>
         </div>
       </aside>
-      <script>
-        // nickname available check
-            function checkNicknameDuplicate() {
-                const nickname = document.getElementById('nickname').value;
-
-                if(!nickname) {
-                    alert('닉네임을 입력해 주세요.');
-                    return;
-                }
-
-                if (nickname.length < 4) {
-                    alert('닉네임의 글자수는 최소 4자입니다.');
-                    return;
-                }
-
-                fetch(`/user/checkNicknameDuplicate?nickname=${encodeURIComponent(nickname)}`)
-                    .then(response => response.json())
-                    .then(data => {
-                        if (data.isDuplicate) alert('이미 사용 중인 닉네임입니다.');
-                        else alert('사용 가능한 닉네임입니다.');
-                    })
-                    .catch(error => {
-                        console.error('Error: ', error);
-                    });
-            } //checkNicknameDuplicate()
-
-            // email available check
-            function checkEmailDuplicate() {
-                const email = document.getElementById('email').value;
-
-                if(!email) {
-                    alert('이메일을 입력해 주세요.');
-                    return;
-                }
-
-                // 이메일 검증
-                if (!validateEmail(email)) {
-                    alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
-                    return;
-                }
-
-                fetch(`/user/checkEmailDuplicate?email=${encodeURIComponent(email)}`)
-                    .then(response => response.json())
-                    .then(data => {
-                        if (data.isDuplicate) alert('이미 등록된 이메일입니다.');
-                        else alert('등록 가능한 이메일입니다.');
-                    })
-                    .catch(error => {
-                        console.error('Error: ', error);
-                    });
-            } //checkEmailDuplicate()
-      </script>
-
 
       <div class="col-md-9" style="position:relative; top:-110px; z-index:1000;">
         <div class="row justify-content-start" style="color: #828282;">
@@ -386,6 +225,10 @@
                 <div class="col-9"></div>
               </div>
               <div class="row p-2">
+                <!--(회원가입과의 차이점) 기존의 닉네임/이메일은 중복체크 대상이면 안된다-->
+                <input id="hiddenNickname" type="hidden" th:value="${user.nickname}"/>
+                <input id="hiddenEmail" type="hidden"th:value="${user.email}"/>
+                <!--(회원가입과의 차이점) 기존의 닉네임/이메일은 중복체크 대상이면 안된다-->
                 <div class="col-3">
                   아이디 <span class="required-star">*</span>
                 </div>
@@ -500,11 +343,11 @@
                   이메일 <span class="required-star">*</span>
                 </div>
                 <div class="col-6">
-                  <input class="form-control" type="text" th:field="*{email}"/>
+                  <input class="form-control" type="text" th:field="*{email}" minlength="5" maxlength="100"/>
                 </div>
                 <div class="col-3">
-                  <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;"
-                          onclick="checkEmailDuplicate()">중복확인
+                  <button id="emailVerifyButton" type="button" class="btn btn-primary btn-block"
+                          style="background-color:#03C75A;" onclick="checkEmailDuplicate()">중복확인
                   </button>
                 </div>
               </div>
@@ -552,6 +395,7 @@
 <div th:replace="common/footer.html"></div>
 <script>
   //탈퇴 관련
+
   function confirmAndValidateDeletion(event) {
         event.preventDefault(); // 기본 동작을 방지하여 링크 클릭 시 바로 제출되지 않도록 합니다.
 

--- a/src/main/resources/templates/user/mypage_editprofile.html
+++ b/src/main/resources/templates/user/mypage_editprofile.html
@@ -252,7 +252,7 @@
   <div class="row">
     <aside class="col-md-3 px-4">
       <div class="row">
-        <div class="col-3"></div>
+        <div class="col-1"></div>
         <div class="col-6">
           <div class="panel">
             <ul class="list-group">

--- a/src/main/resources/templates/user/mypage_editprofile.html
+++ b/src/main/resources/templates/user/mypage_editprofile.html
@@ -253,7 +253,7 @@
     <aside class="col-md-3 px-4">
       <div class="row">
         <div class="col-1"></div>
-        <div class="col-6">
+        <div class="col-8">
           <div class="panel">
             <ul class="list-group">
               <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>

--- a/src/main/resources/templates/user/mypage_editprofile.html
+++ b/src/main/resources/templates/user/mypage_editprofile.html
@@ -332,7 +332,7 @@
     </script>
 
 
-    <div class="col-md-9">
+    <div class="col-md-9" style="position:relative; top:-110px; z-index:1000;">
       <div class="row justify-content-start" style="color: #828282;">
         <div class="col-8 p-3" id="loginbox">
           <form th:object="${user}" method="post" enctype="multipart/form-data"

--- a/src/main/resources/templates/user/mypage_editprofile.html
+++ b/src/main/resources/templates/user/mypage_editprofile.html
@@ -123,14 +123,20 @@
 
     // 비밀번호 일치 여부를 검증하는 함수
     function validatePasswordMatch() {
-        const password = document.querySelector('input[name="password"]').value;
-        const confirmPassword = document.querySelector('input[name="confirmPassword"]').value;
+      const password = document.querySelector('input[name="password"]').value;
+      const confirmPassword = document.querySelector('input[name="confirmPassword"]').value;
 
-        if (password !== confirmPassword) {
-            alert('비밀번호를 다시 확인해주세요.');
-            return false; // 비밀번호가 일치하지 않으면 폼 제출을 막음
-        }
-        return true; // 비밀번호가 일치하면 폼 제출을 진행
+      if (!password || !confirmPassword) {
+          alert('비밀번호와 비밀번호 확인란 모두 입력해 주세요.');
+          return false; // 비밀번호가 입력되지 않으면 폼 제출을 막음
+      }
+
+      if (password !== confirmPassword) {
+          alert('비밀번호를 다시 확인해주세요.');
+          return false; // 비밀번호가 일치하지 않으면 폼 제출을 막음
+      }
+
+      return true; // 비밀번호가 일치하고 둘 다 입력되었으면 폼 제출을 진행
     }
 
 
@@ -329,7 +335,7 @@
     <div class="col-md-9">
       <div class="row justify-content-start" style="color: #828282;">
         <div class="col-8 p-3" id="loginbox">
-          <form th:action="@{/user/my/editprofile}" th:object="${user}" method="post" enctype="multipart/form-data"
+          <form th:object="${user}" method="post" enctype="multipart/form-data"
                 onsubmit="validateForm(event)" id="editProfileForm">
             <div class="row p-2">
               <div class="col-3 m-0 p-0" id="profileimagebox">
@@ -497,8 +503,11 @@
             </div>
             <div class="row">
               <div class="col-3 p-2">
-                <button type="submit" class="btn btn-primary btn-block" style="background-color:#03C75A; height:50px;">
+                <button type="submit" class="btn btn-primary btn-block" style="background-color:#03C75A; height:50px;" th:attr="formaction=@{/user/my/editprofile}">
                   수정하기
+                </button>
+                <button id="deleteUserForm" type="submit" style="display: none;" th:attr="formaction=@{/user/my/deleteprofile}">
+                  탈퇴하기
                 </button>
               </div>
             </div>
@@ -508,37 +517,40 @@
 
       <div class="row justify-content-start" style="color: #828282;">
         <div class="col-6" id="loginbox2">
-          <form id="deleteUserForm" th:action="@{/user/my/deleteprofile}" method="post">
             <div class="row px-3">
-              <a href="javascript:void(0);" onclick="document.getElementById('deleteUserForm').submit();"
+              <a href="javascript:void(0);" onclick="confirmAndValidateDeletion(event);"
                  style="color: #828282;">탈퇴하기</a>
             </div>
-          </form>
         </div>
       </div>
-
-
-      <!--    <form th:action="@{/user/signup}" th:object="${user}" method="post">-->
-      <!--        아이디 : <input type="text" name="userId"><br>-->
-      <!--        비밀번호 : <input type="password" name="password"><br>-->
-      <!--        비밀번호 확인 : <br>-->
-      <!--        닉네임 : <input type="text" name="nickname"><br>-->
-      <!--        연락처 : <input type="text" name="contactNumber"><br>-->
-      <!--        성별 : <select name="gender">-->
-      <!--        <option>성별을 공개하지 않습니다-->
-      <!--        <option>여-->
-      <!--        <option>남</select><br>-->
-      <!--        생년월일 : <input type="text" name="dateOfBirth"><br>-->
-      <!--        이메일 : <input type="text" name="email"><br>-->
-      <!--        자기소개(선택사항) : <input type="text" name="bio"><br>-->
-      <!--        <input type="checkbox" name="termsAgreement">본인은 툰게더 회원 약관에 동의합니다.<br>-->
-
-      <!--        <input type="submit">가입하기-->
-      <!--    </form>-->
     </div>
   </div>
 </div>
 <div th:replace="common/footer.html"></div>
+<script>
+  //탈퇴 관련
+  function confirmAndValidateDeletion(event) {
+        event.preventDefault(); // 기본 동작을 방지하여 링크 클릭 시 바로 제출되지 않도록 합니다.
+
+        const confirmation = confirm("정말로 탈퇴하시겠습니까?");
+
+        if (confirmation && validatePasswordMatch()) {
+            // 확인 창에서 "예"를 선택하고, 비밀번호가 유효한 경우에 폼을 제출합니다.
+            // 폼을 제출하였을 때 비밀번호 일치여부를 UserService에서 확인할 것임
+            document.getElementById('deleteUserForm').click();
+        }
+    }
+
+  //탈퇴 폼 제출 후처리
+  window.onload = function() {
+        const urlParams = new URLSearchParams(window.location.search);
+        const status = urlParams.get('status');
+
+        if (status === 'failure') {
+            alert("회원 탈퇴 처리 중 문제가 발생했습니다.");
+        }
+    }
+</script>
 <script>
   document.getElementById('image').addEventListener('change', function(event) {
     const files = event.target.files;

--- a/src/main/resources/templates/user/mypage_editprofile.html
+++ b/src/main/resources/templates/user/mypage_editprofile.html
@@ -226,19 +226,21 @@
   }
 </style>
 <div class="jumbotron">
-  <div class="row">
-    <div class="col-md-3 px-4">
-      <h3>프로필 수정</h3>
-    </div>
-    <div class="col-md-9">
-      <nav class="navbar navbar-expand-md">
-        <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-          <li>-</li>
-<!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-<!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-<!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-        </ul>
-      </nav>
+  <div class="container">
+    <div class="row">
+      <div class="col-md-3 px-4">
+        <h3>프로필 수정</h3>
+      </div>
+      <div class="col-md-9">
+        <nav class="navbar navbar-expand-md">
+          <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+            <li>-</li>
+            <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+            <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+            <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+          </ul>
+        </nav>
+      </div>
     </div>
   </div>
 </div>

--- a/src/main/resources/templates/user/mypage_editprofile.html
+++ b/src/main/resources/templates/user/mypage_editprofile.html
@@ -328,11 +328,13 @@
                 onsubmit="validateForm(event)" id="editProfileForm">
             <div class="row p-2">
               <div class="col-3 m-0 p-0" id="profileimagebox">
-                <img th:if="${user.profileImagePath == null}" src="/images/defaultprofileimage.png"
-                     style="width: 100px; height: auto;" class="profile-image"/>
-                <img th:if="${user.profileImagePath != null}"
-                     th:src="@{/uploadFiles/{fileName}(fileName=${user.profileImagePath})}"
-                     style="width: 100px; height: auto;" class="profile-image"/>
+                <div id="imagePreview">
+                  <img th:if="${user.profileImagePath == null}" src="/images/defaultprofileimage.png"
+                       style="width: 100px; height: auto;" class="profile-image"/>
+                  <img th:if="${user.profileImagePath != null}"
+                       th:src="@{/uploadFiles/{fileName}(fileName=${user.profileImagePath})}"
+                       style="width: 100px; height: auto;" class="profile-image"/>
+                </div>
                 <div id="profileuploadbutton">
                   <label for="image">
                     <div class="btn-upload"
@@ -532,5 +534,27 @@
   </div>
 </div>
 <div th:replace="common/footer.html"></div>
+<script>
+  document.getElementById('image').addEventListener('change', function(event) {
+    const files = event.target.files;
+    const imagePreview = document.getElementById('imagePreview');
+    imagePreview.innerHTML = '';
+    Array.from(files).forEach(file => {
+        const reader = new FileReader();
+        reader.onload = function(e) {
+            const imgElement = document.createElement('img');
+            imgElement.src = e.target.result;
+
+            // 스타일과 클래스 추가
+            imgElement.style.width = '100px';
+            imgElement.style.height = 'auto';
+            imgElement.className = 'profile-image';
+
+            imagePreview.appendChild(imgElement);
+        }; //reader.onload
+        reader.readAsDataURL(file);
+    }); //Array.from(files).forEach()
+}); //addEventListener()
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/user/mypage_editprofile.html
+++ b/src/main/resources/templates/user/mypage_editprofile.html
@@ -127,7 +127,7 @@
       const confirmPassword = document.querySelector('input[name="confirmPassword"]').value;
 
       if (!password || !confirmPassword) {
-          alert('비밀번호와 비밀번호 확인란 모두 입력해 주세요.');
+          alert('회원정보 수정을 위해 비밀번호와 비밀번호 확인란 모두 입력해 주세요.');
           return false; // 비밀번호가 입력되지 않으면 폼 제출을 막음
       }
 

--- a/src/main/resources/templates/user/mypage_in_event.html
+++ b/src/main/resources/templates/user/mypage_in_event.html
@@ -306,14 +306,69 @@
             <div class="row" style="color: #828282;">
                 <div class="col-11">
                     <div class="row">
-                        <div class="col-12">
+                        <div class="col-12 p-0">
+                            <style>
+                                .col-4 select {
+                                    border-radius: 50px;
+                                    text-align: center;
+                                }
+                                /* 검색창 스타일 */
+                                .search-container {
+                                    width: 300px;
+                                }
+
+                                .search-container select {
+                                    position: absolute;
+                                    left: 0%;
+                                    width: 30%;
+                                    height: 50px;
+                                    color: #828282;
+                                    font-size: 1rem;
+                                    border-radius: 50px 0 0 50px;
+                                    outline: none;
+                                }
+                                .search-container input[type="text"] {
+                                    position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
+                                    left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
+                                    width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
+                                    height: 50px;
+                                    padding: 10px 40px 10px 15px;
+                                    font-size: 1rem;
+                                    outline: none;
+                                    border-radius: 0 50px 50px 0;
+                                    transition: border-color 0.3s, background-color 0.3s;
+                                    color: #828282; /* 입력 텍스트 색상 변경 */
+                                }
+
+                                .search-container input[type="text"]::placeholder {
+                                    color: #BBBBBB; /* placeholder 색상 변경 */
+                                }
+
+
+                                .search-container button {
+                                    position: absolute;
+                                    right: 1rem;
+                                    top: 25px;
+                                    background: none;
+                                    transform: translateY(-50%);
+                                    border: none;
+                                    cursor: pointer;
+                                }
+
+                                .search-container button i {
+                                    color: #666;
+                                }
+
+                                .search-container button:hover i {
+                                    color: #03C75A;
+                                }
+                            </style>
                             <form id="filter-and-sort-form" th:action="@{/user/my/in/event}" method="get">
-                                <div class="row">
-                                    <div class="col-7">
+                                <div class="row m-0">
+                                    <div class="col-7 p-0">
                                         <div class="row justify-content-start m-0">
-                                            <div class="col-4">
-                                                <!-- 검색 조건 -->
-                                                <label>
+                                            <div class="col-12 p-0">
+                                                <div class="search-container">
                                                     <select class="form-select px-3" name="searchBy">
                                                         <option value="title" th:selected="${searchBy == 'title'}">제목
                                                         </option>
@@ -327,16 +382,12 @@
                                                             행사주소
                                                         </option>
                                                     </select>
-                                                </label>
-                                            </div>
-                                            <div class="col-6">
-                                                <input class="form-control px-3" type="text" name="searchTerm"
-                                                       placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
-                                            </div>
-                                            <div class="col-2">
-                                                <!-- 검색 버튼 -->
-                                                <button id="searchbutton" type="submit" class="btn btn-primary">검색
-                                                </button>
+                                                    <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
+                                                    <!-- 검색 버튼 -->
+                                                    <button type="submit">
+                                                        <i class="fas fa-search"></i>
+                                                    </button>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>

--- a/src/main/resources/templates/user/mypage_in_event.html
+++ b/src/main/resources/templates/user/mypage_in_event.html
@@ -132,7 +132,7 @@
         <aside class="col-md-3 px-4">
             <div class="row">
                 <div class="col-1"></div>
-                <div class="col-6">
+                <div class="col-8">
                     <div class="panel">
                         <ul class="list-group">
                             <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>

--- a/src/main/resources/templates/user/mypage_in_event.html
+++ b/src/main/resources/templates/user/mypage_in_event.html
@@ -122,33 +122,35 @@
         </div>
     </div>
 </div>
-<div class="row">
-    <aside class="col-md-3 px-4">
-        <div class="row">
-            <div class="col-3"></div>
-            <div class="col-6">
-                <div class="panel">
-                    <ul class="list-group">
-                        <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
-                        <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-                        <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
-                        <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2" style="color: #03C75A;">나의 소식</a></li>
-                        <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                        <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-                    </ul>
+<div class="container" style="padding:0;">
+    <div class="row">
+        <aside class="col-md-3 px-4">
+            <div class="row">
+                <div class="col-3"></div>
+                <div class="col-6">
+                    <div class="panel">
+                        <ul class="list-group">
+                            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
+                            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
+                            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2" style="color: #03C75A;">나의
+                                소식</a></li>
+                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+                        </ul>
+                    </div>
                 </div>
             </div>
-        </div>
-    </aside>
-<!--    <script>-->
-<!--        function toggleCheckboxValue() {-->
-<!--            const checkbox = document.getElementById('isToggledCheckbox');-->
-<!--            if(!checkbox.checked) checkbox.value = 'N';-->
-<!--            else checkbox.value = 'Y';-->
-<!--            document.getElementById('filter-form').submit();-->
-<!--        }-->
-<!--    </script>-->
-    <script> // toggle + sorting
+        </aside>
+        <!--    <script>-->
+        <!--        function toggleCheckboxValue() {-->
+        <!--            const checkbox = document.getElementById('isToggledCheckbox');-->
+        <!--            if(!checkbox.checked) checkbox.value = 'N';-->
+        <!--            else checkbox.value = 'Y';-->
+        <!--            document.getElementById('filter-form').submit();-->
+        <!--        }-->
+        <!--    </script>-->
+        <script> // toggle + sorting
         function updateCheckboxValueAndSubmit() {
             const checkbox = document.getElementById('isToggledCheckbox');
             const form = document.getElementById('filter-and-sort-form');
@@ -161,431 +163,505 @@
         function submitForm() {
             document.getElementById('filter-and-sort-form').submit();
         }
-    </script>
-    <style>
-        .form-select {
-        background-color : #FCFCFC;
-        border : none;
-        width : 100%;
-        height : 50px;
-        }
-        select {
-        color : #828282;
-        }
-        .form-control {
-        background-color : #FCFCFC;
-        border : none;
-        width : 100%;
-        height : 50px;
-        }
-
-
-        .form-control::placeholder {
-        color : #BBBBBB;
-        }
-
-        .date-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    background-color: #8E4B6E;
-    color: white;
-    border-radius: 10px;
-    text-align:center;
-    font-family: "Work Sans", sans-serif;
-}
-
-.month {
-    font-size: 1.1rem; /* M의 크기를 설정 */
-    font-weight: 550;
-    line-height: 1;
-}
-
-.year {
-    font-size: 0.65rem; /* yyyy의 크기를 설정 */
-    font-weight: 400;
-}
-:root {
-    --background-color-light: #FFFFFF;
-    --text-color-light: #000000;
-    --toggle-background-light: #CCCCCC;
-    --toggle-ball-light: #FFFFFF;
-
-    --background-color-dark: #333333;
-    --text-color-dark: #FFFFFF;
-    --toggle-background-dark: #03C75A;
-    --toggle-ball-dark: #FFFFFF;
-
-    --font-size-base: 32px; /* 기본 텍스트 크기 */
-    --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
-}
-
-
-
-.toggle-switch {
-    position: relative;
-    display: inline-block;
-    width: 62px; /* 너비 조정 */
-    height: 38px; /* 높이 조정 */
-}
-
-.toggle-switch .checkbox {
-    opacity: 0;
-    width: 0;
-    height: 0;
-}
-#isToggledCheckbox {
-     opacity: 0;
-        width: 0;
-        height: 0;
-}
-
-.toggle-switch .label {
-    position: absolute;
-    cursor: pointer;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: var(--toggle-background-light);
-    transition: background-color 0.4s;
-    border-radius: 38px; /* 둥근 모서리 반경 조정 */
-}
-
-.toggle-switch .label:before {
-    position: absolute;
-    content: "";
-    height: 30px; /* 내부 원 높이 조정 */
-    width: 30px; /* 내부 원 너비 조정 */
-    left: 2px;
-    bottom: 0px;
-    background-color: var(--toggle-ball-light);
-    transition: transform 0.4s;
-    border-radius: 50%;
-}
-
-.toggle-switch input:checked + .label {
-    background-color: var(--toggle-background-dark);
-}
-
-.toggle-switch input:checked + .label:before {
-    transform: translateX(28px); /* 내부 원 이동 거리 조정 */
-}
-
-         #absdiv {
-            position: relative;
-            top: 60px; /* Move down by 20px from its current position */
-            z-index : 1000;
-        }
-
-        #searchbutton {
-            background-color: #828282;
-        }
-
-        .card-img-top {
-                width: 100%;
-                height: 100px;
-                object-fit: cover;
+        </script>
+        <style>
+            .form-select {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
+            }
+            select {
+            color : #828282;
+            }
+            .form-control {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
             }
 
-    </style>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
 
-    <div class="col-md-9">
-        <div class="row" style="color: #828282;">
-            <div class="col-11">
-                <div class="row">
-                    <div class="col-12">
-                        <form id="filter-and-sort-form" th:action="@{/user/my/in/event}" method="get">
-                            <div class="row">
-                                <div class="col-7">
-                                    <div class="row justify-content-start m-0">
-                                        <div class="col-4">
-                                            <!-- 검색 조건 -->
+            .form-control::placeholder {
+            color : #BBBBBB;
+            }
+
+            .date-container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        background-color: #8E4B6E;
+        color: white;
+        border-radius: 10px;
+        text-align:center;
+        font-family: "Work Sans", sans-serif;
+    }
+
+    .month {
+        font-size: 1.1rem; /* M의 크기를 설정 */
+        font-weight: 550;
+        line-height: 1;
+    }
+
+    .year {
+        font-size: 0.65rem; /* yyyy의 크기를 설정 */
+        font-weight: 400;
+    }
+    :root {
+        --background-color-light: #FFFFFF;
+        --text-color-light: #000000;
+        --toggle-background-light: #CCCCCC;
+        --toggle-ball-light: #FFFFFF;
+
+        --background-color-dark: #333333;
+        --text-color-dark: #FFFFFF;
+        --toggle-background-dark: #03C75A;
+        --toggle-ball-dark: #FFFFFF;
+
+        --font-size-base: 32px; /* 기본 텍스트 크기 */
+        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+    }
+
+
+
+    .toggle-switch {
+        position: relative;
+        display: inline-block;
+        width: 62px; /* 너비 조정 */
+        height: 38px; /* 높이 조정 */
+    }
+
+    .toggle-switch .checkbox {
+        opacity: 0;
+        width: 0;
+        height: 0;
+    }
+    #isToggledCheckbox {
+         opacity: 0;
+            width: 0;
+            height: 0;
+    }
+
+    .toggle-switch .label {
+        position: absolute;
+        cursor: pointer;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: var(--toggle-background-light);
+        transition: background-color 0.4s;
+        border-radius: 38px; /* 둥근 모서리 반경 조정 */
+    }
+
+    .toggle-switch .label:before {
+        position: absolute;
+        content: "";
+        height: 30px; /* 내부 원 높이 조정 */
+        width: 30px; /* 내부 원 너비 조정 */
+        left: 2px;
+        bottom: 0px;
+        background-color: var(--toggle-ball-light);
+        transition: transform 0.4s;
+        border-radius: 50%;
+    }
+
+    .toggle-switch input:checked + .label {
+        background-color: var(--toggle-background-dark);
+    }
+
+    .toggle-switch input:checked + .label:before {
+        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+    }
+
+             #absdiv {
+                position: relative;
+                top: 60px; /* Move down by 20px from its current position */
+                z-index : 1000;
+            }
+
+            #searchbutton {
+                background-color: #828282;
+            }
+
+            .card-img-top {
+                    width: 100%;
+                    height: 100px;
+                    object-fit: cover;
+                }
+
+        </style>
+        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+              rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+              rel="stylesheet">
+
+        <div class="col-md-9">
+            <div class="row" style="color: #828282;">
+                <div class="col-11">
+                    <div class="row">
+                        <div class="col-12">
+                            <form id="filter-and-sort-form" th:action="@{/user/my/in/event}" method="get">
+                                <div class="row">
+                                    <div class="col-7">
+                                        <div class="row justify-content-start m-0">
+                                            <div class="col-4">
+                                                <!-- 검색 조건 -->
+                                                <label>
+                                                    <select class="form-select px-3" name="searchBy">
+                                                        <option value="title" th:selected="${searchBy == 'title'}">제목
+                                                        </option>
+                                                        <option value="content" th:selected="${searchBy == 'content'}">
+                                                            내용
+                                                        </option>
+                                                        <option value="place" th:selected="${searchBy == 'place'}">
+                                                            행사장소
+                                                        </option>
+                                                        <option value="address" th:selected="${searchBy == 'address'}">
+                                                            행사주소
+                                                        </option>
+                                                    </select>
+                                                </label>
+                                            </div>
+                                            <div class="col-6">
+                                                <input class="form-control px-3" type="text" name="searchTerm"
+                                                       placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
+                                            </div>
+                                            <div class="col-2">
+                                                <!-- 검색 버튼 -->
+                                                <button id="searchbutton" type="submit" class="btn btn-primary">검색
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-1" style=""></div>
+                                    <div class="col-4">
+                                        <div class="row justify-content-end">
+                                            <!-- 정렬 또는 토글2 -->
                                             <label>
-                                                <select class="form-select px-3" name="searchBy">
-                                                    <option value="title" th:selected="${searchBy == 'title'}">제목</option>
-                                                    <option value="content" th:selected="${searchBy == 'content'}">내용</option>
-                                                    <option value="place" th:selected="${searchBy == 'place'}">행사장소</option>
-                                                    <option value="address" th:selected="${searchBy == 'address'}">행사주소</option>
+                                                <select class="form-select px-3" name="orderBy" onchange="submitForm()">
+                                                    <option value="recentliked"
+                                                            th:selected="${orderBy == 'recentliked'}">최근좋아요순
+                                                    </option>
+                                                    <option value="oldestliked"
+                                                            th:selected="${orderBy == 'oldestliked'}">오래된순
+                                                    </option>
+
+                                                    <option value="recent" th:selected="${orderBy == 'recent'}">최신행사순
+                                                    </option>
+                                                    <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된행사순
+                                                    </option>
+
+                                                    <option value="title" th:selected="${orderBy == 'title'}">제목가나다순
+                                                    </option>
                                                 </select>
                                             </label>
                                         </div>
-                                        <div class="col-6">
-                                            <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
-                                        </div>
-                                        <div class="col-2">
-                                            <!-- 검색 버튼 -->
-                                            <button id="searchbutton" type="submit" class="btn btn-primary">검색</button>
-                                        </div>
                                     </div>
-                                </div>
-                                <div class="col-1" style=""></div>
-                                <div class="col-4">
-                                    <div class="row justify-content-end">
-                                        <!-- 정렬 또는 토글2 -->
-                                        <label>
-                                            <select class="form-select px-3" name="orderBy" onchange="submitForm()">
-                                                <option value="recentliked" th:selected="${orderBy == 'recentliked'}">최근좋아요순</option>
-                                                <option value="oldestliked" th:selected="${orderBy == 'oldestliked'}">오래된순</option>
-
-                                                <option value="recent" th:selected="${orderBy == 'recent'}">최신행사순</option>
-                                                <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된행사순</option>
-
-                                                <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>
-                                            </select>
-                                        </label>
-                                    </div>
-                                </div>
-                            </div> <!--검색, 소팅 (토글X)-->
-                            <div class="row justify-content-around">
-                                <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                <div class="col-3" style="padding: 0 1.2rem;">
-                                    <div id="absdiv" class="row justify-content-end">
-                                        <div class="col-3">
-                                            <div class="toggle-switch">
-                                                <!-- 정렬 또는 토글1 -->
-                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">
-                                                <label for="isToggledCheckbox" class="label">
-                                                    <div class="ball"></div>
-                                                </label>
+                                </div> <!--검색, 소팅 (토글X)-->
+                                <div class="row justify-content-around">
+                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                    <div class="col-3" style="padding: 0 1.2rem;">
+                                        <div id="absdiv" class="row justify-content-end">
+                                            <div class="col-3">
+                                                <div class="toggle-switch">
+                                                    <!-- 정렬 또는 토글1 -->
+                                                    <input type="checkbox" name="isToggled" id="isToggledCheckbox"
+                                                           value="Y" th:checked="${isToggled == 'Y'}"
+                                                           onchange="updateCheckboxValueAndSubmit()">
+                                                    <label for="isToggledCheckbox" class="label">
+                                                        <div class="ball"></div>
+                                                    </label>
+                                                </div>
+                                            </div>
+                                            <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">
+                                                진행중인 행사
                                             </div>
                                         </div>
-                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">진행중인 행사</div>
                                     </div>
-                                </div>
-                            </div> <!--토글-->
-                        </form>
-                    </div>
-                </div>
-                <div class="row justify-content-around">
-                    <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
-                        <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
-                            <div class="col-3 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:each="myInEvent, iterStat : ${myInEvents}" th:attr="data-href=@{/introduction/event/eventDetail(eventNo=${myInEvent.eventNo})}" th:if="${iterStat.index < 3}">
-                                <div class="row justify-content-center">
-                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                        <div class="date-container px-2 py-1">
-                                            <div class="month" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myInEvent.startDate)}"></div>
-                                            <div class="year" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myInEvent.startDate)}"></div>
-                                        </div>
-                                    </div>
-                                    <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                    <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                    <!--                                    </div>-->
-                                    <div class="col-5" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
-                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M월 d일').format(myInEvent.startDate)} + ' ~ ' + ${T(java.time.format.DateTimeFormatter).ofPattern('M월 d일').format(myInEvent.endDate)}">닉네임
-                                    </div>
-
-                                    <div class="col-3" style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;" th:text="${myInEvent.formattedEventDuration}">시간</div>
-                                </div>
-                                <div class="row justify-content-center">
-                                    <div class="col-12 my-3" style="">
-                                        <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-<!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                        <!-- 썸네일 이미지 있을때  -->
-                                        <img th:if="${#lists.size(myInEvent.eventFiles) > 0}" th:src="@{/uploadFiles/{fileName}(fileName=${myInEvent.eventFiles.get(0).fileName})}" class="card-img-top" alt="썸네일 이미지">
-                                    </div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" th:text="${myInEvent.title}">이름</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${myInEvent.place}">내용</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${myInEvent.eventCategoryTitle}">내용2</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                </div>
-
-                            </div>
-                            <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
-                            <div class="col-3" th:if="${myInEvents.size() == 0}"></div>
-                            <div class="col-3" th:if="${myInEvents.size() == 0 || myInEvents.size() == 1}"></div>
-                            <div class="col-3" th:if="${myInEvents.size() == 0 || myInEvents.size() == 1 || myInEvents.size() == 2}"></div>
-                        </div>
-                        <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
-                            <div class="col-3 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:each="myInEvent, iterStat : ${myInEvents}" th:attr="data-href=@{/introduction/event/eventDetail(eventNo=${myInEvent.eventNo})}" th:if="${iterStat.index >= 3}">
-                                <div class="row justify-content-center">
-                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                        <div class="date-container px-2 py-1">
-                                            <div class="month" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myInEvent.startDate)}"></div>
-                                            <div class="year" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myInEvent.startDate)}"></div>
-                                        </div>
-                                    </div>
-                                    <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                    <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                    <!--                                    </div>-->
-                                    <div class="col-4" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
-                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M월 d일').format(myInEvent.startDate)} + ' ~ ' + ${T(java.time.format.DateTimeFormatter).ofPattern('M월 d일').format(myInEvent.endDate)}">닉네임
-                                    </div>
-
-                                    <div class="col-4" style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;" th:text="${myInEvent.formattedEventDuration}">시간</div>
-                                </div>
-                                <div class="row justify-content-center">
-                                    <div class="col-10" style="color: white;" th:text="${myInEvent.eventNo}">사진</div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" th:text="${myInEvent.title}">이름</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${myInEvent.place}">내용</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${myInEvent.eventCategoryTitle}">내용2</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                </div>
-
-                            </div>
-
-                            <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
-                            <div class="col-3" th:if="${myInEvents.size() <= 3}"></div>
-                            <div class="col-3" th:if="${myInEvents.size() <= 3 || myInEvents.size() == 4}"></div>
-                            <div class="col-3" th:if="${myInEvents.size() <= 3 || myInEvents.size() == 4 || myInEvents.size() == 5}"></div>
+                                </div> <!--토글-->
+                            </form>
                         </div>
                     </div>
-                </div>
-                <div class="row justify-content-center">
-                    <!-- 페이징 -->
-                    <th:block th:if="${pages != null}">
-                        <div class="d-flex justify-content-center">
-                            <div class="btn-group">
-                                <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/in/event(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-                                        <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                                    </svg>
-                                </button>
-                                <th:block th:each="p : ${#numbers.sequence(1, pages)}">
-                                    <button type="button" class="btn btn-sm me-2 pages"
-                                            th:text="${p}" th:onclick="|location.href='@{/user/my/in/event(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
-                                </th:block>
-                                <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/in/event(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-                                        <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
-                                    </svg>
-                                </button>
+                    <div class="row justify-content-around">
+                        <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
+                            <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
+                                <div class="col-3 clickable-row"
+                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                     th:each="myInEvent, iterStat : ${myInEvents}"
+                                     th:attr="data-href=@{/introduction/event/eventDetail(eventNo=${myInEvent.eventNo})}"
+                                     th:if="${iterStat.index < 3}">
+                                    <div class="row justify-content-center">
+                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                             style="aspect-ratio: 1; border-radius: 5px;">
+                                            <div class="date-container px-2 py-1">
+                                                <div class="month"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myInEvent.startDate)}"></div>
+                                                <div class="year"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myInEvent.startDate)}"></div>
+                                            </div>
+                                        </div>
+                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                        <!--                                    </div>-->
+                                        <div class="col-5" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
+                                             th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M월 d일').format(myInEvent.startDate)} + ' ~ ' + ${T(java.time.format.DateTimeFormatter).ofPattern('M월 d일').format(myInEvent.endDate)}">
+                                            닉네임
+                                        </div>
+
+                                        <div class="col-3"
+                                             style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
+                                             th:text="${myInEvent.formattedEventDuration}">시간
+                                        </div>
+                                    </div>
+                                    <div class="row justify-content-center">
+                                        <div class="col-12 my-3" style="">
+                                            <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                            <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                            <!-- 썸네일 이미지 있을때  -->
+                                            <img th:if="${#lists.size(myInEvent.eventFiles) > 0}"
+                                                 th:src="@{/uploadFiles/{fileName}(fileName=${myInEvent.eventFiles.get(0).fileName})}"
+                                                 class="card-img-top" alt="썸네일 이미지">
+                                        </div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                             th:text="${myInEvent.title}">이름
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                             th:text="${myInEvent.place}">내용
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                             th:text="${myInEvent.eventCategoryTitle}">내용2
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                    </div>
+
+                                </div>
+                                <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
+                                <div class="col-3" th:if="${myInEvents.size() == 0}"></div>
+                                <div class="col-3" th:if="${myInEvents.size() == 0 || myInEvents.size() == 1}"></div>
+                                <div class="col-3"
+                                     th:if="${myInEvents.size() == 0 || myInEvents.size() == 1 || myInEvents.size() == 2}"></div>
+                            </div>
+                            <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
+                                <div class="col-3 clickable-row"
+                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                     th:each="myInEvent, iterStat : ${myInEvents}"
+                                     th:attr="data-href=@{/introduction/event/eventDetail(eventNo=${myInEvent.eventNo})}"
+                                     th:if="${iterStat.index >= 3}">
+                                    <div class="row justify-content-center">
+                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                             style="aspect-ratio: 1; border-radius: 5px;">
+                                            <div class="date-container px-2 py-1">
+                                                <div class="month"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myInEvent.startDate)}"></div>
+                                                <div class="year"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myInEvent.startDate)}"></div>
+                                            </div>
+                                        </div>
+                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                        <!--                                    </div>-->
+                                        <div class="col-4" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
+                                             th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M월 d일').format(myInEvent.startDate)} + ' ~ ' + ${T(java.time.format.DateTimeFormatter).ofPattern('M월 d일').format(myInEvent.endDate)}">
+                                            닉네임
+                                        </div>
+
+                                        <div class="col-4"
+                                             style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
+                                             th:text="${myInEvent.formattedEventDuration}">시간
+                                        </div>
+                                    </div>
+                                    <div class="row justify-content-center">
+                                        <div class="col-10" style="color: white;" th:text="${myInEvent.eventNo}">사진
+                                        </div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                             th:text="${myInEvent.title}">이름
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                             th:text="${myInEvent.place}">내용
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                             th:text="${myInEvent.eventCategoryTitle}">내용2
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                    </div>
+
+                                </div>
+
+                                <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
+                                <div class="col-3" th:if="${myInEvents.size() <= 3}"></div>
+                                <div class="col-3" th:if="${myInEvents.size() <= 3 || myInEvents.size() == 4}"></div>
+                                <div class="col-3"
+                                     th:if="${myInEvents.size() <= 3 || myInEvents.size() == 4 || myInEvents.size() == 5}"></div>
                             </div>
                         </div>
-                    </th:block>
-                </div>
-            </div><!--테이블 및 페이징 포함-->
+                    </div>
+                    <div class="row justify-content-center">
+                        <!-- 페이징 -->
+                        <th:block th:if="${pages != null}">
+                            <div class="d-flex justify-content-center">
+                                <div class="btn-group">
+                                    <button type="button" class="btn btn-sm previous"
+                                            th:onclick="|location.href='@{/user/my/in/event(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
+                                            th:disabled="${currentPage == 1}">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                             fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+                                            <path fill-rule="evenodd"
+                                                  d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                                        </svg>
+                                    </button>
+                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">
+                                        <button type="button" class="btn btn-sm me-2 pages"
+                                                th:text="${p}"
+                                                th:onclick="|location.href='@{/user/my/in/event(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
+                                    </th:block>
+                                    <button type="button" class="btn btn-sm  next"
+                                            th:onclick="|location.href='@{/user/my/in/event(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
+                                            th:disabled="${currentPage == pages}">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                             fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+                                            <path fill-rule="evenodd"
+                                                  d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                                        </svg>
+                                    </button>
+                                </div>
+                            </div>
+                        </th:block>
+                    </div>
+                </div><!--테이블 및 페이징 포함-->
+            </div> <!--본화면-->
         </div> <!--본화면-->
-    </div> <!--본화면-->
 
 
+        <!--수정전-->
+        <!--    <div class="col-md-9">-->
+        <!--        <div class="review-list">-->
+        <!--            <h2>좋아요한 행사</h2>-->
+        <!--            <form id="filter-and-sort-form" th:action="@{/user/my/in/event}" method="get">-->
+        <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
+        <!--                <label>-->
+        <!--                    <select name="searchBy">-->
+        <!--                        <option value="title" th:selected="${searchBy == 'title'}">제목</option>-->
+        <!--                        <option value="content" th:selected="${searchBy == 'content'}">내용</option>-->
+        <!--                        <option value="place" th:selected="${searchBy == 'place'}">행사장소</option>-->
+        <!--                        <option value="address" th:selected="${searchBy == 'address'}">행사주소</option>-->
+        <!--                    </select>-->
+        <!--                </label>-->
+        <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
 
+        <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
+        <!--                <button type="submit">검색</button>-->
 
+        <!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
+        <!--                <label>-->
+        <!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">진행중인 행사-->
+        <!--                </label>-->
 
-    <!--수정전-->
-<!--    <div class="col-md-9">-->
-<!--        <div class="review-list">-->
-<!--            <h2>좋아요한 행사</h2>-->
-<!--            <form id="filter-and-sort-form" th:action="@{/user/my/in/event}" method="get">-->
-<!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
-<!--                <label>-->
-<!--                    <select name="searchBy">-->
-<!--                        <option value="title" th:selected="${searchBy == 'title'}">제목</option>-->
-<!--                        <option value="content" th:selected="${searchBy == 'content'}">내용</option>-->
-<!--                        <option value="place" th:selected="${searchBy == 'place'}">행사장소</option>-->
-<!--                        <option value="address" th:selected="${searchBy == 'address'}">행사주소</option>-->
-<!--                    </select>-->
-<!--                </label>-->
-<!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
+        <!--                <label>-->
+        <!--                    <select name="orderBy" onchange="submitForm()">-->
+        <!--                        <option value="recentliked" th:selected="${orderBy == 'recentliked'}">최근좋아요순</option>-->
+        <!--                        <option value="oldestliked" th:selected="${orderBy == 'oldestliked'}">오래된순</option>-->
 
-<!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
-<!--                <button type="submit">검색</button>-->
+        <!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최신행사순</option>-->
+        <!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된행사순</option>-->
 
-<!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
-<!--                <label>-->
-<!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">진행중인 행사-->
-<!--                </label>-->
-
-<!--                <label>-->
-<!--                    <select name="orderBy" onchange="submitForm()">-->
-<!--                        <option value="recentliked" th:selected="${orderBy == 'recentliked'}">최근좋아요순</option>-->
-<!--                        <option value="oldestliked" th:selected="${orderBy == 'oldestliked'}">오래된순</option>-->
-
-<!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최신행사순</option>-->
-<!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된행사순</option>-->
-
-<!--                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
-<!--                    </select>-->
-<!--                </label>-->
-<!--            </form>-->
-<!--&lt;!&ndash;            <form id="filter-form" th:action="@{/user/my/in/event}" method="get">&ndash;&gt;-->
-<!--&lt;!&ndash;                <label>&ndash;&gt;-->
-<!--&lt;!&ndash;                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="toggleCheckboxValue()">진행중인 행사&ndash;&gt;-->
-<!--&lt;!&ndash;                </label>&ndash;&gt;-->
-<!--&lt;!&ndash;            </form>&ndash;&gt;-->
-<!--            <table>-->
-<!--                <thead>-->
-<!--                <tr>-->
-<!--                    <th>좋아요 번호</th>-->
-<!--                    <th>행사 게시글 번호</th>-->
-<!--                    <th>회원번호</th>-->
-<!--                    <th>좋아요 날짜</th>-->
-<!--                    <th>행사 제목</th>-->
-<!--                    <th>행사 카테고리 코드</th>-->
-<!--                    <th>행사 시작일</th>-->
-<!--                    <th>행사 종료일</th>-->
-<!--                    <th>행사 비용</th>-->
-<!--                    <th>관련사이트URL</th>-->
-<!--                    <th>장소명</th>-->
-<!--                    <th>주소명</th>-->
-<!--                    <th>좌표</th>-->
-<!--                    <th>행사 내용</th>-->
-<!--                    <th>게시 일시</th>-->
-<!--                </tr>-->
-<!--                </thead>-->
-<!--                <tbody>-->
-<!--                <tr th:each="myInEvent : ${myInEvents}" class="clickable-row" th:attr="data-href=@{/introduction/event/eventDetail(eventNo=${myInEvent.eventNo})}">-->
-<!--                    <td th:text="${myInEvent.likedNo}">좋아요 번호</td>-->
-<!--                    <td th:text="${myInEvent.eventNo}">행사 게시글 번호</td>-->
-<!--                    <td th:text="${myInEvent.userNo}">회원번호</td>-->
-<!--                    <td th:text="${myInEvent.likedDate}">좋아요 날짜</td>-->
-<!--                    <td th:text="${myInEvent.title}">행사 제목</td>-->
-<!--                    <td th:text="${myInEvent.eventCategoryCode}">행사 카테고리 코드</td>-->
-<!--                    <td th:text="${myInEvent.startDate}">행사 시작일</td>-->
-<!--                    <td th:text="${myInEvent.endDate}">행사 종료일</td>-->
-<!--                    <td th:text="${myInEvent.cost}">행사 비용</td>-->
-<!--                    <td th:text="${myInEvent.site}">관련사이트URL</td>-->
-<!--                    <td th:text="${myInEvent.place}">장소명</td>-->
-<!--                    <td th:text="${myInEvent.address}">주소명</td>-->
-<!--                    <td th:text="${myInEvent.coordinates}">좌표</td>-->
-<!--                    <td th:text="${myInEvent.content}">행사 내용</td>-->
-<!--                    <td th:text="${myInEvent.postingDate}">게시 일시</td>-->
-<!--                </tr>-->
-<!--                </tbody>-->
-<!--            </table>-->
-<!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
-<!--            <th:block th:if="${pages != null}">-->
-<!--                <div class="d-flex justify-content-center">-->
-<!--                    <div class="btn-group">-->
-<!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/in/event(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
-<!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
-<!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
-<!--                            </svg>-->
-<!--                        </button>-->
-<!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
-<!--                            <button type="button" class="btn btn-sm me-2 pages"-->
-<!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/in/event(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
-<!--                        </th:block>-->
-<!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/in/event(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
-<!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
-<!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
-<!--                            </svg>-->
-<!--                        </button>-->
-<!--                    </div>-->
-<!--                </div>-->
-<!--            </th:block>-->
-<!--        </div>-->
-<!--    </div>-->
+        <!--                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
+        <!--                    </select>-->
+        <!--                </label>-->
+        <!--            </form>-->
+        <!--&lt;!&ndash;            <form id="filter-form" th:action="@{/user/my/in/event}" method="get">&ndash;&gt;-->
+        <!--&lt;!&ndash;                <label>&ndash;&gt;-->
+        <!--&lt;!&ndash;                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="toggleCheckboxValue()">진행중인 행사&ndash;&gt;-->
+        <!--&lt;!&ndash;                </label>&ndash;&gt;-->
+        <!--&lt;!&ndash;            </form>&ndash;&gt;-->
+        <!--            <table>-->
+        <!--                <thead>-->
+        <!--                <tr>-->
+        <!--                    <th>좋아요 번호</th>-->
+        <!--                    <th>행사 게시글 번호</th>-->
+        <!--                    <th>회원번호</th>-->
+        <!--                    <th>좋아요 날짜</th>-->
+        <!--                    <th>행사 제목</th>-->
+        <!--                    <th>행사 카테고리 코드</th>-->
+        <!--                    <th>행사 시작일</th>-->
+        <!--                    <th>행사 종료일</th>-->
+        <!--                    <th>행사 비용</th>-->
+        <!--                    <th>관련사이트URL</th>-->
+        <!--                    <th>장소명</th>-->
+        <!--                    <th>주소명</th>-->
+        <!--                    <th>좌표</th>-->
+        <!--                    <th>행사 내용</th>-->
+        <!--                    <th>게시 일시</th>-->
+        <!--                </tr>-->
+        <!--                </thead>-->
+        <!--                <tbody>-->
+        <!--                <tr th:each="myInEvent : ${myInEvents}" class="clickable-row" th:attr="data-href=@{/introduction/event/eventDetail(eventNo=${myInEvent.eventNo})}">-->
+        <!--                    <td th:text="${myInEvent.likedNo}">좋아요 번호</td>-->
+        <!--                    <td th:text="${myInEvent.eventNo}">행사 게시글 번호</td>-->
+        <!--                    <td th:text="${myInEvent.userNo}">회원번호</td>-->
+        <!--                    <td th:text="${myInEvent.likedDate}">좋아요 날짜</td>-->
+        <!--                    <td th:text="${myInEvent.title}">행사 제목</td>-->
+        <!--                    <td th:text="${myInEvent.eventCategoryCode}">행사 카테고리 코드</td>-->
+        <!--                    <td th:text="${myInEvent.startDate}">행사 시작일</td>-->
+        <!--                    <td th:text="${myInEvent.endDate}">행사 종료일</td>-->
+        <!--                    <td th:text="${myInEvent.cost}">행사 비용</td>-->
+        <!--                    <td th:text="${myInEvent.site}">관련사이트URL</td>-->
+        <!--                    <td th:text="${myInEvent.place}">장소명</td>-->
+        <!--                    <td th:text="${myInEvent.address}">주소명</td>-->
+        <!--                    <td th:text="${myInEvent.coordinates}">좌표</td>-->
+        <!--                    <td th:text="${myInEvent.content}">행사 내용</td>-->
+        <!--                    <td th:text="${myInEvent.postingDate}">게시 일시</td>-->
+        <!--                </tr>-->
+        <!--                </tbody>-->
+        <!--            </table>-->
+        <!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
+        <!--            <th:block th:if="${pages != null}">-->
+        <!--                <div class="d-flex justify-content-center">-->
+        <!--                    <div class="btn-group">-->
+        <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/in/event(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
+        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
+        <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
+        <!--                            </svg>-->
+        <!--                        </button>-->
+        <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
+        <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
+        <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/in/event(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
+        <!--                        </th:block>-->
+        <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/in/event(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
+        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
+        <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
+        <!--                            </svg>-->
+        <!--                        </button>-->
+        <!--                    </div>-->
+        <!--                </div>-->
+        <!--            </th:block>-->
+        <!--        </div>-->
+        <!--    </div>-->
+    </div>
 </div>
 <div th:replace="common/footer.html"></div>
 </body>

--- a/src/main/resources/templates/user/mypage_in_event.html
+++ b/src/main/resources/templates/user/mypage_in_event.html
@@ -86,637 +86,668 @@
 
 <div th:replace="~{common/menubar}"></div>
 <style>
-    .jumbotron {
-    position : relative;
-    background-color : #EEEEEE;
+    html, body {
+        height: 100%;
+        margin: 0;
     }
-    .jumbotron .row {
-    position : absolute;
-    width : 100%;
-    bottom: 0%;
+    body {
+        display: flex;
+        flex-direction: column;
     }
-    .nav-link {
-            color: #828282;
+    .content-wrapper {
+        flex: 1 0 auto;
     }
-    ul {
-  list-style: none;
-  padding-left : 0px;
-  }
+    footer {
+        flex-shrink: 0;
+    }
+
 </style>
-<div class="jumbotron">
-    <div class="container">
-        <div class="row">
-            <div class="col-9">
-                <div class="row">
-                    <div class="col-md-3 px-4">
-                        <h3>나의 소식</h3>
-                    </div>
-                    <div class="col-md-9">
-                        <nav class="navbar navbar-expand-md">
-                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                                <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>
-                                <li><a th:href="@{/user/my/in/event}" class="nav-link px-2" style="color: #000;">좋아요한
-                                    행사</a>
-                                </li>
-                                <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>
-                            </ul>
-                        </nav>
+<div class="content-wrapper">
+    <style>
+        .jumbotron {
+        position : relative;
+        background-color : #EEEEEE;
+        }
+        .jumbotron .row {
+        position : absolute;
+        width : 100%;
+        bottom: 0%;
+        }
+        .nav-link {
+                color: #828282;
+        }
+        ul {
+      list-style: none;
+      padding-left : 0px;
+      }
+    </style>
+    <div class="jumbotron">
+        <div class="container">
+            <div class="row">
+                <div class="col-9">
+                    <div class="row">
+                        <div class="col-md-3 px-4">
+                            <h3>나의 소식</h3>
+                        </div>
+                        <div class="col-md-9">
+                            <nav class="navbar navbar-expand-md">
+                                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                    <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>
+                                    <li><a th:href="@{/user/my/in/event}" class="nav-link px-2" style="color: #000;">좋아요한
+                                        행사</a>
+                                    </li>
+                                    <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>
+                                </ul>
+                            </nav>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
-<div class="container" style="padding:0;">
-    <div class="row">
-        <aside class="col-md-3 px-4">
-            <div class="row">
-                <div class="col-1"></div>
-                <div class="col-8">
-                    <div class="panel">
-                        <ul class="list-group">
-                            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
-                            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-                            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
-                            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2" style="color: #03C75A;">나의
-                                소식</a></li>
-                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-                        </ul>
+    <div class="container" style="padding:0;">
+        <div class="row">
+            <aside class="col-md-3 px-4">
+                <div class="row">
+                    <div class="col-1"></div>
+                    <div class="col-8">
+                        <div class="panel">
+                            <ul class="list-group">
+                                <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
+                                <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
+                                <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2" style="color: #03C75A;">나의
+                                    소식</a></li>
+                                <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                                <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </aside>
-        <!--    <script>-->
-        <!--        function toggleCheckboxValue() {-->
-        <!--            const checkbox = document.getElementById('isToggledCheckbox');-->
-        <!--            if(!checkbox.checked) checkbox.value = 'N';-->
-        <!--            else checkbox.value = 'Y';-->
-        <!--            document.getElementById('filter-form').submit();-->
-        <!--        }-->
-        <!--    </script>-->
-        <script> // toggle + sorting
-        function updateCheckboxValueAndSubmit() {
-            const checkbox = document.getElementById('isToggledCheckbox');
-            const form = document.getElementById('filter-and-sort-form');
-            // 체크박스가 체크된 상태를 확인
-            checkbox.value = checkbox.checked ? 'Y' : 'N';
-            // 폼 제출
-            form.submit();
-        }
-
-        function submitForm() {
-            document.getElementById('filter-and-sort-form').submit();
-        }
-        </script>
-        <style>
-            .form-select {
-            background-color : #FCFCFC;
-            border : none;
-            width : 100%;
-            height : 50px;
-            }
-            select {
-            color : #828282;
-            }
-            .form-control {
-            background-color : #FCFCFC;
-            border : none;
-            width : 100%;
-            height : 50px;
+            </aside>
+            <!--    <script>-->
+            <!--        function toggleCheckboxValue() {-->
+            <!--            const checkbox = document.getElementById('isToggledCheckbox');-->
+            <!--            if(!checkbox.checked) checkbox.value = 'N';-->
+            <!--            else checkbox.value = 'Y';-->
+            <!--            document.getElementById('filter-form').submit();-->
+            <!--        }-->
+            <!--    </script>-->
+            <script> // toggle + sorting
+            function updateCheckboxValueAndSubmit() {
+                const checkbox = document.getElementById('isToggledCheckbox');
+                const form = document.getElementById('filter-and-sort-form');
+                // 체크박스가 체크된 상태를 확인
+                checkbox.value = checkbox.checked ? 'Y' : 'N';
+                // 폼 제출
+                form.submit();
             }
 
-
-            .form-control::placeholder {
-            color : #BBBBBB;
+            function submitForm() {
+                document.getElementById('filter-and-sort-form').submit();
             }
-
-            .date-container {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        background-color: #8E4B6E;
-        color: white;
-        border-radius: 10px;
-        text-align:center;
-        font-family: "Work Sans", sans-serif;
-    }
-
-    .month {
-        font-size: 1.1rem; /* M의 크기를 설정 */
-        font-weight: 550;
-        line-height: 1;
-    }
-
-    .year {
-        font-size: 0.65rem; /* yyyy의 크기를 설정 */
-        font-weight: 400;
-    }
-    :root {
-        --background-color-light: #FFFFFF;
-        --text-color-light: #000000;
-        --toggle-background-light: #CCCCCC;
-        --toggle-ball-light: #FFFFFF;
-
-        --background-color-dark: #333333;
-        --text-color-dark: #FFFFFF;
-        --toggle-background-dark: #03C75A;
-        --toggle-ball-dark: #FFFFFF;
-
-        --font-size-base: 32px; /* 기본 텍스트 크기 */
-        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
-    }
-
-
-
-    .toggle-switch {
-        position: relative;
-        display: inline-block;
-        width: 62px; /* 너비 조정 */
-        height: 38px; /* 높이 조정 */
-    }
-
-    .toggle-switch .checkbox {
-        opacity: 0;
-        width: 0;
-        height: 0;
-    }
-    #isToggledCheckbox {
-         opacity: 0;
-            width: 0;
-            height: 0;
-    }
-
-    .toggle-switch .label {
-        position: absolute;
-        cursor: pointer;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background-color: var(--toggle-background-light);
-        transition: background-color 0.4s;
-        border-radius: 38px; /* 둥근 모서리 반경 조정 */
-    }
-
-    .toggle-switch .label:before {
-        position: absolute;
-        content: "";
-        height: 30px; /* 내부 원 높이 조정 */
-        width: 30px; /* 내부 원 너비 조정 */
-        left: 2px;
-        bottom: 0px;
-        background-color: var(--toggle-ball-light);
-        transition: transform 0.4s;
-        border-radius: 50%;
-    }
-
-    .toggle-switch input:checked + .label {
-        background-color: var(--toggle-background-dark);
-    }
-
-    .toggle-switch input:checked + .label:before {
-        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
-    }
-
-             #absdiv {
-                position: relative;
-                top: 60px; /* Move down by 20px from its current position */
-                z-index : 1000;
-            }
-
-            #searchbutton {
-                background-color: #828282;
-            }
-
-            .card-img-top {
-                    width: 100%;
-                    height: 100px;
-                    object-fit: cover;
+            </script>
+            <style>
+                .form-select {
+                background-color : #FCFCFC;
+                border : none;
+                width : 100%;
+                height : 50px;
+                }
+                select {
+                color : #828282;
+                }
+                .form-control {
+                background-color : #FCFCFC;
+                border : none;
+                width : 100%;
+                height : 50px;
                 }
 
-        </style>
-        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
-              rel="stylesheet">
-        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
-              rel="stylesheet">
 
-        <div class="col-md-9">
-            <div class="row" style="color: #828282;">
-                <div class="col-11">
-                    <div class="row">
-                        <div class="col-12 p-0">
-                            <style>
-                                .col-4 select {
-                                    border-radius: 50px;
-                                    text-align: center;
-                                }
-                                /* 검색창 스타일 */
-                                .search-container {
-                                    width: 300px;
-                                }
+                .form-control::placeholder {
+                color : #BBBBBB;
+                }
 
-                                .search-container select {
-                                    position: absolute;
-                                    left: 0%;
-                                    width: 30%;
-                                    height: 50px;
-                                    color: #828282;
-                                    font-size: 1rem;
-                                    border-radius: 50px 0 0 50px;
-                                    outline: none;
-                                }
-                                .search-container input[type="text"] {
-                                    position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
-                                    left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
-                                    width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
-                                    height: 50px;
-                                    padding: 10px 40px 10px 15px;
-                                    font-size: 1rem;
-                                    outline: none;
-                                    border-radius: 0 50px 50px 0;
-                                    transition: border-color 0.3s, background-color 0.3s;
-                                    color: #828282; /* 입력 텍스트 색상 변경 */
-                                }
+                .date-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            background-color: #8E4B6E;
+            color: white;
+            border-radius: 10px;
+            text-align:center;
+            font-family: "Work Sans", sans-serif;
+        }
 
-                                .search-container input[type="text"]::placeholder {
-                                    color: #BBBBBB; /* placeholder 색상 변경 */
-                                }
+        .month {
+            font-size: 1.1rem; /* M의 크기를 설정 */
+            font-weight: 550;
+            line-height: 1;
+        }
+
+        .year {
+            font-size: 0.65rem; /* yyyy의 크기를 설정 */
+            font-weight: 400;
+        }
+        :root {
+            --background-color-light: #FFFFFF;
+            --text-color-light: #000000;
+            --toggle-background-light: #CCCCCC;
+            --toggle-ball-light: #FFFFFF;
+
+            --background-color-dark: #333333;
+            --text-color-dark: #FFFFFF;
+            --toggle-background-dark: #03C75A;
+            --toggle-ball-dark: #FFFFFF;
+
+            --font-size-base: 32px; /* 기본 텍스트 크기 */
+            --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+        }
 
 
-                                .search-container button {
-                                    position: absolute;
-                                    right: 1rem;
-                                    top: 25px;
-                                    background: none;
-                                    transform: translateY(-50%);
-                                    border: none;
-                                    cursor: pointer;
-                                }
 
-                                .search-container button i {
-                                    color: #A6AAB5;
-                                }
+        .toggle-switch {
+            position: relative;
+            display: inline-block;
+            width: 62px; /* 너비 조정 */
+            height: 38px; /* 높이 조정 */
+        }
 
-                                .search-container button:hover i {
-                                    color: #03C75A;
-                                }
-                            </style>
-                            <form id="filter-and-sort-form" th:action="@{/user/my/in/event}" method="get">
-                                <div class="row m-0">
-                                    <div class="col-7 p-0">
-                                        <div class="row justify-content-start m-0">
-                                            <div class="col-12 p-0">
-                                                <div class="search-container">
-                                                    <select class="form-select px-3" name="searchBy">
-                                                        <option value="title" th:selected="${searchBy == 'title'}">제목
+        .toggle-switch .checkbox {
+            opacity: 0;
+            width: 0;
+            height: 0;
+        }
+        #isToggledCheckbox {
+             opacity: 0;
+                width: 0;
+                height: 0;
+        }
+
+        .toggle-switch .label {
+            position: absolute;
+            cursor: pointer;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: var(--toggle-background-light);
+            transition: background-color 0.4s;
+            border-radius: 38px; /* 둥근 모서리 반경 조정 */
+        }
+
+        .toggle-switch .label:before {
+            position: absolute;
+            content: "";
+            height: 30px; /* 내부 원 높이 조정 */
+            width: 30px; /* 내부 원 너비 조정 */
+            left: 2px;
+            bottom: 0px;
+            background-color: var(--toggle-ball-light);
+            transition: transform 0.4s;
+            border-radius: 50%;
+        }
+
+        .toggle-switch input:checked + .label {
+            background-color: var(--toggle-background-dark);
+        }
+
+        .toggle-switch input:checked + .label:before {
+            transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+        }
+
+                 #absdiv {
+                    position: relative;
+                    top: 60px; /* Move down by 20px from its current position */
+                    z-index : 1000;
+                }
+
+                #searchbutton {
+                    background-color: #828282;
+                }
+
+                .card-img-top {
+                        width: 100%;
+                        height: 100px;
+                        object-fit: cover;
+                    }
+
+            </style>
+            <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+                  rel="stylesheet">
+            <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+                  rel="stylesheet">
+
+            <div class="col-md-9">
+                <div class="row" style="color: #828282;">
+                    <div class="col-11">
+                        <div class="row">
+                            <div class="col-12 p-0">
+                                <style>
+                                    .col-4 select {
+                                        border-radius: 50px;
+                                        text-align: center;
+                                    }
+                                    /* 검색창 스타일 */
+                                    .search-container {
+                                        width: 300px;
+                                    }
+
+                                    .search-container select {
+                                        position: absolute;
+                                        left: 0%;
+                                        width: 30%;
+                                        height: 50px;
+                                        color: #828282;
+                                        font-size: 1rem;
+                                        border-radius: 50px 0 0 50px;
+                                        outline: none;
+                                    }
+                                    .search-container input[type="text"] {
+                                        position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
+                                        left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
+                                        width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
+                                        height: 50px;
+                                        padding: 10px 40px 10px 15px;
+                                        font-size: 1rem;
+                                        outline: none;
+                                        border-radius: 0 50px 50px 0;
+                                        transition: border-color 0.3s, background-color 0.3s;
+                                        color: #828282; /* 입력 텍스트 색상 변경 */
+                                    }
+
+                                    .search-container input[type="text"]::placeholder {
+                                        color: #BBBBBB; /* placeholder 색상 변경 */
+                                    }
+
+
+                                    .search-container button {
+                                        position: absolute;
+                                        right: 1rem;
+                                        top: 25px;
+                                        background: none;
+                                        transform: translateY(-50%);
+                                        border: none;
+                                        cursor: pointer;
+                                    }
+
+                                    .search-container button i {
+                                        color: #A6AAB5;
+                                    }
+
+                                    .search-container button:hover i {
+                                        color: #03C75A;
+                                    }
+                                </style>
+                                <form id="filter-and-sort-form" th:action="@{/user/my/in/event}" method="get">
+                                    <div class="row m-0">
+                                        <div class="col-7 p-0">
+                                            <div class="row justify-content-start m-0">
+                                                <div class="col-12 p-0">
+                                                    <div class="search-container">
+                                                        <select class="form-select px-3" name="searchBy">
+                                                            <option value="title" th:selected="${searchBy == 'title'}">
+                                                                제목
+                                                            </option>
+                                                            <option value="content"
+                                                                    th:selected="${searchBy == 'content'}">
+                                                                내용
+                                                            </option>
+                                                            <option value="place" th:selected="${searchBy == 'place'}">
+                                                                행사장소
+                                                            </option>
+                                                            <option value="address"
+                                                                    th:selected="${searchBy == 'address'}">
+                                                                행사주소
+                                                            </option>
+                                                        </select>
+                                                        <input class="form-control px-3" type="text" name="searchTerm"
+                                                               placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
+                                                        <!-- 검색 버튼 -->
+                                                        <button type="submit">
+                                                            <i class="fas fa-search"></i>
+                                                        </button>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="col-1" style=""></div>
+                                        <div class="col-4">
+                                            <div class="row justify-content-end">
+                                                <!-- 정렬 또는 토글2 -->
+                                                <label>
+                                                    <select class="form-select px-3" name="orderBy"
+                                                            onchange="submitForm()">
+                                                        <option value="recentliked"
+                                                                th:selected="${orderBy == 'recentliked'}">최근좋아요순
                                                         </option>
-                                                        <option value="content" th:selected="${searchBy == 'content'}">
-                                                            내용
+                                                        <option value="oldestliked"
+                                                                th:selected="${orderBy == 'oldestliked'}">오래된순
                                                         </option>
-                                                        <option value="place" th:selected="${searchBy == 'place'}">
-                                                            행사장소
+
+                                                        <option value="recent" th:selected="${orderBy == 'recent'}">
+                                                            최신행사순
                                                         </option>
-                                                        <option value="address" th:selected="${searchBy == 'address'}">
-                                                            행사주소
+                                                        <option value="oldest" th:selected="${orderBy == 'oldest'}">
+                                                            오래된행사순
+                                                        </option>
+
+                                                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순
                                                         </option>
                                                     </select>
-                                                    <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
-                                                    <!-- 검색 버튼 -->
-                                                    <button type="submit">
-                                                        <i class="fas fa-search"></i>
-                                                    </button>
+                                                </label>
+                                            </div>
+                                        </div>
+                                    </div> <!--검색, 소팅 (토글X)-->
+                                    <div class="row justify-content-around">
+                                        <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                        <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                        <div class="col-3" style="padding: 0 1.2rem;">
+                                            <div id="absdiv" class="row justify-content-end">
+                                                <div class="col-3">
+                                                    <div class="toggle-switch">
+                                                        <!-- 정렬 또는 토글1 -->
+                                                        <input type="checkbox" name="isToggled" id="isToggledCheckbox"
+                                                               value="Y" th:checked="${isToggled == 'Y'}"
+                                                               onchange="updateCheckboxValueAndSubmit()">
+                                                        <label for="isToggledCheckbox" class="label">
+                                                            <div class="ball"></div>
+                                                        </label>
+                                                    </div>
+                                                </div>
+                                                <div class="col-8"
+                                                     style="text-align: right; padding: 0px; margin : 0px;">
+                                                    진행중인 행사
                                                 </div>
                                             </div>
                                         </div>
-                                    </div>
-                                    <div class="col-1" style=""></div>
-                                    <div class="col-4">
-                                        <div class="row justify-content-end">
-                                            <!-- 정렬 또는 토글2 -->
-                                            <label>
-                                                <select class="form-select px-3" name="orderBy" onchange="submitForm()">
-                                                    <option value="recentliked"
-                                                            th:selected="${orderBy == 'recentliked'}">최근좋아요순
-                                                    </option>
-                                                    <option value="oldestliked"
-                                                            th:selected="${orderBy == 'oldestliked'}">오래된순
-                                                    </option>
-
-                                                    <option value="recent" th:selected="${orderBy == 'recent'}">최신행사순
-                                                    </option>
-                                                    <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된행사순
-                                                    </option>
-
-                                                    <option value="title" th:selected="${orderBy == 'title'}">제목가나다순
-                                                    </option>
-                                                </select>
-                                            </label>
-                                        </div>
-                                    </div>
-                                </div> <!--검색, 소팅 (토글X)-->
-                                <div class="row justify-content-around">
-                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                    <div class="col-3" style="padding: 0 1.2rem;">
-                                        <div id="absdiv" class="row justify-content-end">
-                                            <div class="col-3">
-                                                <div class="toggle-switch">
-                                                    <!-- 정렬 또는 토글1 -->
-                                                    <input type="checkbox" name="isToggled" id="isToggledCheckbox"
-                                                           value="Y" th:checked="${isToggled == 'Y'}"
-                                                           onchange="updateCheckboxValueAndSubmit()">
-                                                    <label for="isToggledCheckbox" class="label">
-                                                        <div class="ball"></div>
-                                                    </label>
+                                    </div> <!--토글-->
+                                </form>
+                            </div>
+                        </div>
+                        <div class="row justify-content-around">
+                            <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
+                                <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
+                                    <div class="col-3 clickable-row"
+                                         style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                         th:each="myInEvent, iterStat : ${myInEvents}"
+                                         th:attr="data-href=@{/introduction/event/eventDetail(eventNo=${myInEvent.eventNo})}"
+                                         th:if="${iterStat.index < 3}">
+                                        <div class="row justify-content-center">
+                                            <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                                 style="aspect-ratio: 1; border-radius: 5px;">
+                                                <div class="date-container px-2 py-1">
+                                                    <div class="month"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myInEvent.startDate)}"></div>
+                                                    <div class="year"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myInEvent.startDate)}"></div>
                                                 </div>
                                             </div>
-                                            <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">
-                                                진행중인 행사
+                                            <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                            <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                            <!--                                    </div>-->
+                                            <div class="col-5"
+                                                 style="color: #333333; font-size: 0.8rem; font-weight: 530;"
+                                                 th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M월 d일').format(myInEvent.startDate)} + ' ~ ' + ${T(java.time.format.DateTimeFormatter).ofPattern('M월 d일').format(myInEvent.endDate)}">
+                                                닉네임
+                                            </div>
+
+                                            <div class="col-3"
+                                                 style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
+                                                 th:text="${myInEvent.formattedEventDuration}">시간
                                             </div>
                                         </div>
-                                    </div>
-                                </div> <!--토글-->
-                            </form>
-                        </div>
-                    </div>
-                    <div class="row justify-content-around">
-                        <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
-                            <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
-                                <div class="col-3 clickable-row"
-                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
-                                     th:each="myInEvent, iterStat : ${myInEvents}"
-                                     th:attr="data-href=@{/introduction/event/eventDetail(eventNo=${myInEvent.eventNo})}"
-                                     th:if="${iterStat.index < 3}">
-                                    <div class="row justify-content-center">
-                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
-                                             style="aspect-ratio: 1; border-radius: 5px;">
-                                            <div class="date-container px-2 py-1">
-                                                <div class="month"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myInEvent.startDate)}"></div>
-                                                <div class="year"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myInEvent.startDate)}"></div>
+                                        <div class="row justify-content-center">
+                                            <div class="col-12 my-3" style="">
+                                                <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                                <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                                <!-- 썸네일 이미지 있을때  -->
+                                                <img th:if="${#lists.size(myInEvent.eventFiles) > 0}"
+                                                     th:src="@{/uploadFiles/{fileName}(fileName=${myInEvent.eventFiles.get(0).fileName})}"
+                                                     class="card-img-top" alt="썸네일 이미지">
                                             </div>
                                         </div>
-                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                        <!--                                    </div>-->
-                                        <div class="col-5" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
-                                             th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M월 d일').format(myInEvent.startDate)} + ' ~ ' + ${T(java.time.format.DateTimeFormatter).ofPattern('M월 d일').format(myInEvent.endDate)}">
-                                            닉네임
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                                 th:text="${myInEvent.title}">이름
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                                 th:text="${myInEvent.place}">내용
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                                 th:text="${myInEvent.eventCategoryTitle}">내용2
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;">→</div>
                                         </div>
 
-                                        <div class="col-3"
-                                             style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
-                                             th:text="${myInEvent.formattedEventDuration}">시간
-                                        </div>
                                     </div>
-                                    <div class="row justify-content-center">
-                                        <div class="col-12 my-3" style="">
-                                            <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                            <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                            <!-- 썸네일 이미지 있을때  -->
-                                            <img th:if="${#lists.size(myInEvent.eventFiles) > 0}"
-                                                 th:src="@{/uploadFiles/{fileName}(fileName=${myInEvent.eventFiles.get(0).fileName})}"
-                                                 class="card-img-top" alt="썸네일 이미지">
-                                        </div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
-                                             th:text="${myInEvent.title}">이름
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
-                                             th:text="${myInEvent.place}">내용
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
-                                             th:text="${myInEvent.eventCategoryTitle}">내용2
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                    </div>
-
+                                    <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
+                                    <div class="col-3" th:if="${myInEvents.size() == 0}"></div>
+                                    <div class="col-3"
+                                         th:if="${myInEvents.size() == 0 || myInEvents.size() == 1}"></div>
+                                    <div class="col-3"
+                                         th:if="${myInEvents.size() == 0 || myInEvents.size() == 1 || myInEvents.size() == 2}"></div>
                                 </div>
-                                <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
-                                <div class="col-3" th:if="${myInEvents.size() == 0}"></div>
-                                <div class="col-3" th:if="${myInEvents.size() == 0 || myInEvents.size() == 1}"></div>
-                                <div class="col-3"
-                                     th:if="${myInEvents.size() == 0 || myInEvents.size() == 1 || myInEvents.size() == 2}"></div>
-                            </div>
-                            <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
-                                <div class="col-3 clickable-row"
-                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
-                                     th:each="myInEvent, iterStat : ${myInEvents}"
-                                     th:attr="data-href=@{/introduction/event/eventDetail(eventNo=${myInEvent.eventNo})}"
-                                     th:if="${iterStat.index >= 3}">
-                                    <div class="row justify-content-center">
-                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
-                                             style="aspect-ratio: 1; border-radius: 5px;">
-                                            <div class="date-container px-2 py-1">
-                                                <div class="month"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myInEvent.startDate)}"></div>
-                                                <div class="year"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myInEvent.startDate)}"></div>
+                                <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
+                                    <div class="col-3 clickable-row"
+                                         style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                         th:each="myInEvent, iterStat : ${myInEvents}"
+                                         th:attr="data-href=@{/introduction/event/eventDetail(eventNo=${myInEvent.eventNo})}"
+                                         th:if="${iterStat.index >= 3}">
+                                        <div class="row justify-content-center">
+                                            <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                                 style="aspect-ratio: 1; border-radius: 5px;">
+                                                <div class="date-container px-2 py-1">
+                                                    <div class="month"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myInEvent.startDate)}"></div>
+                                                    <div class="year"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myInEvent.startDate)}"></div>
+                                                </div>
+                                            </div>
+                                            <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                            <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                            <!--                                    </div>-->
+                                            <div class="col-4"
+                                                 style="color: #333333; font-size: 0.8rem; font-weight: 530;"
+                                                 th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M월 d일').format(myInEvent.startDate)} + ' ~ ' + ${T(java.time.format.DateTimeFormatter).ofPattern('M월 d일').format(myInEvent.endDate)}">
+                                                닉네임
+                                            </div>
+
+                                            <div class="col-4"
+                                                 style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
+                                                 th:text="${myInEvent.formattedEventDuration}">시간
                                             </div>
                                         </div>
-                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                        <!--                                    </div>-->
-                                        <div class="col-4" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
-                                             th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M월 d일').format(myInEvent.startDate)} + ' ~ ' + ${T(java.time.format.DateTimeFormatter).ofPattern('M월 d일').format(myInEvent.endDate)}">
-                                            닉네임
+                                        <div class="row justify-content-center">
+                                            <div class="col-10" style="color: white;" th:text="${myInEvent.eventNo}">사진
+                                            </div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                                 th:text="${myInEvent.title}">이름
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                                 th:text="${myInEvent.place}">내용
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                                 th:text="${myInEvent.eventCategoryTitle}">내용2
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;">→</div>
                                         </div>
 
-                                        <div class="col-4"
-                                             style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
-                                             th:text="${myInEvent.formattedEventDuration}">시간
-                                        </div>
-                                    </div>
-                                    <div class="row justify-content-center">
-                                        <div class="col-10" style="color: white;" th:text="${myInEvent.eventNo}">사진
-                                        </div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
-                                             th:text="${myInEvent.title}">이름
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
-                                             th:text="${myInEvent.place}">내용
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
-                                             th:text="${myInEvent.eventCategoryTitle}">내용2
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
                                     </div>
 
+                                    <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
+                                    <div class="col-3" th:if="${myInEvents.size() <= 3}"></div>
+                                    <div class="col-3"
+                                         th:if="${myInEvents.size() <= 3 || myInEvents.size() == 4}"></div>
+                                    <div class="col-3"
+                                         th:if="${myInEvents.size() <= 3 || myInEvents.size() == 4 || myInEvents.size() == 5}"></div>
                                 </div>
-
-                                <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
-                                <div class="col-3" th:if="${myInEvents.size() <= 3}"></div>
-                                <div class="col-3" th:if="${myInEvents.size() <= 3 || myInEvents.size() == 4}"></div>
-                                <div class="col-3"
-                                     th:if="${myInEvents.size() <= 3 || myInEvents.size() == 4 || myInEvents.size() == 5}"></div>
                             </div>
                         </div>
-                    </div>
-                    <div class="row justify-content-center">
-                        <!-- 페이징 -->
-                        <th:block th:if="${pages != null}">
-                            <div class="d-flex justify-content-center">
-                                <div class="btn-group">
-                                    <button type="button" class="btn btn-sm previous"
-                                            th:onclick="|location.href='@{/user/my/in/event(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
-                                            th:disabled="${currentPage == 1}">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                             fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-                                            <path fill-rule="evenodd"
-                                                  d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                                        </svg>
-                                    </button>
-                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">
-                                        <button type="button" class="btn btn-sm me-2 pages"
-                                                th:text="${p}"
-                                                th:onclick="|location.href='@{/user/my/in/event(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
-                                    </th:block>
-                                    <button type="button" class="btn btn-sm  next"
-                                            th:onclick="|location.href='@{/user/my/in/event(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
-                                            th:disabled="${currentPage == pages}">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                             fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-                                            <path fill-rule="evenodd"
-                                                  d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
-                                        </svg>
-                                    </button>
+                        <div class="row justify-content-center">
+                            <!-- 페이징 -->
+                            <th:block th:if="${pages != null}">
+                                <div class="d-flex justify-content-center">
+                                    <div class="btn-group">
+                                        <button type="button" class="btn btn-sm previous"
+                                                th:onclick="|location.href='@{/user/my/in/event(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
+                                                th:disabled="${currentPage == 1}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                                 fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+                                                <path fill-rule="evenodd"
+                                                      d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                                            </svg>
+                                        </button>
+                                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">
+                                            <button type="button" class="btn btn-sm me-2 pages"
+                                                    th:text="${p}"
+                                                    th:onclick="|location.href='@{/user/my/in/event(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
+                                        </th:block>
+                                        <button type="button" class="btn btn-sm  next"
+                                                th:onclick="|location.href='@{/user/my/in/event(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
+                                                th:disabled="${currentPage == pages}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                                 fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+                                                <path fill-rule="evenodd"
+                                                      d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                                            </svg>
+                                        </button>
+                                    </div>
                                 </div>
-                            </div>
-                        </th:block>
-                    </div>
-                </div><!--테이블 및 페이징 포함-->
+                            </th:block>
+                        </div>
+                    </div><!--테이블 및 페이징 포함-->
+                </div> <!--본화면-->
             </div> <!--본화면-->
-        </div> <!--본화면-->
 
 
-        <!--수정전-->
-        <!--    <div class="col-md-9">-->
-        <!--        <div class="review-list">-->
-        <!--            <h2>좋아요한 행사</h2>-->
-        <!--            <form id="filter-and-sort-form" th:action="@{/user/my/in/event}" method="get">-->
-        <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
-        <!--                <label>-->
-        <!--                    <select name="searchBy">-->
-        <!--                        <option value="title" th:selected="${searchBy == 'title'}">제목</option>-->
-        <!--                        <option value="content" th:selected="${searchBy == 'content'}">내용</option>-->
-        <!--                        <option value="place" th:selected="${searchBy == 'place'}">행사장소</option>-->
-        <!--                        <option value="address" th:selected="${searchBy == 'address'}">행사주소</option>-->
-        <!--                    </select>-->
-        <!--                </label>-->
-        <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
+            <!--수정전-->
+            <!--    <div class="col-md-9">-->
+            <!--        <div class="review-list">-->
+            <!--            <h2>좋아요한 행사</h2>-->
+            <!--            <form id="filter-and-sort-form" th:action="@{/user/my/in/event}" method="get">-->
+            <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
+            <!--                <label>-->
+            <!--                    <select name="searchBy">-->
+            <!--                        <option value="title" th:selected="${searchBy == 'title'}">제목</option>-->
+            <!--                        <option value="content" th:selected="${searchBy == 'content'}">내용</option>-->
+            <!--                        <option value="place" th:selected="${searchBy == 'place'}">행사장소</option>-->
+            <!--                        <option value="address" th:selected="${searchBy == 'address'}">행사주소</option>-->
+            <!--                    </select>-->
+            <!--                </label>-->
+            <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
 
-        <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
-        <!--                <button type="submit">검색</button>-->
+            <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
+            <!--                <button type="submit">검색</button>-->
 
-        <!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
-        <!--                <label>-->
-        <!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">진행중인 행사-->
-        <!--                </label>-->
+            <!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
+            <!--                <label>-->
+            <!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">진행중인 행사-->
+            <!--                </label>-->
 
-        <!--                <label>-->
-        <!--                    <select name="orderBy" onchange="submitForm()">-->
-        <!--                        <option value="recentliked" th:selected="${orderBy == 'recentliked'}">최근좋아요순</option>-->
-        <!--                        <option value="oldestliked" th:selected="${orderBy == 'oldestliked'}">오래된순</option>-->
+            <!--                <label>-->
+            <!--                    <select name="orderBy" onchange="submitForm()">-->
+            <!--                        <option value="recentliked" th:selected="${orderBy == 'recentliked'}">최근좋아요순</option>-->
+            <!--                        <option value="oldestliked" th:selected="${orderBy == 'oldestliked'}">오래된순</option>-->
 
-        <!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최신행사순</option>-->
-        <!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된행사순</option>-->
+            <!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최신행사순</option>-->
+            <!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된행사순</option>-->
 
-        <!--                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
-        <!--                    </select>-->
-        <!--                </label>-->
-        <!--            </form>-->
-        <!--&lt;!&ndash;            <form id="filter-form" th:action="@{/user/my/in/event}" method="get">&ndash;&gt;-->
-        <!--&lt;!&ndash;                <label>&ndash;&gt;-->
-        <!--&lt;!&ndash;                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="toggleCheckboxValue()">진행중인 행사&ndash;&gt;-->
-        <!--&lt;!&ndash;                </label>&ndash;&gt;-->
-        <!--&lt;!&ndash;            </form>&ndash;&gt;-->
-        <!--            <table>-->
-        <!--                <thead>-->
-        <!--                <tr>-->
-        <!--                    <th>좋아요 번호</th>-->
-        <!--                    <th>행사 게시글 번호</th>-->
-        <!--                    <th>회원번호</th>-->
-        <!--                    <th>좋아요 날짜</th>-->
-        <!--                    <th>행사 제목</th>-->
-        <!--                    <th>행사 카테고리 코드</th>-->
-        <!--                    <th>행사 시작일</th>-->
-        <!--                    <th>행사 종료일</th>-->
-        <!--                    <th>행사 비용</th>-->
-        <!--                    <th>관련사이트URL</th>-->
-        <!--                    <th>장소명</th>-->
-        <!--                    <th>주소명</th>-->
-        <!--                    <th>좌표</th>-->
-        <!--                    <th>행사 내용</th>-->
-        <!--                    <th>게시 일시</th>-->
-        <!--                </tr>-->
-        <!--                </thead>-->
-        <!--                <tbody>-->
-        <!--                <tr th:each="myInEvent : ${myInEvents}" class="clickable-row" th:attr="data-href=@{/introduction/event/eventDetail(eventNo=${myInEvent.eventNo})}">-->
-        <!--                    <td th:text="${myInEvent.likedNo}">좋아요 번호</td>-->
-        <!--                    <td th:text="${myInEvent.eventNo}">행사 게시글 번호</td>-->
-        <!--                    <td th:text="${myInEvent.userNo}">회원번호</td>-->
-        <!--                    <td th:text="${myInEvent.likedDate}">좋아요 날짜</td>-->
-        <!--                    <td th:text="${myInEvent.title}">행사 제목</td>-->
-        <!--                    <td th:text="${myInEvent.eventCategoryCode}">행사 카테고리 코드</td>-->
-        <!--                    <td th:text="${myInEvent.startDate}">행사 시작일</td>-->
-        <!--                    <td th:text="${myInEvent.endDate}">행사 종료일</td>-->
-        <!--                    <td th:text="${myInEvent.cost}">행사 비용</td>-->
-        <!--                    <td th:text="${myInEvent.site}">관련사이트URL</td>-->
-        <!--                    <td th:text="${myInEvent.place}">장소명</td>-->
-        <!--                    <td th:text="${myInEvent.address}">주소명</td>-->
-        <!--                    <td th:text="${myInEvent.coordinates}">좌표</td>-->
-        <!--                    <td th:text="${myInEvent.content}">행사 내용</td>-->
-        <!--                    <td th:text="${myInEvent.postingDate}">게시 일시</td>-->
-        <!--                </tr>-->
-        <!--                </tbody>-->
-        <!--            </table>-->
-        <!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
-        <!--            <th:block th:if="${pages != null}">-->
-        <!--                <div class="d-flex justify-content-center">-->
-        <!--                    <div class="btn-group">-->
-        <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/in/event(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
-        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
-        <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
-        <!--                            </svg>-->
-        <!--                        </button>-->
-        <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
-        <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
-        <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/in/event(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
-        <!--                        </th:block>-->
-        <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/in/event(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
-        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
-        <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
-        <!--                            </svg>-->
-        <!--                        </button>-->
-        <!--                    </div>-->
-        <!--                </div>-->
-        <!--            </th:block>-->
-        <!--        </div>-->
-        <!--    </div>-->
+            <!--                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
+            <!--                    </select>-->
+            <!--                </label>-->
+            <!--            </form>-->
+            <!--&lt;!&ndash;            <form id="filter-form" th:action="@{/user/my/in/event}" method="get">&ndash;&gt;-->
+            <!--&lt;!&ndash;                <label>&ndash;&gt;-->
+            <!--&lt;!&ndash;                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="toggleCheckboxValue()">진행중인 행사&ndash;&gt;-->
+            <!--&lt;!&ndash;                </label>&ndash;&gt;-->
+            <!--&lt;!&ndash;            </form>&ndash;&gt;-->
+            <!--            <table>-->
+            <!--                <thead>-->
+            <!--                <tr>-->
+            <!--                    <th>좋아요 번호</th>-->
+            <!--                    <th>행사 게시글 번호</th>-->
+            <!--                    <th>회원번호</th>-->
+            <!--                    <th>좋아요 날짜</th>-->
+            <!--                    <th>행사 제목</th>-->
+            <!--                    <th>행사 카테고리 코드</th>-->
+            <!--                    <th>행사 시작일</th>-->
+            <!--                    <th>행사 종료일</th>-->
+            <!--                    <th>행사 비용</th>-->
+            <!--                    <th>관련사이트URL</th>-->
+            <!--                    <th>장소명</th>-->
+            <!--                    <th>주소명</th>-->
+            <!--                    <th>좌표</th>-->
+            <!--                    <th>행사 내용</th>-->
+            <!--                    <th>게시 일시</th>-->
+            <!--                </tr>-->
+            <!--                </thead>-->
+            <!--                <tbody>-->
+            <!--                <tr th:each="myInEvent : ${myInEvents}" class="clickable-row" th:attr="data-href=@{/introduction/event/eventDetail(eventNo=${myInEvent.eventNo})}">-->
+            <!--                    <td th:text="${myInEvent.likedNo}">좋아요 번호</td>-->
+            <!--                    <td th:text="${myInEvent.eventNo}">행사 게시글 번호</td>-->
+            <!--                    <td th:text="${myInEvent.userNo}">회원번호</td>-->
+            <!--                    <td th:text="${myInEvent.likedDate}">좋아요 날짜</td>-->
+            <!--                    <td th:text="${myInEvent.title}">행사 제목</td>-->
+            <!--                    <td th:text="${myInEvent.eventCategoryCode}">행사 카테고리 코드</td>-->
+            <!--                    <td th:text="${myInEvent.startDate}">행사 시작일</td>-->
+            <!--                    <td th:text="${myInEvent.endDate}">행사 종료일</td>-->
+            <!--                    <td th:text="${myInEvent.cost}">행사 비용</td>-->
+            <!--                    <td th:text="${myInEvent.site}">관련사이트URL</td>-->
+            <!--                    <td th:text="${myInEvent.place}">장소명</td>-->
+            <!--                    <td th:text="${myInEvent.address}">주소명</td>-->
+            <!--                    <td th:text="${myInEvent.coordinates}">좌표</td>-->
+            <!--                    <td th:text="${myInEvent.content}">행사 내용</td>-->
+            <!--                    <td th:text="${myInEvent.postingDate}">게시 일시</td>-->
+            <!--                </tr>-->
+            <!--                </tbody>-->
+            <!--            </table>-->
+            <!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
+            <!--            <th:block th:if="${pages != null}">-->
+            <!--                <div class="d-flex justify-content-center">-->
+            <!--                    <div class="btn-group">-->
+            <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/in/event(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
+            <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
+            <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
+            <!--                            </svg>-->
+            <!--                        </button>-->
+            <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
+            <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
+            <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/in/event(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
+            <!--                        </th:block>-->
+            <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/in/event(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
+            <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
+            <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
+            <!--                            </svg>-->
+            <!--                        </button>-->
+            <!--                    </div>-->
+            <!--                </div>-->
+            <!--            </th:block>-->
+            <!--        </div>-->
+            <!--    </div>-->
+        </div>
     </div>
 </div>
 <div th:replace="common/footer.html"></div>

--- a/src/main/resources/templates/user/mypage_in_event.html
+++ b/src/main/resources/templates/user/mypage_in_event.html
@@ -106,18 +106,23 @@
 <div class="jumbotron">
     <div class="container">
         <div class="row">
-            <div class="col-md-3 px-4">
-                <h3>나의 소식</h3>
-            </div>
-            <div class="col-md-9">
-                <nav class="navbar navbar-expand-md">
-                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                        <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>
-                        <li><a th:href="@{/user/my/in/event}" class="nav-link px-2" style="color: #000;">좋아요한 행사</a>
-                        </li>
-                        <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>
-                    </ul>
-                </nav>
+            <div class="col-9">
+                <div class="row">
+                    <div class="col-md-3 px-4">
+                        <h3>나의 소식</h3>
+                    </div>
+                    <div class="col-md-9">
+                        <nav class="navbar navbar-expand-md">
+                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>
+                                <li><a th:href="@{/user/my/in/event}" class="nav-link px-2" style="color: #000;">좋아요한
+                                    행사</a>
+                                </li>
+                                <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>
+                            </ul>
+                        </nav>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/user/mypage_in_event.html
+++ b/src/main/resources/templates/user/mypage_in_event.html
@@ -104,18 +104,21 @@
   }
 </style>
 <div class="jumbotron">
-    <div class="row">
-        <div class="col-md-3 px-4">
-            <h3>나의 소식</h3>
-        </div>
-        <div class="col-md-9">
-            <nav class="navbar navbar-expand-md">
-                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                    <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>
-                    <li><a th:href="@{/user/my/in/event}" class="nav-link px-2" style="color: #000;">좋아요한 행사</a></li>
-                    <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>
-                </ul>
-            </nav>
+    <div class="container">
+        <div class="row">
+            <div class="col-md-3 px-4">
+                <h3>나의 소식</h3>
+            </div>
+            <div class="col-md-9">
+                <nav class="navbar navbar-expand-md">
+                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                        <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>
+                        <li><a th:href="@{/user/my/in/event}" class="nav-link px-2" style="color: #000;">좋아요한 행사</a>
+                        </li>
+                        <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>
+                    </ul>
+                </nav>
+            </div>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/user/mypage_in_event.html
+++ b/src/main/resources/templates/user/mypage_in_event.html
@@ -131,7 +131,7 @@
     <div class="row">
         <aside class="col-md-3 px-4">
             <div class="row">
-                <div class="col-3"></div>
+                <div class="col-1"></div>
                 <div class="col-6">
                     <div class="panel">
                         <ul class="list-group">

--- a/src/main/resources/templates/user/mypage_in_event.html
+++ b/src/main/resources/templates/user/mypage_in_event.html
@@ -356,7 +356,7 @@
                                 }
 
                                 .search-container button i {
-                                    color: #666;
+                                    color: #A6AAB5;
                                 }
 
                                 .search-container button:hover i {

--- a/src/main/resources/templates/user/mypage_in_journal.html
+++ b/src/main/resources/templates/user/mypage_in_journal.html
@@ -334,7 +334,7 @@
                                 }
 
                                 .search-container button i {
-                                    color: #666;
+                                    color: #A6AAB5;
                                 }
 
                                 .search-container button:hover i {

--- a/src/main/resources/templates/user/mypage_in_journal.html
+++ b/src/main/resources/templates/user/mypage_in_journal.html
@@ -106,18 +106,23 @@
 <div class="jumbotron">
     <div class="container">
         <div class="row">
-            <div class="col-md-3 px-4">
-                <h3>나의 소식</h3>
-            </div>
-            <div class="col-md-9">
-                <nav class="navbar navbar-expand-md">
-                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                        <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2" style="color: #000;">좋아요한 웹툰소식</a>
-                        </li>
-                        <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>
-                        <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>
-                    </ul>
-                </nav>
+            <div class="col-9">
+                <div class="row">
+                    <div class="col-md-3 px-4">
+                        <h3>나의 소식</h3>
+                    </div>
+                    <div class="col-md-9">
+                        <nav class="navbar navbar-expand-md">
+                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2" style="color: #000;">좋아요한
+                                    웹툰소식</a>
+                                </li>
+                                <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>
+                                <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>
+                            </ul>
+                        </nav>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/user/mypage_in_journal.html
+++ b/src/main/resources/templates/user/mypage_in_journal.html
@@ -284,14 +284,69 @@
             <div class="row" style="color: #828282;">
                 <div class="col-11">
                     <div class="row mb-4">
-                        <div class="col-12">
+                        <div class="col-12 p-0">
+                            <style>
+                                .col-4 select {
+                                    border-radius: 50px;
+                                    text-align: center;
+                                }
+                                /* 검색창 스타일 */
+                                .search-container {
+                                    width: 300px;
+                                }
+
+                                .search-container select {
+                                    position: absolute;
+                                    left: 0%;
+                                    width: 30%;
+                                    height: 50px;
+                                    color: #828282;
+                                    font-size: 1rem;
+                                    border-radius: 50px 0 0 50px;
+                                    outline: none;
+                                }
+                                .search-container input[type="text"] {
+                                    position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
+                                    left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
+                                    width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
+                                    height: 50px;
+                                    padding: 10px 40px 10px 15px;
+                                    font-size: 1rem;
+                                    outline: none;
+                                    border-radius: 0 50px 50px 0;
+                                    transition: border-color 0.3s, background-color 0.3s;
+                                    color: #828282; /* 입력 텍스트 색상 변경 */
+                                }
+
+                                .search-container input[type="text"]::placeholder {
+                                    color: #BBBBBB; /* placeholder 색상 변경 */
+                                }
+
+
+                                .search-container button {
+                                    position: absolute;
+                                    right: 1rem;
+                                    top: 25px;
+                                    background: none;
+                                    transform: translateY(-50%);
+                                    border: none;
+                                    cursor: pointer;
+                                }
+
+                                .search-container button i {
+                                    color: #666;
+                                }
+
+                                .search-container button:hover i {
+                                    color: #03C75A;
+                                }
+                            </style>
                             <form id="sort-form" th:action="@{/user/my/in/journal}" method="get">
-                                <div class="row">
-                                    <div class="col-7">
+                                <div class="row m-0">
+                                    <div class="col-7 p-0">
                                         <div class="row justify-content-start m-0">
-                                            <div class="col-4">
-                                                <!-- 검색 조건 -->
-                                                <label>
+                                            <div class="col-12 p-0">
+                                                <div class="search-container">
                                                     <select class="form-select px-3" name="searchBy">
                                                         <option value="title" th:selected="${searchBy == 'title'}">제목
                                                         </option>
@@ -299,16 +354,12 @@
                                                             내용
                                                         </option>
                                                     </select>
-                                                </label>
-                                            </div>
-                                            <div class="col-6">
-                                                <input class="form-control px-3" type="text" name="searchTerm"
-                                                       placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
-                                            </div>
-                                            <div class="col-2">
-                                                <!-- 검색 버튼 -->
-                                                <button id="searchbutton" type="submit" class="btn btn-primary">검색
-                                                </button>
+                                                    <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
+                                                    <!-- 검색 버튼 -->
+                                                    <button type="submit">
+                                                        <i class="fas fa-search"></i>
+                                                    </button>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>

--- a/src/main/resources/templates/user/mypage_in_journal.html
+++ b/src/main/resources/templates/user/mypage_in_journal.html
@@ -122,423 +122,489 @@
         </div>
     </div>
 </div>
-<div class="row">
-    <aside class="col-md-3 px-4">
-        <div class="row">
-            <div class="col-3"></div>
-            <div class="col-6">
-                <div class="panel">
-                    <ul class="list-group">
-                        <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
-                        <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-                        <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
-                        <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2" style="color: #03C75A;">나의 소식</a></li>
-                        <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                        <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-                    </ul>
+<div class="container" style="padding:0;">
+    <div class="row">
+        <aside class="col-md-3 px-4">
+            <div class="row">
+                <div class="col-3"></div>
+                <div class="col-6">
+                    <div class="panel">
+                        <ul class="list-group">
+                            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
+                            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
+                            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2" style="color: #03C75A;">나의
+                                소식</a></li>
+                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+                        </ul>
+                    </div>
                 </div>
             </div>
-        </div>
-    </aside>
-    <style>
-        .form-select {
-        background-color : #FCFCFC;
-        border : none;
-        width : 100%;
-        height : 50px;
-        }
-        select {
-        color : #828282;
-        }
-        .form-control {
-        background-color : #FCFCFC;
-        border : none;
-        width : 100%;
-        height : 50px;
-        }
-
-
-        .form-control::placeholder {
-        color : #BBBBBB;
-        }
-
-        .date-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    background-color: #8E4B6E;
-    color: white;
-    border-radius: 10px;
-    text-align:center;
-    font-family: "Work Sans", sans-serif;
-}
-
-.month {
-    font-size: 1.1rem; /* M의 크기를 설정 */
-    font-weight: 550;
-    line-height: 1;
-}
-
-.year {
-    font-size: 0.65rem; /* yyyy의 크기를 설정 */
-    font-weight: 400;
-}
-:root {
-    --background-color-light: #FFFFFF;
-    --text-color-light: #000000;
-    --toggle-background-light: #CCCCCC;
-    --toggle-ball-light: #FFFFFF;
-
-    --background-color-dark: #333333;
-    --text-color-dark: #FFFFFF;
-    --toggle-background-dark: #03C75A;
-    --toggle-ball-dark: #FFFFFF;
-
-    --font-size-base: 32px; /* 기본 텍스트 크기 */
-    --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
-}
-
-
-
-.toggle-switch {
-    position: relative;
-    display: inline-block;
-    width: 62px; /* 너비 조정 */
-    height: 38px; /* 높이 조정 */
-}
-
-.toggle-switch .checkbox {
-    opacity: 0;
-    width: 0;
-    height: 0;
-}
-#isToggledCheckbox {
-     opacity: 0;
-        width: 0;
-        height: 0;
-}
-
-.toggle-switch .label {
-    position: absolute;
-    cursor: pointer;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: var(--toggle-background-light);
-    transition: background-color 0.4s;
-    border-radius: 38px; /* 둥근 모서리 반경 조정 */
-}
-
-.toggle-switch .label:before {
-    position: absolute;
-    content: "";
-    height: 30px; /* 내부 원 높이 조정 */
-    width: 30px; /* 내부 원 너비 조정 */
-    left: 2px;
-    bottom: 0px;
-    background-color: var(--toggle-ball-light);
-    transition: transform 0.4s;
-    border-radius: 50%;
-}
-
-.toggle-switch input:checked + .label {
-    background-color: var(--toggle-background-dark);
-}
-
-.toggle-switch input:checked + .label:before {
-    transform: translateX(28px); /* 내부 원 이동 거리 조정 */
-}
-
-         #absdiv {
-            position: relative;
-            top: 60px; /* Move down by 20px from its current position */
-            z-index : 1000;
-        }
-
-        #searchbutton {
-            background-color: #828282;
-        }
-
-        .card-img-top {
-                width: 100%;
-                height: 100px;
-                object-fit: cover;
+        </aside>
+        <style>
+            .form-select {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
+            }
+            select {
+            color : #828282;
+            }
+            .form-control {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
             }
 
-    </style>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
 
-    <div class="col-md-9">
-        <div class="row" style="color: #828282;">
-            <div class="col-11">
-                <div class="row mb-4">
-                    <div class="col-12">
-                        <form id="sort-form" th:action="@{/user/my/in/journal}" method="get">
-                            <div class="row">
-                                <div class="col-7">
-                                    <div class="row justify-content-start m-0">
-                                        <div class="col-4">
-                                            <!-- 검색 조건 -->
+            .form-control::placeholder {
+            color : #BBBBBB;
+            }
+
+            .date-container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        background-color: #8E4B6E;
+        color: white;
+        border-radius: 10px;
+        text-align:center;
+        font-family: "Work Sans", sans-serif;
+    }
+
+    .month {
+        font-size: 1.1rem; /* M의 크기를 설정 */
+        font-weight: 550;
+        line-height: 1;
+    }
+
+    .year {
+        font-size: 0.65rem; /* yyyy의 크기를 설정 */
+        font-weight: 400;
+    }
+    :root {
+        --background-color-light: #FFFFFF;
+        --text-color-light: #000000;
+        --toggle-background-light: #CCCCCC;
+        --toggle-ball-light: #FFFFFF;
+
+        --background-color-dark: #333333;
+        --text-color-dark: #FFFFFF;
+        --toggle-background-dark: #03C75A;
+        --toggle-ball-dark: #FFFFFF;
+
+        --font-size-base: 32px; /* 기본 텍스트 크기 */
+        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+    }
+
+
+
+    .toggle-switch {
+        position: relative;
+        display: inline-block;
+        width: 62px; /* 너비 조정 */
+        height: 38px; /* 높이 조정 */
+    }
+
+    .toggle-switch .checkbox {
+        opacity: 0;
+        width: 0;
+        height: 0;
+    }
+    #isToggledCheckbox {
+         opacity: 0;
+            width: 0;
+            height: 0;
+    }
+
+    .toggle-switch .label {
+        position: absolute;
+        cursor: pointer;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: var(--toggle-background-light);
+        transition: background-color 0.4s;
+        border-radius: 38px; /* 둥근 모서리 반경 조정 */
+    }
+
+    .toggle-switch .label:before {
+        position: absolute;
+        content: "";
+        height: 30px; /* 내부 원 높이 조정 */
+        width: 30px; /* 내부 원 너비 조정 */
+        left: 2px;
+        bottom: 0px;
+        background-color: var(--toggle-ball-light);
+        transition: transform 0.4s;
+        border-radius: 50%;
+    }
+
+    .toggle-switch input:checked + .label {
+        background-color: var(--toggle-background-dark);
+    }
+
+    .toggle-switch input:checked + .label:before {
+        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+    }
+
+             #absdiv {
+                position: relative;
+                top: 60px; /* Move down by 20px from its current position */
+                z-index : 1000;
+            }
+
+            #searchbutton {
+                background-color: #828282;
+            }
+
+            .card-img-top {
+                    width: 100%;
+                    height: 100px;
+                    object-fit: cover;
+                }
+
+        </style>
+        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+              rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+              rel="stylesheet">
+
+        <div class="col-md-9">
+            <div class="row" style="color: #828282;">
+                <div class="col-11">
+                    <div class="row mb-4">
+                        <div class="col-12">
+                            <form id="sort-form" th:action="@{/user/my/in/journal}" method="get">
+                                <div class="row">
+                                    <div class="col-7">
+                                        <div class="row justify-content-start m-0">
+                                            <div class="col-4">
+                                                <!-- 검색 조건 -->
+                                                <label>
+                                                    <select class="form-select px-3" name="searchBy">
+                                                        <option value="title" th:selected="${searchBy == 'title'}">제목
+                                                        </option>
+                                                        <option value="content" th:selected="${searchBy == 'content'}">
+                                                            내용
+                                                        </option>
+                                                    </select>
+                                                </label>
+                                            </div>
+                                            <div class="col-6">
+                                                <input class="form-control px-3" type="text" name="searchTerm"
+                                                       placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
+                                            </div>
+                                            <div class="col-2">
+                                                <!-- 검색 버튼 -->
+                                                <button id="searchbutton" type="submit" class="btn btn-primary">검색
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-1" style=""></div>
+                                    <div class="col-4">
+                                        <div class="row justify-content-end">
+                                            <!-- 정렬 또는 토글2 -->
                                             <label>
-                                                <select class="form-select px-3" name="searchBy">
-                                                    <option value="title" th:selected="${searchBy == 'title'}">제목</option>
-                                                    <option value="content" th:selected="${searchBy == 'content'}">내용</option>
+                                                <select class="form-select px-3" name="orderBy"
+                                                        onchange="this.form.submit()">
+                                                    <option value="recentliked"
+                                                            th:selected="${orderBy == 'recentliked'}">최근좋아요순
+                                                    </option>
+                                                    <option value="oldestliked"
+                                                            th:selected="${orderBy == 'oldestliked'}">오래된순
+                                                    </option>
+
+                                                    <option value="recent" th:selected="${orderBy == 'recent'}">최신소식순
+                                                    </option>
+                                                    <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된소식순
+                                                    </option>
+
+                                                    <option value="title" th:selected="${orderBy == 'title'}">제목가나다순
+                                                    </option>
                                                 </select>
                                             </label>
                                         </div>
-                                        <div class="col-6">
-                                            <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
-                                        </div>
-                                        <div class="col-2">
-                                            <!-- 검색 버튼 -->
-                                            <button id="searchbutton" type="submit" class="btn btn-primary">검색</button>
-                                        </div>
                                     </div>
-                                </div>
-                                <div class="col-1" style=""></div>
-                                <div class="col-4">
-                                    <div class="row justify-content-end">
-                                        <!-- 정렬 또는 토글2 -->
-                                        <label>
-                                            <select class="form-select px-3" name="orderBy" onchange="this.form.submit()">
-                                                <option value="recentliked" th:selected="${orderBy == 'recentliked'}">최근좋아요순</option>
-                                                <option value="oldestliked" th:selected="${orderBy == 'oldestliked'}">오래된순</option>
-
-                                                <option value="recent" th:selected="${orderBy == 'recent'}">최신소식순</option>
-                                                <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된소식순</option>
-
-                                                <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>
-                                            </select>
-                                        </label>
-                                    </div>
-                                </div>
-                            </div> <!--검색, 소팅 (토글X)-->
-                            <div class="row justify-content-around">
-                                <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                <div class="col-3" style="padding: 0 1.2rem;">
-                                    <div id="absdiv" class="row justify-content-end">
-<!--                                        <div class="col-3">-->
-<!--                                            <div class="toggle-switch">-->
-<!--                                                &lt;!&ndash; 정렬 또는 토글1 &ndash;&gt;-->
-<!--                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">-->
-<!--                                                <label for="isToggledCheckbox" class="label">-->
-<!--                                                    <div class="ball"></div>-->
-<!--                                                </label>-->
-<!--                                            </div>-->
-<!--                                        </div>-->
-<!--                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">진행중인 행사</div>-->
-                                    </div>
-                                </div>
-                            </div> <!--토글-->
-                        </form>
-                    </div>
-                </div>
-                <div class="row justify-content-around mt-4">
-                    <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
-                        <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
-                            <div class="col-3 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:each="myInJournal, iterStat : ${myInJournals}" th:attr="data-href=@{/introduction/journal/journalDetail(journalNo=${myInJournal.journalNo})}" th:if="${iterStat.index < 3}">
-                                <div class="row justify-content-center">
-                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                        <div class="date-container px-2 py-1">
-                                            <div class="month" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myInJournal.postingDate)}"></div>
-                                            <div class="year" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myInJournal.postingDate)}"></div>
+                                </div> <!--검색, 소팅 (토글X)-->
+                                <div class="row justify-content-around">
+                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                    <div class="col-3" style="padding: 0 1.2rem;">
+                                        <div id="absdiv" class="row justify-content-end">
+                                            <!--                                        <div class="col-3">-->
+                                            <!--                                            <div class="toggle-switch">-->
+                                            <!--                                                &lt;!&ndash; 정렬 또는 토글1 &ndash;&gt;-->
+                                            <!--                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">-->
+                                            <!--                                                <label for="isToggledCheckbox" class="label">-->
+                                            <!--                                                    <div class="ball"></div>-->
+                                            <!--                                                </label>-->
+                                            <!--                                            </div>-->
+                                            <!--                                        </div>-->
+                                            <!--                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">진행중인 행사</div>-->
                                         </div>
                                     </div>
-                                    <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                    <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                    <!--                                    </div>-->
-                                    <div class="col-5" style="color: white; font-size: 0.8rem; font-weight: 530;"
-                                         th:text="${myInJournal.journalNo}">닉네임
-                                    </div>
-
-                                    <div class="col-3" style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;" th:text="${myInJournal.formattedPostingDate}">시간</div>
-                                </div>
-                                <div class="row justify-content-center">
-                                    <div class="col-12 my-3" style="">
-                                        <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                        <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                        <!-- 썸네일 이미지 있을때  -->
-                                        <img th:if="${#lists.size(myInJournal.journalFiles) > 0}" th:src="@{/uploadFiles/{fileName}(fileName=${myInJournal.journalFiles.get(0).fileName})}" class="card-img-top" alt="썸네일 이미지">
-                                    </div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" th:text="${myInJournal.title}">이름</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${myInJournal.content}">내용</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                </div>
-
-                            </div>
-                            <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
-                            <div class="col-3" th:if="${myInJournals.size() == 0}"></div>
-                            <div class="col-3" th:if="${myInJournals.size() == 0 || myInJournals.size() == 1}"></div>
-                            <div class="col-3" th:if="${myInJournals.size() == 0 || myInJournals.size() == 1 || myInJournals.size() == 2}"></div>
-                        </div>
-                        <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
-                            <div class="col-3 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:each="myInJournal, iterStat : ${myInJournals}" th:attr="data-href=@{/introduction/journal/journalDetail(journalNo=${myInJournal.journalNo})}" th:if="${iterStat.index >= 3}">
-                                <div class="row justify-content-center">
-                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                        <div class="date-container px-2 py-1">
-                                            <div class="month" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myInJournal.postingDate)}"></div>
-                                            <div class="year" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myInJournal.postingDate)}"></div>
-                                        </div>
-                                    </div>
-                                    <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                    <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                    <!--                                    </div>-->
-                                    <div class="col-5" style="color: white; font-size: 0.8rem; font-weight: 530;"
-                                         th:text="${myInJournal.journalNo}">닉네임
-                                    </div>
-
-                                    <div class="col-3" style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;" th:text="${myInJournal.formattedPostingDate}">시간</div>
-                                </div>
-                                <div class="row justify-content-center">
-                                    <div class="col-12 my-3" style="">
-                                        <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                        <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                        <!-- 썸네일 이미지 있을때  -->
-                                        <img th:if="${#lists.size(myInJournal.journalFiles) > 0}" th:src="@{/uploadFiles/{fileName}(fileName=${myInJournal.journalFiles.get(0).fileName})}" class="card-img-top" alt="썸네일 이미지">
-                                    </div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" th:text="${myInJournal.title}">이름</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${myInJournal.content}">내용</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                </div>
-
-                            </div>
-
-                            <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
-                            <div class="col-3" th:if="${myInJournals.size() <= 3}"></div>
-                            <div class="col-3" th:if="${myInJournals.size() <= 3 || myInJournals.size() == 4}"></div>
-                            <div class="col-3" th:if="${myInJournals.size() <= 3 || myInJournals.size() == 4 || myInJournals.size() == 5}"></div>
+                                </div> <!--토글-->
+                            </form>
                         </div>
                     </div>
-                </div>
-                <div class="row justify-content-center">
-                    <!-- 페이징 -->
-                    <th:block th:if="${pages != null}">
-                        <div class="d-flex justify-content-center">
-                            <div class="btn-group">
-                                <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/in/journal(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-                                        <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                                    </svg>
-                                </button>
-                                <th:block th:each="p : ${#numbers.sequence(1, pages)}">
-                                    <button type="button" class="btn btn-sm me-2 pages"
-                                            th:text="${p}" th:onclick="|location.href='@{/user/my/in/journal(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
-                                </th:block>
-                                <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/in/journal(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-                                        <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
-                                    </svg>
-                                </button>
+                    <div class="row justify-content-around mt-4">
+                        <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
+                            <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
+                                <div class="col-3 clickable-row"
+                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                     th:each="myInJournal, iterStat : ${myInJournals}"
+                                     th:attr="data-href=@{/introduction/journal/journalDetail(journalNo=${myInJournal.journalNo})}"
+                                     th:if="${iterStat.index < 3}">
+                                    <div class="row justify-content-center">
+                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                             style="aspect-ratio: 1; border-radius: 5px;">
+                                            <div class="date-container px-2 py-1">
+                                                <div class="month"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myInJournal.postingDate)}"></div>
+                                                <div class="year"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myInJournal.postingDate)}"></div>
+                                            </div>
+                                        </div>
+                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                        <!--                                    </div>-->
+                                        <div class="col-5" style="color: white; font-size: 0.8rem; font-weight: 530;"
+                                             th:text="${myInJournal.journalNo}">닉네임
+                                        </div>
+
+                                        <div class="col-3"
+                                             style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
+                                             th:text="${myInJournal.formattedPostingDate}">시간
+                                        </div>
+                                    </div>
+                                    <div class="row justify-content-center">
+                                        <div class="col-12 my-3" style="">
+                                            <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                            <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                            <!-- 썸네일 이미지 있을때  -->
+                                            <img th:if="${#lists.size(myInJournal.journalFiles) > 0}"
+                                                 th:src="@{/uploadFiles/{fileName}(fileName=${myInJournal.journalFiles.get(0).fileName})}"
+                                                 class="card-img-top" alt="썸네일 이미지">
+                                        </div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                             th:text="${myInJournal.title}">이름
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                             th:text="${myInJournal.content}">내용
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                    </div>
+
+                                </div>
+                                <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
+                                <div class="col-3" th:if="${myInJournals.size() == 0}"></div>
+                                <div class="col-3"
+                                     th:if="${myInJournals.size() == 0 || myInJournals.size() == 1}"></div>
+                                <div class="col-3"
+                                     th:if="${myInJournals.size() == 0 || myInJournals.size() == 1 || myInJournals.size() == 2}"></div>
+                            </div>
+                            <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
+                                <div class="col-3 clickable-row"
+                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                     th:each="myInJournal, iterStat : ${myInJournals}"
+                                     th:attr="data-href=@{/introduction/journal/journalDetail(journalNo=${myInJournal.journalNo})}"
+                                     th:if="${iterStat.index >= 3}">
+                                    <div class="row justify-content-center">
+                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                             style="aspect-ratio: 1; border-radius: 5px;">
+                                            <div class="date-container px-2 py-1">
+                                                <div class="month"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myInJournal.postingDate)}"></div>
+                                                <div class="year"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myInJournal.postingDate)}"></div>
+                                            </div>
+                                        </div>
+                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                        <!--                                    </div>-->
+                                        <div class="col-5" style="color: white; font-size: 0.8rem; font-weight: 530;"
+                                             th:text="${myInJournal.journalNo}">닉네임
+                                        </div>
+
+                                        <div class="col-3"
+                                             style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
+                                             th:text="${myInJournal.formattedPostingDate}">시간
+                                        </div>
+                                    </div>
+                                    <div class="row justify-content-center">
+                                        <div class="col-12 my-3" style="">
+                                            <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                            <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                            <!-- 썸네일 이미지 있을때  -->
+                                            <img th:if="${#lists.size(myInJournal.journalFiles) > 0}"
+                                                 th:src="@{/uploadFiles/{fileName}(fileName=${myInJournal.journalFiles.get(0).fileName})}"
+                                                 class="card-img-top" alt="썸네일 이미지">
+                                        </div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                             th:text="${myInJournal.title}">이름
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                             th:text="${myInJournal.content}">내용
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                    </div>
+
+                                </div>
+
+                                <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
+                                <div class="col-3" th:if="${myInJournals.size() <= 3}"></div>
+                                <div class="col-3"
+                                     th:if="${myInJournals.size() <= 3 || myInJournals.size() == 4}"></div>
+                                <div class="col-3"
+                                     th:if="${myInJournals.size() <= 3 || myInJournals.size() == 4 || myInJournals.size() == 5}"></div>
                             </div>
                         </div>
-                    </th:block>
-                </div>
-            </div><!--테이블 및 페이징 포함-->
+                    </div>
+                    <div class="row justify-content-center">
+                        <!-- 페이징 -->
+                        <th:block th:if="${pages != null}">
+                            <div class="d-flex justify-content-center">
+                                <div class="btn-group">
+                                    <button type="button" class="btn btn-sm previous"
+                                            th:onclick="|location.href='@{/user/my/in/journal(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
+                                            th:disabled="${currentPage == 1}">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                             fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+                                            <path fill-rule="evenodd"
+                                                  d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                                        </svg>
+                                    </button>
+                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">
+                                        <button type="button" class="btn btn-sm me-2 pages"
+                                                th:text="${p}"
+                                                th:onclick="|location.href='@{/user/my/in/journal(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
+                                    </th:block>
+                                    <button type="button" class="btn btn-sm  next"
+                                            th:onclick="|location.href='@{/user/my/in/journal(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
+                                            th:disabled="${currentPage == pages}">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                             fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+                                            <path fill-rule="evenodd"
+                                                  d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                                        </svg>
+                                    </button>
+                                </div>
+                            </div>
+                        </th:block>
+                    </div>
+                </div><!--테이블 및 페이징 포함-->
+            </div> <!--본화면-->
         </div> <!--본화면-->
-    </div> <!--본화면-->
 
 
+        <!--수정전-->
+        <!--    <div class="col-md-9">-->
+        <!--        <div class="review-list">-->
+        <!--            <h2>좋아요한 웹툰 소식</h2>-->
+        <!--            <form id="sort-form" th:action="@{/user/my/in/journal}" method="get">-->
+        <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
+        <!--                <label>-->
+        <!--                    <select name="searchBy">-->
+        <!--                        <option value="title" th:selected="${searchBy == 'title'}">제목</option>-->
+        <!--                        <option value="content" th:selected="${searchBy == 'content'}">내용</option>-->
+        <!--                    </select>-->
+        <!--                </label>-->
+        <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
 
-    <!--수정전-->
-<!--    <div class="col-md-9">-->
-<!--        <div class="review-list">-->
-<!--            <h2>좋아요한 웹툰 소식</h2>-->
-<!--            <form id="sort-form" th:action="@{/user/my/in/journal}" method="get">-->
-<!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
-<!--                <label>-->
-<!--                    <select name="searchBy">-->
-<!--                        <option value="title" th:selected="${searchBy == 'title'}">제목</option>-->
-<!--                        <option value="content" th:selected="${searchBy == 'content'}">내용</option>-->
-<!--                    </select>-->
-<!--                </label>-->
-<!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
+        <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
+        <!--                <button type="submit">검색</button>-->
 
-<!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
-<!--                <button type="submit">검색</button>-->
+        <!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
+        <!--                <label>-->
+        <!--                    <select name="orderBy" onchange="this.form.submit()">-->
+        <!--                        <option value="recentliked" th:selected="${orderBy == 'recentliked'}">최근좋아요순</option>-->
+        <!--                        <option value="oldestliked" th:selected="${orderBy == 'oldestliked'}">오래된순</option>-->
 
-<!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
-<!--                <label>-->
-<!--                    <select name="orderBy" onchange="this.form.submit()">-->
-<!--                        <option value="recentliked" th:selected="${orderBy == 'recentliked'}">최근좋아요순</option>-->
-<!--                        <option value="oldestliked" th:selected="${orderBy == 'oldestliked'}">오래된순</option>-->
+        <!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최신소식순</option>-->
+        <!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된소식순</option>-->
 
-<!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최신소식순</option>-->
-<!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된소식순</option>-->
+        <!--                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
+        <!--                    </select>-->
+        <!--                </label>-->
+        <!--            </form>-->
+        <!--            <table>-->
+        <!--                <thead>-->
+        <!--                <tr>-->
+        <!--                    <th>좋아요 번호</th>-->
+        <!--                    <th>회원번호</th>-->
+        <!--                    <th>좋아요 날짜</th>-->
+        <!--                    <th>소식 게시글 번호</th>-->
+        <!--                    <th>소식 제목</th>-->
+        <!--                    <th>소식 내용</th>-->
+        <!--                    <th>게시 일시</th>-->
 
-<!--                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
-<!--                    </select>-->
-<!--                </label>-->
-<!--            </form>-->
-<!--            <table>-->
-<!--                <thead>-->
-<!--                <tr>-->
-<!--                    <th>좋아요 번호</th>-->
-<!--                    <th>회원번호</th>-->
-<!--                    <th>좋아요 날짜</th>-->
-<!--                    <th>소식 게시글 번호</th>-->
-<!--                    <th>소식 제목</th>-->
-<!--                    <th>소식 내용</th>-->
-<!--                    <th>게시 일시</th>-->
+        <!--    &lt;!&ndash;                <th>ijl.liked_no</th>&ndash;&gt;-->
+        <!--    &lt;!&ndash;                <th>ijl.user_no</th>&ndash;&gt;-->
+        <!--    &lt;!&ndash;                <th>ijl.liked_date</th>&ndash;&gt;-->
+        <!--    &lt;!&ndash;                <th>ij.journal_no</th>&ndash;&gt;-->
+        <!--    &lt;!&ndash;                <th>ij.title</th>&ndash;&gt;-->
+        <!--    &lt;!&ndash;                <th>ij.content</th>&ndash;&gt;-->
+        <!--    &lt;!&ndash;                <th>ij.posting_date</th>&ndash;&gt;-->
 
-<!--    &lt;!&ndash;                <th>ijl.liked_no</th>&ndash;&gt;-->
-<!--    &lt;!&ndash;                <th>ijl.user_no</th>&ndash;&gt;-->
-<!--    &lt;!&ndash;                <th>ijl.liked_date</th>&ndash;&gt;-->
-<!--    &lt;!&ndash;                <th>ij.journal_no</th>&ndash;&gt;-->
-<!--    &lt;!&ndash;                <th>ij.title</th>&ndash;&gt;-->
-<!--    &lt;!&ndash;                <th>ij.content</th>&ndash;&gt;-->
-<!--    &lt;!&ndash;                <th>ij.posting_date</th>&ndash;&gt;-->
-
-<!--                </tr>-->
-<!--                </thead>-->
-<!--                <tbody>-->
-<!--                <tr th:each="myInJournal : ${myInJournals}" class="clickable-row" th:attr="data-href=@{/introduction/journal/journalDetail(journalNo=${myInJournal.journalNo})}">-->
-<!--                    <td th:text="${myInJournal.likedNo}">좋아요 번호</td>-->
-<!--                    <td th:text="${myInJournal.userNo}">회원번호</td>-->
-<!--                    <td th:text="${myInJournal.likedDate}">좋아요 날짜</td>-->
-<!--                    <td th:text="${myInJournal.journalNo}">소식 게시글 번호</td>-->
-<!--                    <td th:text="${myInJournal.title}">소식 제목</td>-->
-<!--                    <td th:text="${myInJournal.content}">소식 내용</td>-->
-<!--                    <td th:text="${myInJournal.postingDate}">게시 일시</td>-->
-<!--                </tr>-->
-<!--                </tbody>-->
-<!--            </table>-->
-<!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
-<!--            <th:block th:if="${pages != null}">-->
-<!--                <div class="d-flex justify-content-center">-->
-<!--                    <div class="btn-group">-->
-<!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/in/journal(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
-<!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
-<!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
-<!--                            </svg>-->
-<!--                        </button>-->
-<!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
-<!--                            <button type="button" class="btn btn-sm me-2 pages"-->
-<!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/in/journal(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
-<!--                        </th:block>-->
-<!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/in/journal(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
-<!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
-<!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
-<!--                            </svg>-->
-<!--                        </button>-->
-<!--                    </div>-->
-<!--                </div>-->
-<!--            </th:block>-->
-<!--        </div>-->
-<!--    </div>-->
+        <!--                </tr>-->
+        <!--                </thead>-->
+        <!--                <tbody>-->
+        <!--                <tr th:each="myInJournal : ${myInJournals}" class="clickable-row" th:attr="data-href=@{/introduction/journal/journalDetail(journalNo=${myInJournal.journalNo})}">-->
+        <!--                    <td th:text="${myInJournal.likedNo}">좋아요 번호</td>-->
+        <!--                    <td th:text="${myInJournal.userNo}">회원번호</td>-->
+        <!--                    <td th:text="${myInJournal.likedDate}">좋아요 날짜</td>-->
+        <!--                    <td th:text="${myInJournal.journalNo}">소식 게시글 번호</td>-->
+        <!--                    <td th:text="${myInJournal.title}">소식 제목</td>-->
+        <!--                    <td th:text="${myInJournal.content}">소식 내용</td>-->
+        <!--                    <td th:text="${myInJournal.postingDate}">게시 일시</td>-->
+        <!--                </tr>-->
+        <!--                </tbody>-->
+        <!--            </table>-->
+        <!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
+        <!--            <th:block th:if="${pages != null}">-->
+        <!--                <div class="d-flex justify-content-center">-->
+        <!--                    <div class="btn-group">-->
+        <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/in/journal(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
+        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
+        <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
+        <!--                            </svg>-->
+        <!--                        </button>-->
+        <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
+        <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
+        <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/in/journal(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
+        <!--                        </th:block>-->
+        <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/in/journal(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
+        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
+        <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
+        <!--                            </svg>-->
+        <!--                        </button>-->
+        <!--                    </div>-->
+        <!--                </div>-->
+        <!--            </th:block>-->
+        <!--        </div>-->
+        <!--    </div>-->
+    </div>
 </div>
 <div th:replace="common/footer.html"></div>
 </body>

--- a/src/main/resources/templates/user/mypage_in_journal.html
+++ b/src/main/resources/templates/user/mypage_in_journal.html
@@ -132,7 +132,7 @@
         <aside class="col-md-3 px-4">
             <div class="row">
                 <div class="col-1"></div>
-                <div class="col-6">
+                <div class="col-8">
                     <div class="panel">
                         <ul class="list-group">
                             <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>

--- a/src/main/resources/templates/user/mypage_in_journal.html
+++ b/src/main/resources/templates/user/mypage_in_journal.html
@@ -104,18 +104,21 @@
   }
 </style>
 <div class="jumbotron">
-    <div class="row">
-        <div class="col-md-3 px-4">
-            <h3>나의 소식</h3>
-        </div>
-        <div class="col-md-9">
-            <nav class="navbar navbar-expand-md">
-                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                    <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2" style="color: #000;">좋아요한 웹툰소식</a></li>
-                    <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>
-                    <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>
-                </ul>
-            </nav>
+    <div class="container">
+        <div class="row">
+            <div class="col-md-3 px-4">
+                <h3>나의 소식</h3>
+            </div>
+            <div class="col-md-9">
+                <nav class="navbar navbar-expand-md">
+                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                        <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2" style="color: #000;">좋아요한 웹툰소식</a>
+                        </li>
+                        <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>
+                        <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>
+                    </ul>
+                </nav>
+            </div>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/user/mypage_in_journal.html
+++ b/src/main/resources/templates/user/mypage_in_journal.html
@@ -86,580 +86,606 @@
 
 <div th:replace="~{common/menubar}"></div>
 <style>
-    .jumbotron {
-    position : relative;
-    background-color : #EEEEEE;
+    html, body {
+        height: 100%;
+        margin: 0;
     }
-    .jumbotron .row {
-    position : absolute;
-    width : 100%;
-    bottom: 0%;
+    body {
+        display: flex;
+        flex-direction: column;
     }
-    .nav-link {
-            color: #828282;
+    .content-wrapper {
+        flex: 1 0 auto;
     }
-    ul {
-  list-style: none;
-  padding-left : 0px;
-  }
+    footer {
+        flex-shrink: 0;
+    }
+
 </style>
-<div class="jumbotron">
-    <div class="container">
-        <div class="row">
-            <div class="col-9">
-                <div class="row">
-                    <div class="col-md-3 px-4">
-                        <h3>나의 소식</h3>
-                    </div>
-                    <div class="col-md-9">
-                        <nav class="navbar navbar-expand-md">
-                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                                <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2" style="color: #000;">좋아요한
-                                    웹툰소식</a>
-                                </li>
-                                <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>
-                                <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>
-                            </ul>
-                        </nav>
+<div class="content-wrapper">
+    <style>
+        .jumbotron {
+        position : relative;
+        background-color : #EEEEEE;
+        }
+        .jumbotron .row {
+        position : absolute;
+        width : 100%;
+        bottom: 0%;
+        }
+        .nav-link {
+                color: #828282;
+        }
+        ul {
+      list-style: none;
+      padding-left : 0px;
+      }
+    </style>
+    <div class="jumbotron">
+        <div class="container">
+            <div class="row">
+                <div class="col-9">
+                    <div class="row">
+                        <div class="col-md-3 px-4">
+                            <h3>나의 소식</h3>
+                        </div>
+                        <div class="col-md-9">
+                            <nav class="navbar navbar-expand-md">
+                                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                    <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2" style="color: #000;">좋아요한
+                                        웹툰소식</a>
+                                    </li>
+                                    <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>
+                                    <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>
+                                </ul>
+                            </nav>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
-<div class="container" style="padding:0;">
-    <div class="row">
-        <aside class="col-md-3 px-4">
-            <div class="row">
-                <div class="col-1"></div>
-                <div class="col-8">
-                    <div class="panel">
-                        <ul class="list-group">
-                            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
-                            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-                            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
-                            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2" style="color: #03C75A;">나의
-                                소식</a></li>
-                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-                        </ul>
+    <div class="container" style="padding:0;">
+        <div class="row">
+            <aside class="col-md-3 px-4">
+                <div class="row">
+                    <div class="col-1"></div>
+                    <div class="col-8">
+                        <div class="panel">
+                            <ul class="list-group">
+                                <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
+                                <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
+                                <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2" style="color: #03C75A;">나의
+                                    소식</a></li>
+                                <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                                <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </aside>
-        <style>
-            .form-select {
-            background-color : #FCFCFC;
-            border : none;
-            width : 100%;
-            height : 50px;
-            }
-            select {
-            color : #828282;
-            }
-            .form-control {
-            background-color : #FCFCFC;
-            border : none;
-            width : 100%;
-            height : 50px;
-            }
-
-
-            .form-control::placeholder {
-            color : #BBBBBB;
-            }
-
-            .date-container {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        background-color: #8E4B6E;
-        color: white;
-        border-radius: 10px;
-        text-align:center;
-        font-family: "Work Sans", sans-serif;
-    }
-
-    .month {
-        font-size: 1.1rem; /* M의 크기를 설정 */
-        font-weight: 550;
-        line-height: 1;
-    }
-
-    .year {
-        font-size: 0.65rem; /* yyyy의 크기를 설정 */
-        font-weight: 400;
-    }
-    :root {
-        --background-color-light: #FFFFFF;
-        --text-color-light: #000000;
-        --toggle-background-light: #CCCCCC;
-        --toggle-ball-light: #FFFFFF;
-
-        --background-color-dark: #333333;
-        --text-color-dark: #FFFFFF;
-        --toggle-background-dark: #03C75A;
-        --toggle-ball-dark: #FFFFFF;
-
-        --font-size-base: 32px; /* 기본 텍스트 크기 */
-        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
-    }
-
-
-
-    .toggle-switch {
-        position: relative;
-        display: inline-block;
-        width: 62px; /* 너비 조정 */
-        height: 38px; /* 높이 조정 */
-    }
-
-    .toggle-switch .checkbox {
-        opacity: 0;
-        width: 0;
-        height: 0;
-    }
-    #isToggledCheckbox {
-         opacity: 0;
-            width: 0;
-            height: 0;
-    }
-
-    .toggle-switch .label {
-        position: absolute;
-        cursor: pointer;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background-color: var(--toggle-background-light);
-        transition: background-color 0.4s;
-        border-radius: 38px; /* 둥근 모서리 반경 조정 */
-    }
-
-    .toggle-switch .label:before {
-        position: absolute;
-        content: "";
-        height: 30px; /* 내부 원 높이 조정 */
-        width: 30px; /* 내부 원 너비 조정 */
-        left: 2px;
-        bottom: 0px;
-        background-color: var(--toggle-ball-light);
-        transition: transform 0.4s;
-        border-radius: 50%;
-    }
-
-    .toggle-switch input:checked + .label {
-        background-color: var(--toggle-background-dark);
-    }
-
-    .toggle-switch input:checked + .label:before {
-        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
-    }
-
-             #absdiv {
-                position: relative;
-                top: 60px; /* Move down by 20px from its current position */
-                z-index : 1000;
-            }
-
-            #searchbutton {
-                background-color: #828282;
-            }
-
-            .card-img-top {
-                    width: 100%;
-                    height: 100px;
-                    object-fit: cover;
+            </aside>
+            <style>
+                .form-select {
+                background-color : #FCFCFC;
+                border : none;
+                width : 100%;
+                height : 50px;
+                }
+                select {
+                color : #828282;
+                }
+                .form-control {
+                background-color : #FCFCFC;
+                border : none;
+                width : 100%;
+                height : 50px;
                 }
 
-        </style>
-        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
-              rel="stylesheet">
-        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
-              rel="stylesheet">
 
-        <div class="col-md-9">
-            <div class="row" style="color: #828282;">
-                <div class="col-11">
-                    <div class="row mb-4">
-                        <div class="col-12 p-0">
-                            <style>
-                                .col-4 select {
-                                    border-radius: 50px;
-                                    text-align: center;
-                                }
-                                /* 검색창 스타일 */
-                                .search-container {
-                                    width: 300px;
-                                }
+                .form-control::placeholder {
+                color : #BBBBBB;
+                }
 
-                                .search-container select {
-                                    position: absolute;
-                                    left: 0%;
-                                    width: 30%;
-                                    height: 50px;
-                                    color: #828282;
-                                    font-size: 1rem;
-                                    border-radius: 50px 0 0 50px;
-                                    outline: none;
-                                }
-                                .search-container input[type="text"] {
-                                    position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
-                                    left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
-                                    width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
-                                    height: 50px;
-                                    padding: 10px 40px 10px 15px;
-                                    font-size: 1rem;
-                                    outline: none;
-                                    border-radius: 0 50px 50px 0;
-                                    transition: border-color 0.3s, background-color 0.3s;
-                                    color: #828282; /* 입력 텍스트 색상 변경 */
-                                }
+                .date-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            background-color: #8E4B6E;
+            color: white;
+            border-radius: 10px;
+            text-align:center;
+            font-family: "Work Sans", sans-serif;
+        }
 
-                                .search-container input[type="text"]::placeholder {
-                                    color: #BBBBBB; /* placeholder 색상 변경 */
-                                }
+        .month {
+            font-size: 1.1rem; /* M의 크기를 설정 */
+            font-weight: 550;
+            line-height: 1;
+        }
+
+        .year {
+            font-size: 0.65rem; /* yyyy의 크기를 설정 */
+            font-weight: 400;
+        }
+        :root {
+            --background-color-light: #FFFFFF;
+            --text-color-light: #000000;
+            --toggle-background-light: #CCCCCC;
+            --toggle-ball-light: #FFFFFF;
+
+            --background-color-dark: #333333;
+            --text-color-dark: #FFFFFF;
+            --toggle-background-dark: #03C75A;
+            --toggle-ball-dark: #FFFFFF;
+
+            --font-size-base: 32px; /* 기본 텍스트 크기 */
+            --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+        }
 
 
-                                .search-container button {
-                                    position: absolute;
-                                    right: 1rem;
-                                    top: 25px;
-                                    background: none;
-                                    transform: translateY(-50%);
-                                    border: none;
-                                    cursor: pointer;
-                                }
 
-                                .search-container button i {
-                                    color: #A6AAB5;
-                                }
+        .toggle-switch {
+            position: relative;
+            display: inline-block;
+            width: 62px; /* 너비 조정 */
+            height: 38px; /* 높이 조정 */
+        }
 
-                                .search-container button:hover i {
-                                    color: #03C75A;
-                                }
-                            </style>
-                            <form id="sort-form" th:action="@{/user/my/in/journal}" method="get">
-                                <div class="row m-0">
-                                    <div class="col-7 p-0">
-                                        <div class="row justify-content-start m-0">
-                                            <div class="col-12 p-0">
-                                                <div class="search-container">
-                                                    <select class="form-select px-3" name="searchBy">
-                                                        <option value="title" th:selected="${searchBy == 'title'}">제목
-                                                        </option>
-                                                        <option value="content" th:selected="${searchBy == 'content'}">
-                                                            내용
-                                                        </option>
-                                                    </select>
-                                                    <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
-                                                    <!-- 검색 버튼 -->
-                                                    <button type="submit">
-                                                        <i class="fas fa-search"></i>
-                                                    </button>
+        .toggle-switch .checkbox {
+            opacity: 0;
+            width: 0;
+            height: 0;
+        }
+        #isToggledCheckbox {
+             opacity: 0;
+                width: 0;
+                height: 0;
+        }
+
+        .toggle-switch .label {
+            position: absolute;
+            cursor: pointer;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: var(--toggle-background-light);
+            transition: background-color 0.4s;
+            border-radius: 38px; /* 둥근 모서리 반경 조정 */
+        }
+
+        .toggle-switch .label:before {
+            position: absolute;
+            content: "";
+            height: 30px; /* 내부 원 높이 조정 */
+            width: 30px; /* 내부 원 너비 조정 */
+            left: 2px;
+            bottom: 0px;
+            background-color: var(--toggle-ball-light);
+            transition: transform 0.4s;
+            border-radius: 50%;
+        }
+
+        .toggle-switch input:checked + .label {
+            background-color: var(--toggle-background-dark);
+        }
+
+        .toggle-switch input:checked + .label:before {
+            transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+        }
+
+                 #absdiv {
+                    position: relative;
+                    top: 60px; /* Move down by 20px from its current position */
+                    z-index : 1000;
+                }
+
+                #searchbutton {
+                    background-color: #828282;
+                }
+
+                .card-img-top {
+                        width: 100%;
+                        height: 100px;
+                        object-fit: cover;
+                    }
+
+            </style>
+            <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+                  rel="stylesheet">
+            <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+                  rel="stylesheet">
+
+            <div class="col-md-9">
+                <div class="row" style="color: #828282;">
+                    <div class="col-11">
+                        <div class="row mb-4">
+                            <div class="col-12 p-0">
+                                <style>
+                                    .col-4 select {
+                                        border-radius: 50px;
+                                        text-align: center;
+                                    }
+                                    /* 검색창 스타일 */
+                                    .search-container {
+                                        width: 300px;
+                                    }
+
+                                    .search-container select {
+                                        position: absolute;
+                                        left: 0%;
+                                        width: 30%;
+                                        height: 50px;
+                                        color: #828282;
+                                        font-size: 1rem;
+                                        border-radius: 50px 0 0 50px;
+                                        outline: none;
+                                    }
+                                    .search-container input[type="text"] {
+                                        position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
+                                        left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
+                                        width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
+                                        height: 50px;
+                                        padding: 10px 40px 10px 15px;
+                                        font-size: 1rem;
+                                        outline: none;
+                                        border-radius: 0 50px 50px 0;
+                                        transition: border-color 0.3s, background-color 0.3s;
+                                        color: #828282; /* 입력 텍스트 색상 변경 */
+                                    }
+
+                                    .search-container input[type="text"]::placeholder {
+                                        color: #BBBBBB; /* placeholder 색상 변경 */
+                                    }
+
+
+                                    .search-container button {
+                                        position: absolute;
+                                        right: 1rem;
+                                        top: 25px;
+                                        background: none;
+                                        transform: translateY(-50%);
+                                        border: none;
+                                        cursor: pointer;
+                                    }
+
+                                    .search-container button i {
+                                        color: #A6AAB5;
+                                    }
+
+                                    .search-container button:hover i {
+                                        color: #03C75A;
+                                    }
+                                </style>
+                                <form id="sort-form" th:action="@{/user/my/in/journal}" method="get">
+                                    <div class="row m-0">
+                                        <div class="col-7 p-0">
+                                            <div class="row justify-content-start m-0">
+                                                <div class="col-12 p-0">
+                                                    <div class="search-container">
+                                                        <select class="form-select px-3" name="searchBy">
+                                                            <option value="title" th:selected="${searchBy == 'title'}">
+                                                                제목
+                                                            </option>
+                                                            <option value="content"
+                                                                    th:selected="${searchBy == 'content'}">
+                                                                내용
+                                                            </option>
+                                                        </select>
+                                                        <input class="form-control px-3" type="text" name="searchTerm"
+                                                               placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
+                                                        <!-- 검색 버튼 -->
+                                                        <button type="submit">
+                                                            <i class="fas fa-search"></i>
+                                                        </button>
+                                                    </div>
                                                 </div>
                                             </div>
                                         </div>
-                                    </div>
-                                    <div class="col-1" style=""></div>
-                                    <div class="col-4">
-                                        <div class="row justify-content-end">
-                                            <!-- 정렬 또는 토글2 -->
-                                            <label>
-                                                <select class="form-select px-3" name="orderBy"
-                                                        onchange="this.form.submit()">
-                                                    <option value="recentliked"
-                                                            th:selected="${orderBy == 'recentliked'}">최근좋아요순
-                                                    </option>
-                                                    <option value="oldestliked"
-                                                            th:selected="${orderBy == 'oldestliked'}">오래된순
-                                                    </option>
+                                        <div class="col-1" style=""></div>
+                                        <div class="col-4">
+                                            <div class="row justify-content-end">
+                                                <!-- 정렬 또는 토글2 -->
+                                                <label>
+                                                    <select class="form-select px-3" name="orderBy"
+                                                            onchange="this.form.submit()">
+                                                        <option value="recentliked"
+                                                                th:selected="${orderBy == 'recentliked'}">최근좋아요순
+                                                        </option>
+                                                        <option value="oldestliked"
+                                                                th:selected="${orderBy == 'oldestliked'}">오래된순
+                                                        </option>
 
-                                                    <option value="recent" th:selected="${orderBy == 'recent'}">최신소식순
-                                                    </option>
-                                                    <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된소식순
-                                                    </option>
+                                                        <option value="recent" th:selected="${orderBy == 'recent'}">
+                                                            최신소식순
+                                                        </option>
+                                                        <option value="oldest" th:selected="${orderBy == 'oldest'}">
+                                                            오래된소식순
+                                                        </option>
 
-                                                    <option value="title" th:selected="${orderBy == 'title'}">제목가나다순
-                                                    </option>
-                                                </select>
-                                            </label>
-                                        </div>
-                                    </div>
-                                </div> <!--검색, 소팅 (토글X)-->
-                                <div class="row justify-content-around">
-                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                    <div class="col-3" style="padding: 0 1.2rem;">
-                                        <div id="absdiv" class="row justify-content-end">
-                                            <!--                                        <div class="col-3">-->
-                                            <!--                                            <div class="toggle-switch">-->
-                                            <!--                                                &lt;!&ndash; 정렬 또는 토글1 &ndash;&gt;-->
-                                            <!--                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">-->
-                                            <!--                                                <label for="isToggledCheckbox" class="label">-->
-                                            <!--                                                    <div class="ball"></div>-->
-                                            <!--                                                </label>-->
-                                            <!--                                            </div>-->
-                                            <!--                                        </div>-->
-                                            <!--                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">진행중인 행사</div>-->
-                                        </div>
-                                    </div>
-                                </div> <!--토글-->
-                            </form>
-                        </div>
-                    </div>
-                    <div class="row justify-content-around mt-4">
-                        <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
-                            <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
-                                <div class="col-3 clickable-row"
-                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
-                                     th:each="myInJournal, iterStat : ${myInJournals}"
-                                     th:attr="data-href=@{/introduction/journal/journalDetail(journalNo=${myInJournal.journalNo})}"
-                                     th:if="${iterStat.index < 3}">
-                                    <div class="row justify-content-center">
-                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
-                                             style="aspect-ratio: 1; border-radius: 5px;">
-                                            <div class="date-container px-2 py-1">
-                                                <div class="month"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myInJournal.postingDate)}"></div>
-                                                <div class="year"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myInJournal.postingDate)}"></div>
+                                                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순
+                                                        </option>
+                                                    </select>
+                                                </label>
                                             </div>
                                         </div>
-                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                        <!--                                    </div>-->
-                                        <div class="col-5" style="color: white; font-size: 0.8rem; font-weight: 530;"
-                                             th:text="${myInJournal.journalNo}">닉네임
-                                        </div>
-
-                                        <div class="col-3"
-                                             style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
-                                             th:text="${myInJournal.formattedPostingDate}">시간
-                                        </div>
-                                    </div>
-                                    <div class="row justify-content-center">
-                                        <div class="col-12 my-3" style="">
-                                            <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                            <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                            <!-- 썸네일 이미지 있을때  -->
-                                            <img th:if="${#lists.size(myInJournal.journalFiles) > 0}"
-                                                 th:src="@{/uploadFiles/{fileName}(fileName=${myInJournal.journalFiles.get(0).fileName})}"
-                                                 class="card-img-top" alt="썸네일 이미지">
-                                        </div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
-                                             th:text="${myInJournal.title}">이름
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
-                                             th:text="${myInJournal.content}">내용
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                    </div>
-
-                                </div>
-                                <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
-                                <div class="col-3" th:if="${myInJournals.size() == 0}"></div>
-                                <div class="col-3"
-                                     th:if="${myInJournals.size() == 0 || myInJournals.size() == 1}"></div>
-                                <div class="col-3"
-                                     th:if="${myInJournals.size() == 0 || myInJournals.size() == 1 || myInJournals.size() == 2}"></div>
-                            </div>
-                            <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
-                                <div class="col-3 clickable-row"
-                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
-                                     th:each="myInJournal, iterStat : ${myInJournals}"
-                                     th:attr="data-href=@{/introduction/journal/journalDetail(journalNo=${myInJournal.journalNo})}"
-                                     th:if="${iterStat.index >= 3}">
-                                    <div class="row justify-content-center">
-                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
-                                             style="aspect-ratio: 1; border-radius: 5px;">
-                                            <div class="date-container px-2 py-1">
-                                                <div class="month"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myInJournal.postingDate)}"></div>
-                                                <div class="year"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myInJournal.postingDate)}"></div>
+                                    </div> <!--검색, 소팅 (토글X)-->
+                                    <div class="row justify-content-around">
+                                        <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                        <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                        <div class="col-3" style="padding: 0 1.2rem;">
+                                            <div id="absdiv" class="row justify-content-end">
+                                                <!--                                        <div class="col-3">-->
+                                                <!--                                            <div class="toggle-switch">-->
+                                                <!--                                                &lt;!&ndash; 정렬 또는 토글1 &ndash;&gt;-->
+                                                <!--                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">-->
+                                                <!--                                                <label for="isToggledCheckbox" class="label">-->
+                                                <!--                                                    <div class="ball"></div>-->
+                                                <!--                                                </label>-->
+                                                <!--                                            </div>-->
+                                                <!--                                        </div>-->
+                                                <!--                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">진행중인 행사</div>-->
                                             </div>
                                         </div>
-                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                        <!--                                    </div>-->
-                                        <div class="col-5" style="color: white; font-size: 0.8rem; font-weight: 530;"
-                                             th:text="${myInJournal.journalNo}">닉네임
-                                        </div>
-
-                                        <div class="col-3"
-                                             style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
-                                             th:text="${myInJournal.formattedPostingDate}">시간
-                                        </div>
-                                    </div>
-                                    <div class="row justify-content-center">
-                                        <div class="col-12 my-3" style="">
-                                            <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                            <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                            <!-- 썸네일 이미지 있을때  -->
-                                            <img th:if="${#lists.size(myInJournal.journalFiles) > 0}"
-                                                 th:src="@{/uploadFiles/{fileName}(fileName=${myInJournal.journalFiles.get(0).fileName})}"
-                                                 class="card-img-top" alt="썸네일 이미지">
-                                        </div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
-                                             th:text="${myInJournal.title}">이름
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
-                                             th:text="${myInJournal.content}">내용
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                    </div>
-
-                                </div>
-
-                                <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
-                                <div class="col-3" th:if="${myInJournals.size() <= 3}"></div>
-                                <div class="col-3"
-                                     th:if="${myInJournals.size() <= 3 || myInJournals.size() == 4}"></div>
-                                <div class="col-3"
-                                     th:if="${myInJournals.size() <= 3 || myInJournals.size() == 4 || myInJournals.size() == 5}"></div>
+                                    </div> <!--토글-->
+                                </form>
                             </div>
                         </div>
-                    </div>
-                    <div class="row justify-content-center">
-                        <!-- 페이징 -->
-                        <th:block th:if="${pages != null}">
-                            <div class="d-flex justify-content-center">
-                                <div class="btn-group">
-                                    <button type="button" class="btn btn-sm previous"
-                                            th:onclick="|location.href='@{/user/my/in/journal(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
-                                            th:disabled="${currentPage == 1}">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                             fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-                                            <path fill-rule="evenodd"
-                                                  d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                                        </svg>
-                                    </button>
-                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">
-                                        <button type="button" class="btn btn-sm me-2 pages"
-                                                th:text="${p}"
-                                                th:onclick="|location.href='@{/user/my/in/journal(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
-                                    </th:block>
-                                    <button type="button" class="btn btn-sm  next"
-                                            th:onclick="|location.href='@{/user/my/in/journal(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
-                                            th:disabled="${currentPage == pages}">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                             fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-                                            <path fill-rule="evenodd"
-                                                  d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
-                                        </svg>
-                                    </button>
+                        <div class="row justify-content-around mt-4">
+                            <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
+                                <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
+                                    <div class="col-3 clickable-row"
+                                         style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                         th:each="myInJournal, iterStat : ${myInJournals}"
+                                         th:attr="data-href=@{/introduction/journal/journalDetail(journalNo=${myInJournal.journalNo})}"
+                                         th:if="${iterStat.index < 3}">
+                                        <div class="row justify-content-center">
+                                            <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                                 style="aspect-ratio: 1; border-radius: 5px;">
+                                                <div class="date-container px-2 py-1">
+                                                    <div class="month"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myInJournal.postingDate)}"></div>
+                                                    <div class="year"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myInJournal.postingDate)}"></div>
+                                                </div>
+                                            </div>
+                                            <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                            <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                            <!--                                    </div>-->
+                                            <div class="col-5"
+                                                 style="color: white; font-size: 0.8rem; font-weight: 530;"
+                                                 th:text="${myInJournal.journalNo}">닉네임
+                                            </div>
+
+                                            <div class="col-3"
+                                                 style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
+                                                 th:text="${myInJournal.formattedPostingDate}">시간
+                                            </div>
+                                        </div>
+                                        <div class="row justify-content-center">
+                                            <div class="col-12 my-3" style="">
+                                                <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                                <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                                <!-- 썸네일 이미지 있을때  -->
+                                                <img th:if="${#lists.size(myInJournal.journalFiles) > 0}"
+                                                     th:src="@{/uploadFiles/{fileName}(fileName=${myInJournal.journalFiles.get(0).fileName})}"
+                                                     class="card-img-top" alt="썸네일 이미지">
+                                            </div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                                 th:text="${myInJournal.title}">이름
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                                 th:text="${myInJournal.content}">내용
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                        </div>
+
+                                    </div>
+                                    <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
+                                    <div class="col-3" th:if="${myInJournals.size() == 0}"></div>
+                                    <div class="col-3"
+                                         th:if="${myInJournals.size() == 0 || myInJournals.size() == 1}"></div>
+                                    <div class="col-3"
+                                         th:if="${myInJournals.size() == 0 || myInJournals.size() == 1 || myInJournals.size() == 2}"></div>
+                                </div>
+                                <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
+                                    <div class="col-3 clickable-row"
+                                         style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                         th:each="myInJournal, iterStat : ${myInJournals}"
+                                         th:attr="data-href=@{/introduction/journal/journalDetail(journalNo=${myInJournal.journalNo})}"
+                                         th:if="${iterStat.index >= 3}">
+                                        <div class="row justify-content-center">
+                                            <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                                 style="aspect-ratio: 1; border-radius: 5px;">
+                                                <div class="date-container px-2 py-1">
+                                                    <div class="month"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myInJournal.postingDate)}"></div>
+                                                    <div class="year"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myInJournal.postingDate)}"></div>
+                                                </div>
+                                            </div>
+                                            <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                            <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                            <!--                                    </div>-->
+                                            <div class="col-5"
+                                                 style="color: white; font-size: 0.8rem; font-weight: 530;"
+                                                 th:text="${myInJournal.journalNo}">닉네임
+                                            </div>
+
+                                            <div class="col-3"
+                                                 style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
+                                                 th:text="${myInJournal.formattedPostingDate}">시간
+                                            </div>
+                                        </div>
+                                        <div class="row justify-content-center">
+                                            <div class="col-12 my-3" style="">
+                                                <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                                <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                                <!-- 썸네일 이미지 있을때  -->
+                                                <img th:if="${#lists.size(myInJournal.journalFiles) > 0}"
+                                                     th:src="@{/uploadFiles/{fileName}(fileName=${myInJournal.journalFiles.get(0).fileName})}"
+                                                     class="card-img-top" alt="썸네일 이미지">
+                                            </div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                                 th:text="${myInJournal.title}">이름
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                                 th:text="${myInJournal.content}">내용
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                        </div>
+
+                                    </div>
+
+                                    <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
+                                    <div class="col-3" th:if="${myInJournals.size() <= 3}"></div>
+                                    <div class="col-3"
+                                         th:if="${myInJournals.size() <= 3 || myInJournals.size() == 4}"></div>
+                                    <div class="col-3"
+                                         th:if="${myInJournals.size() <= 3 || myInJournals.size() == 4 || myInJournals.size() == 5}"></div>
                                 </div>
                             </div>
-                        </th:block>
-                    </div>
-                </div><!--테이블 및 페이징 포함-->
+                        </div>
+                        <div class="row justify-content-center">
+                            <!-- 페이징 -->
+                            <th:block th:if="${pages != null}">
+                                <div class="d-flex justify-content-center">
+                                    <div class="btn-group">
+                                        <button type="button" class="btn btn-sm previous"
+                                                th:onclick="|location.href='@{/user/my/in/journal(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
+                                                th:disabled="${currentPage == 1}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                                 fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+                                                <path fill-rule="evenodd"
+                                                      d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                                            </svg>
+                                        </button>
+                                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">
+                                            <button type="button" class="btn btn-sm me-2 pages"
+                                                    th:text="${p}"
+                                                    th:onclick="|location.href='@{/user/my/in/journal(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
+                                        </th:block>
+                                        <button type="button" class="btn btn-sm  next"
+                                                th:onclick="|location.href='@{/user/my/in/journal(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
+                                                th:disabled="${currentPage == pages}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                                 fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+                                                <path fill-rule="evenodd"
+                                                      d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                                            </svg>
+                                        </button>
+                                    </div>
+                                </div>
+                            </th:block>
+                        </div>
+                    </div><!--테이블 및 페이징 포함-->
+                </div> <!--본화면-->
             </div> <!--본화면-->
-        </div> <!--본화면-->
 
 
-        <!--수정전-->
-        <!--    <div class="col-md-9">-->
-        <!--        <div class="review-list">-->
-        <!--            <h2>좋아요한 웹툰 소식</h2>-->
-        <!--            <form id="sort-form" th:action="@{/user/my/in/journal}" method="get">-->
-        <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
-        <!--                <label>-->
-        <!--                    <select name="searchBy">-->
-        <!--                        <option value="title" th:selected="${searchBy == 'title'}">제목</option>-->
-        <!--                        <option value="content" th:selected="${searchBy == 'content'}">내용</option>-->
-        <!--                    </select>-->
-        <!--                </label>-->
-        <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
+            <!--수정전-->
+            <!--    <div class="col-md-9">-->
+            <!--        <div class="review-list">-->
+            <!--            <h2>좋아요한 웹툰 소식</h2>-->
+            <!--            <form id="sort-form" th:action="@{/user/my/in/journal}" method="get">-->
+            <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
+            <!--                <label>-->
+            <!--                    <select name="searchBy">-->
+            <!--                        <option value="title" th:selected="${searchBy == 'title'}">제목</option>-->
+            <!--                        <option value="content" th:selected="${searchBy == 'content'}">내용</option>-->
+            <!--                    </select>-->
+            <!--                </label>-->
+            <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
 
-        <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
-        <!--                <button type="submit">검색</button>-->
+            <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
+            <!--                <button type="submit">검색</button>-->
 
-        <!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
-        <!--                <label>-->
-        <!--                    <select name="orderBy" onchange="this.form.submit()">-->
-        <!--                        <option value="recentliked" th:selected="${orderBy == 'recentliked'}">최근좋아요순</option>-->
-        <!--                        <option value="oldestliked" th:selected="${orderBy == 'oldestliked'}">오래된순</option>-->
+            <!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
+            <!--                <label>-->
+            <!--                    <select name="orderBy" onchange="this.form.submit()">-->
+            <!--                        <option value="recentliked" th:selected="${orderBy == 'recentliked'}">최근좋아요순</option>-->
+            <!--                        <option value="oldestliked" th:selected="${orderBy == 'oldestliked'}">오래된순</option>-->
 
-        <!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최신소식순</option>-->
-        <!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된소식순</option>-->
+            <!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최신소식순</option>-->
+            <!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된소식순</option>-->
 
-        <!--                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
-        <!--                    </select>-->
-        <!--                </label>-->
-        <!--            </form>-->
-        <!--            <table>-->
-        <!--                <thead>-->
-        <!--                <tr>-->
-        <!--                    <th>좋아요 번호</th>-->
-        <!--                    <th>회원번호</th>-->
-        <!--                    <th>좋아요 날짜</th>-->
-        <!--                    <th>소식 게시글 번호</th>-->
-        <!--                    <th>소식 제목</th>-->
-        <!--                    <th>소식 내용</th>-->
-        <!--                    <th>게시 일시</th>-->
+            <!--                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
+            <!--                    </select>-->
+            <!--                </label>-->
+            <!--            </form>-->
+            <!--            <table>-->
+            <!--                <thead>-->
+            <!--                <tr>-->
+            <!--                    <th>좋아요 번호</th>-->
+            <!--                    <th>회원번호</th>-->
+            <!--                    <th>좋아요 날짜</th>-->
+            <!--                    <th>소식 게시글 번호</th>-->
+            <!--                    <th>소식 제목</th>-->
+            <!--                    <th>소식 내용</th>-->
+            <!--                    <th>게시 일시</th>-->
 
-        <!--    &lt;!&ndash;                <th>ijl.liked_no</th>&ndash;&gt;-->
-        <!--    &lt;!&ndash;                <th>ijl.user_no</th>&ndash;&gt;-->
-        <!--    &lt;!&ndash;                <th>ijl.liked_date</th>&ndash;&gt;-->
-        <!--    &lt;!&ndash;                <th>ij.journal_no</th>&ndash;&gt;-->
-        <!--    &lt;!&ndash;                <th>ij.title</th>&ndash;&gt;-->
-        <!--    &lt;!&ndash;                <th>ij.content</th>&ndash;&gt;-->
-        <!--    &lt;!&ndash;                <th>ij.posting_date</th>&ndash;&gt;-->
+            <!--    &lt;!&ndash;                <th>ijl.liked_no</th>&ndash;&gt;-->
+            <!--    &lt;!&ndash;                <th>ijl.user_no</th>&ndash;&gt;-->
+            <!--    &lt;!&ndash;                <th>ijl.liked_date</th>&ndash;&gt;-->
+            <!--    &lt;!&ndash;                <th>ij.journal_no</th>&ndash;&gt;-->
+            <!--    &lt;!&ndash;                <th>ij.title</th>&ndash;&gt;-->
+            <!--    &lt;!&ndash;                <th>ij.content</th>&ndash;&gt;-->
+            <!--    &lt;!&ndash;                <th>ij.posting_date</th>&ndash;&gt;-->
 
-        <!--                </tr>-->
-        <!--                </thead>-->
-        <!--                <tbody>-->
-        <!--                <tr th:each="myInJournal : ${myInJournals}" class="clickable-row" th:attr="data-href=@{/introduction/journal/journalDetail(journalNo=${myInJournal.journalNo})}">-->
-        <!--                    <td th:text="${myInJournal.likedNo}">좋아요 번호</td>-->
-        <!--                    <td th:text="${myInJournal.userNo}">회원번호</td>-->
-        <!--                    <td th:text="${myInJournal.likedDate}">좋아요 날짜</td>-->
-        <!--                    <td th:text="${myInJournal.journalNo}">소식 게시글 번호</td>-->
-        <!--                    <td th:text="${myInJournal.title}">소식 제목</td>-->
-        <!--                    <td th:text="${myInJournal.content}">소식 내용</td>-->
-        <!--                    <td th:text="${myInJournal.postingDate}">게시 일시</td>-->
-        <!--                </tr>-->
-        <!--                </tbody>-->
-        <!--            </table>-->
-        <!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
-        <!--            <th:block th:if="${pages != null}">-->
-        <!--                <div class="d-flex justify-content-center">-->
-        <!--                    <div class="btn-group">-->
-        <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/in/journal(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
-        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
-        <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
-        <!--                            </svg>-->
-        <!--                        </button>-->
-        <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
-        <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
-        <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/in/journal(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
-        <!--                        </th:block>-->
-        <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/in/journal(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
-        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
-        <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
-        <!--                            </svg>-->
-        <!--                        </button>-->
-        <!--                    </div>-->
-        <!--                </div>-->
-        <!--            </th:block>-->
-        <!--        </div>-->
-        <!--    </div>-->
+            <!--                </tr>-->
+            <!--                </thead>-->
+            <!--                <tbody>-->
+            <!--                <tr th:each="myInJournal : ${myInJournals}" class="clickable-row" th:attr="data-href=@{/introduction/journal/journalDetail(journalNo=${myInJournal.journalNo})}">-->
+            <!--                    <td th:text="${myInJournal.likedNo}">좋아요 번호</td>-->
+            <!--                    <td th:text="${myInJournal.userNo}">회원번호</td>-->
+            <!--                    <td th:text="${myInJournal.likedDate}">좋아요 날짜</td>-->
+            <!--                    <td th:text="${myInJournal.journalNo}">소식 게시글 번호</td>-->
+            <!--                    <td th:text="${myInJournal.title}">소식 제목</td>-->
+            <!--                    <td th:text="${myInJournal.content}">소식 내용</td>-->
+            <!--                    <td th:text="${myInJournal.postingDate}">게시 일시</td>-->
+            <!--                </tr>-->
+            <!--                </tbody>-->
+            <!--            </table>-->
+            <!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
+            <!--            <th:block th:if="${pages != null}">-->
+            <!--                <div class="d-flex justify-content-center">-->
+            <!--                    <div class="btn-group">-->
+            <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/in/journal(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
+            <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
+            <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
+            <!--                            </svg>-->
+            <!--                        </button>-->
+            <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
+            <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
+            <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/in/journal(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
+            <!--                        </th:block>-->
+            <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/in/journal(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
+            <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
+            <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
+            <!--                            </svg>-->
+            <!--                        </button>-->
+            <!--                    </div>-->
+            <!--                </div>-->
+            <!--            </th:block>-->
+            <!--        </div>-->
+            <!--    </div>-->
+        </div>
     </div>
 </div>
 <div th:replace="common/footer.html"></div>

--- a/src/main/resources/templates/user/mypage_in_journal.html
+++ b/src/main/resources/templates/user/mypage_in_journal.html
@@ -131,7 +131,7 @@
     <div class="row">
         <aside class="col-md-3 px-4">
             <div class="row">
-                <div class="col-3"></div>
+                <div class="col-1"></div>
                 <div class="col-6">
                     <div class="panel">
                         <ul class="list-group">

--- a/src/main/resources/templates/user/mypage_in_merchan.html
+++ b/src/main/resources/templates/user/mypage_in_merchan.html
@@ -104,18 +104,21 @@
   }
 </style>
 <div class="jumbotron">
-    <div class="row">
-        <div class="col-md-3 px-4">
-            <h3>나의 소식</h3>
-        </div>
-        <div class="col-md-9">
-            <nav class="navbar navbar-expand-md">
-                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                    <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>
-                    <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>
-                    <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2" style="color: #000;">좋아요한 굿즈</a></li>
-                </ul>
-            </nav>
+    <div class="container">
+        <div class="row">
+            <div class="col-md-3 px-4">
+                <h3>나의 소식</h3>
+            </div>
+            <div class="col-md-9">
+                <nav class="navbar navbar-expand-md">
+                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                        <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>
+                        <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>
+                        <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2" style="color: #000;">좋아요한 굿즈</a>
+                        </li>
+                    </ul>
+                </nav>
+            </div>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/user/mypage_in_merchan.html
+++ b/src/main/resources/templates/user/mypage_in_merchan.html
@@ -106,18 +106,23 @@
 <div class="jumbotron">
     <div class="container">
         <div class="row">
-            <div class="col-md-3 px-4">
-                <h3>나의 소식</h3>
-            </div>
-            <div class="col-md-9">
-                <nav class="navbar navbar-expand-md">
-                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                        <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>
-                        <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>
-                        <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2" style="color: #000;">좋아요한 굿즈</a>
-                        </li>
-                    </ul>
-                </nav>
+            <div class="col-9">
+                <div class="row">
+                    <div class="col-md-3 px-4">
+                        <h3>나의 소식</h3>
+                    </div>
+                    <div class="col-md-9">
+                        <nav class="navbar navbar-expand-md">
+                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>
+                                <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>
+                                <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2" style="color: #000;">좋아요한
+                                    굿즈</a>
+                                </li>
+                            </ul>
+                        </nav>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/user/mypage_in_merchan.html
+++ b/src/main/resources/templates/user/mypage_in_merchan.html
@@ -298,14 +298,69 @@
             <div class="row" style="color: #828282;">
                 <div class="col-11">
                     <div class="row">
-                        <div class="col-12">
+                        <div class="col-12 p-0">
+                            <style>
+                                .col-4 select {
+                                    border-radius: 50px;
+                                    text-align: center;
+                                }
+                                /* 검색창 스타일 */
+                                .search-container {
+                                    width: 300px;
+                                }
+
+                                .search-container select {
+                                    position: absolute;
+                                    left: 0%;
+                                    width: 30%;
+                                    height: 50px;
+                                    color: #828282;
+                                    font-size: 1rem;
+                                    border-radius: 50px 0 0 50px;
+                                    outline: none;
+                                }
+                                .search-container input[type="text"] {
+                                    position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
+                                    left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
+                                    width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
+                                    height: 50px;
+                                    padding: 10px 40px 10px 15px;
+                                    font-size: 1rem;
+                                    outline: none;
+                                    border-radius: 0 50px 50px 0;
+                                    transition: border-color 0.3s, background-color 0.3s;
+                                    color: #828282; /* 입력 텍스트 색상 변경 */
+                                }
+
+                                .search-container input[type="text"]::placeholder {
+                                    color: #BBBBBB; /* placeholder 색상 변경 */
+                                }
+
+
+                                .search-container button {
+                                    position: absolute;
+                                    right: 1rem;
+                                    top: 25px;
+                                    background: none;
+                                    transform: translateY(-50%);
+                                    border: none;
+                                    cursor: pointer;
+                                }
+
+                                .search-container button i {
+                                    color: #666;
+                                }
+
+                                .search-container button:hover i {
+                                    color: #03C75A;
+                                }
+                            </style>
                             <form id="filter-and-sort-form" th:action="@{/user/my/in/merchan}" method="get">
-                                <div class="row">
-                                    <div class="col-7">
+                                <div class="row m-0">
+                                    <div class="col-7 p-0">
                                         <div class="row justify-content-start m-0">
-                                            <div class="col-4">
-                                                <!-- 검색 조건 -->
-                                                <label>
+                                            <div class="col-12 p-0">
+                                                <div class="search-container">
                                                     <select class="form-select px-3" name="searchBy">
                                                         <option value="title" th:selected="${searchBy == 'title'}">
                                                             상품제목
@@ -316,16 +371,12 @@
                                                             상품내용
                                                         </option>
                                                     </select>
-                                                </label>
-                                            </div>
-                                            <div class="col-6">
-                                                <input class="form-control px-3" type="text" name="searchTerm"
-                                                       placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
-                                            </div>
-                                            <div class="col-2">
-                                                <!-- 검색 버튼 -->
-                                                <button id="searchbutton" type="submit" class="btn btn-primary">검색
-                                                </button>
+                                                    <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
+                                                    <!-- 검색 버튼 -->
+                                                    <button type="submit">
+                                                        <i class="fas fa-search"></i>
+                                                    </button>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>

--- a/src/main/resources/templates/user/mypage_in_merchan.html
+++ b/src/main/resources/templates/user/mypage_in_merchan.html
@@ -132,7 +132,7 @@
         <aside class="col-md-3 px-4">
             <div class="row">
                 <div class="col-1"></div>
-                <div class="col-6">
+                <div class="col-8">
                     <div class="panel">
                         <ul class="list-group">
                             <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>

--- a/src/main/resources/templates/user/mypage_in_merchan.html
+++ b/src/main/resources/templates/user/mypage_in_merchan.html
@@ -122,25 +122,27 @@
         </div>
     </div>
 </div>
-<div class="row">
-    <aside class="col-md-3 px-4">
-        <div class="row">
-            <div class="col-3"></div>
-            <div class="col-6">
-                <div class="panel">
-                    <ul class="list-group">
-                        <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
-                        <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-                        <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
-                        <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2" style="color: #03C75A;">나의 소식</a></li>
-                        <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                        <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-                    </ul>
+<div class="container" style="padding:0;">
+    <div class="row">
+        <aside class="col-md-3 px-4">
+            <div class="row">
+                <div class="col-3"></div>
+                <div class="col-6">
+                    <div class="panel">
+                        <ul class="list-group">
+                            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
+                            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
+                            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2" style="color: #03C75A;">나의
+                                소식</a></li>
+                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+                        </ul>
+                    </div>
                 </div>
             </div>
-        </div>
-    </aside>
-    <script> // toggle + sorting
+        </aside>
+        <script> // toggle + sorting
         function updateCheckboxValueAndSubmit() {
             const checkbox = document.getElementById('isToggledCheckbox');
             const form = document.getElementById('filter-and-sort-form');
@@ -153,414 +155,487 @@
         function submitForm() {
             document.getElementById('filter-and-sort-form').submit();
         }
-    </script>
-    <style>
-        .form-select {
-        background-color : #FCFCFC;
-        border : none;
-        width : 100%;
-        height : 50px;
-        }
-        select {
-        color : #828282;
-        }
-        .form-control {
-        background-color : #FCFCFC;
-        border : none;
-        width : 100%;
-        height : 50px;
-        }
-
-
-        .form-control::placeholder {
-        color : #BBBBBB;
-        }
-
-        .date-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    background-color: #8E4B6E;
-    color: white;
-    border-radius: 10px;
-    text-align:center;
-    font-family: "Work Sans", sans-serif;
-}
-
-.month {
-    font-size: 1.1rem; /* M의 크기를 설정 */
-    font-weight: 550;
-    line-height: 1;
-}
-
-.year {
-    font-size: 0.65rem; /* yyyy의 크기를 설정 */
-    font-weight: 400;
-}
-:root {
-    --background-color-light: #FFFFFF;
-    --text-color-light: #000000;
-    --toggle-background-light: #CCCCCC;
-    --toggle-ball-light: #FFFFFF;
-
-    --background-color-dark: #333333;
-    --text-color-dark: #FFFFFF;
-    --toggle-background-dark: #03C75A;
-    --toggle-ball-dark: #FFFFFF;
-
-    --font-size-base: 32px; /* 기본 텍스트 크기 */
-    --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
-}
-
-
-
-.toggle-switch {
-    position: relative;
-    display: inline-block;
-    width: 62px; /* 너비 조정 */
-    height: 38px; /* 높이 조정 */
-}
-
-.toggle-switch .checkbox {
-    opacity: 0;
-    width: 0;
-    height: 0;
-}
-#isToggledCheckbox {
-     opacity: 0;
-        width: 0;
-        height: 0;
-}
-
-.toggle-switch .label {
-    position: absolute;
-    cursor: pointer;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: var(--toggle-background-light);
-    transition: background-color 0.4s;
-    border-radius: 38px; /* 둥근 모서리 반경 조정 */
-}
-
-.toggle-switch .label:before {
-    position: absolute;
-    content: "";
-    height: 30px; /* 내부 원 높이 조정 */
-    width: 30px; /* 내부 원 너비 조정 */
-    left: 2px;
-    bottom: 0px;
-    background-color: var(--toggle-ball-light);
-    transition: transform 0.4s;
-    border-radius: 50%;
-}
-
-.toggle-switch input:checked + .label {
-    background-color: var(--toggle-background-dark);
-}
-
-.toggle-switch input:checked + .label:before {
-    transform: translateX(28px); /* 내부 원 이동 거리 조정 */
-}
-
-         #absdiv {
-            position: relative;
-            top: 60px; /* Move down by 20px from its current position */
-            z-index : 1000;
-        }
-
-        #searchbutton {
-            background-color: #828282;
-        }
-
-        .card-img-top {
-                width: 100%;
-                height: 100px;
-                object-fit: cover;
+        </script>
+        <style>
+            .form-select {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
+            }
+            select {
+            color : #828282;
+            }
+            .form-control {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
             }
 
-    </style>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
 
-    <div class="col-md-9">
-        <div class="row" style="color: #828282;">
-            <div class="col-11">
-                <div class="row">
-                    <div class="col-12">
-                        <form id="filter-and-sort-form" th:action="@{/user/my/in/merchan}" method="get">
-                            <div class="row">
-                                <div class="col-7">
-                                    <div class="row justify-content-start m-0">
-                                        <div class="col-4">
-                                            <!-- 검색 조건 -->
+            .form-control::placeholder {
+            color : #BBBBBB;
+            }
+
+            .date-container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        background-color: #8E4B6E;
+        color: white;
+        border-radius: 10px;
+        text-align:center;
+        font-family: "Work Sans", sans-serif;
+    }
+
+    .month {
+        font-size: 1.1rem; /* M의 크기를 설정 */
+        font-weight: 550;
+        line-height: 1;
+    }
+
+    .year {
+        font-size: 0.65rem; /* yyyy의 크기를 설정 */
+        font-weight: 400;
+    }
+    :root {
+        --background-color-light: #FFFFFF;
+        --text-color-light: #000000;
+        --toggle-background-light: #CCCCCC;
+        --toggle-ball-light: #FFFFFF;
+
+        --background-color-dark: #333333;
+        --text-color-dark: #FFFFFF;
+        --toggle-background-dark: #03C75A;
+        --toggle-ball-dark: #FFFFFF;
+
+        --font-size-base: 32px; /* 기본 텍스트 크기 */
+        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+    }
+
+
+
+    .toggle-switch {
+        position: relative;
+        display: inline-block;
+        width: 62px; /* 너비 조정 */
+        height: 38px; /* 높이 조정 */
+    }
+
+    .toggle-switch .checkbox {
+        opacity: 0;
+        width: 0;
+        height: 0;
+    }
+    #isToggledCheckbox {
+         opacity: 0;
+            width: 0;
+            height: 0;
+    }
+
+    .toggle-switch .label {
+        position: absolute;
+        cursor: pointer;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: var(--toggle-background-light);
+        transition: background-color 0.4s;
+        border-radius: 38px; /* 둥근 모서리 반경 조정 */
+    }
+
+    .toggle-switch .label:before {
+        position: absolute;
+        content: "";
+        height: 30px; /* 내부 원 높이 조정 */
+        width: 30px; /* 내부 원 너비 조정 */
+        left: 2px;
+        bottom: 0px;
+        background-color: var(--toggle-ball-light);
+        transition: transform 0.4s;
+        border-radius: 50%;
+    }
+
+    .toggle-switch input:checked + .label {
+        background-color: var(--toggle-background-dark);
+    }
+
+    .toggle-switch input:checked + .label:before {
+        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+    }
+
+             #absdiv {
+                position: relative;
+                top: 60px; /* Move down by 20px from its current position */
+                z-index : 1000;
+            }
+
+            #searchbutton {
+                background-color: #828282;
+            }
+
+            .card-img-top {
+                    width: 100%;
+                    height: 100px;
+                    object-fit: cover;
+                }
+
+        </style>
+        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+              rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+              rel="stylesheet">
+
+        <div class="col-md-9">
+            <div class="row" style="color: #828282;">
+                <div class="col-11">
+                    <div class="row">
+                        <div class="col-12">
+                            <form id="filter-and-sort-form" th:action="@{/user/my/in/merchan}" method="get">
+                                <div class="row">
+                                    <div class="col-7">
+                                        <div class="row justify-content-start m-0">
+                                            <div class="col-4">
+                                                <!-- 검색 조건 -->
+                                                <label>
+                                                    <select class="form-select px-3" name="searchBy">
+                                                        <option value="title" th:selected="${searchBy == 'title'}">
+                                                            상품제목
+                                                        </option>
+                                                        <option value="info" th:selected="${searchBy == 'info'}">상품정보
+                                                        </option>
+                                                        <option value="content" th:selected="${searchBy == 'content'}">
+                                                            상품내용
+                                                        </option>
+                                                    </select>
+                                                </label>
+                                            </div>
+                                            <div class="col-6">
+                                                <input class="form-control px-3" type="text" name="searchTerm"
+                                                       placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
+                                            </div>
+                                            <div class="col-2">
+                                                <!-- 검색 버튼 -->
+                                                <button id="searchbutton" type="submit" class="btn btn-primary">검색
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-1" style=""></div>
+                                    <div class="col-4">
+                                        <div class="row justify-content-end">
+                                            <!-- 정렬 또는 토글2 -->
                                             <label>
-                                                <select class="form-select px-3" name="searchBy">
-                                                    <option value="title" th:selected="${searchBy == 'title'}">상품제목</option>
-                                                    <option value="info" th:selected="${searchBy == 'info'}">상품정보</option>
-                                                    <option value="content" th:selected="${searchBy == 'content'}">상품내용</option>
+                                                <select class="form-select px-3" name="orderBy" onchange="submitForm()">
+                                                    <option value="recentliked"
+                                                            th:selected="${orderBy == 'recentliked'}">최근좋아요순
+                                                    </option>
+                                                    <option value="oldestliked"
+                                                            th:selected="${orderBy == 'oldestliked'}">오래된순
+                                                    </option>
+
+                                                    <option value="recent" th:selected="${orderBy == 'recent'}">최신상품순
+                                                    </option>
+                                                    <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된상품순
+                                                    </option>
+
+                                                    <option value="expensive" th:selected="${orderBy == 'expensive'}">
+                                                        금액높은순
+                                                    </option>
+                                                    <option value="cheap" th:selected="${orderBy == 'cheap'}">금액낮은순
+                                                    </option>
+
+                                                    <option value="title" th:selected="${orderBy == 'title'}">제목가나다순
+                                                    </option>
                                                 </select>
                                             </label>
                                         </div>
-                                        <div class="col-6">
-                                            <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
-                                        </div>
-                                        <div class="col-2">
-                                            <!-- 검색 버튼 -->
-                                            <button id="searchbutton" type="submit" class="btn btn-primary">검색</button>
-                                        </div>
                                     </div>
-                                </div>
-                                <div class="col-1" style=""></div>
-                                <div class="col-4">
-                                    <div class="row justify-content-end">
-                                        <!-- 정렬 또는 토글2 -->
-                                        <label>
-                                            <select class="form-select px-3" name="orderBy" onchange="submitForm()">
-                                                <option value="recentliked" th:selected="${orderBy == 'recentliked'}">최근좋아요순</option>
-                                                <option value="oldestliked" th:selected="${orderBy == 'oldestliked'}">오래된순</option>
-
-                                                <option value="recent" th:selected="${orderBy == 'recent'}">최신상품순</option>
-                                                <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된상품순</option>
-
-                                                <option value="expensive" th:selected="${orderBy == 'expensive'}">금액높은순</option>
-                                                <option value="cheap" th:selected="${orderBy == 'cheap'}">금액낮은순</option>
-
-                                                <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>
-                                            </select>
-                                        </label>
-                                    </div>
-                                </div>
-                            </div> <!--검색, 소팅 (토글X)-->
-                            <div class="row justify-content-around">
-                                <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                <div class="col-3" style="padding: 0 1.2rem;">
-                                    <div id="absdiv" class="row justify-content-end">
-                                        <div class="col-3">
-                                            <div class="toggle-switch">
-                                                <!-- 정렬 또는 토글1 -->
-                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">
-                                                <label for="isToggledCheckbox" class="label">
-                                                    <div class="ball"></div>
-                                                </label>
+                                </div> <!--검색, 소팅 (토글X)-->
+                                <div class="row justify-content-around">
+                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                    <div class="col-3" style="padding: 0 1.2rem;">
+                                        <div id="absdiv" class="row justify-content-end">
+                                            <div class="col-3">
+                                                <div class="toggle-switch">
+                                                    <!-- 정렬 또는 토글1 -->
+                                                    <input type="checkbox" name="isToggled" id="isToggledCheckbox"
+                                                           value="Y" th:checked="${isToggled == 'Y'}"
+                                                           onchange="updateCheckboxValueAndSubmit()">
+                                                    <label for="isToggledCheckbox" class="label">
+                                                        <div class="ball"></div>
+                                                    </label>
+                                                </div>
+                                            </div>
+                                            <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">
+                                                품절됨
                                             </div>
                                         </div>
-                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">품절됨</div>
                                     </div>
-                                </div>
-                            </div> <!--토글-->
-                        </form>
-                    </div>
-                </div>
-                <div class="row justify-content-around">
-                    <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
-                        <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
-                            <div class="col-3 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:each="myInMerchan, iterStat : ${myInMerchans}" th:attr="data-href=@{/introduction/merchanDetail(no=${myInMerchan.merchanNo})}" th:if="${iterStat.index < 3}">
-                                <div class="row justify-content-center">
-                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                        <div class="date-container px-2 py-1">
-                                            <div class="month" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myInMerchan.postingDate)}"></div>
-                                            <div class="year" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myInMerchan.postingDate)}"></div>
-                                        </div>
-                                    </div>
-                                    <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                    <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                    <!--                                    </div>-->
-                                    <div class="col-5" style="color: white; font-size: 0.8rem; font-weight: 530;"
-                                         th:text="myInMerchan.merchanNo">닉네임
-                                    </div>
-
-                                    <div class="col-3" style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;" th:text="${myInMerchan.formattedPostingDate}">시간</div>
-                                </div>
-                                <div class="row justify-content-center">
-                                    <div class="col-12 my-3" style="">
-                                        <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                        <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                        <!-- 썸네일 이미지 있을때  -->
-                                        <img th:if="${#lists.size(myInMerchan.merchanFiles) > 0}" th:src="@{/uploadFiles/{fileName}(fileName=${myInMerchan.merchanFiles.get(0).fileName})}" class="card-img-top" alt="썸네일 이미지">
-                                    </div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" th:text="${myInMerchan.title}">이름</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${myInMerchan.merchanInfo}">내용</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                </div>
-
-                            </div>
-                            <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
-                            <div class="col-3" th:if="${myInMerchans.size() == 0}"></div>
-                            <div class="col-3" th:if="${myInMerchans.size() == 0 || myInMerchans.size() == 1}"></div>
-                            <div class="col-3" th:if="${myInMerchans.size() == 0 || myInMerchans.size() == 1 || myInMerchans.size() == 2}"></div>
-                        </div>
-                        <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
-                            <div class="col-3 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:each="myInMerchan, iterStat : ${myInMerchans}" th:attr="data-href=@{/introduction/merchanDetail(no=${myInMerchan.merchanNo})}" th:if="${iterStat.index >= 3}">
-                                <div class="row justify-content-center">
-                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                        <div class="date-container px-2 py-1">
-                                            <div class="month" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myInMerchan.postingDate)}"></div>
-                                            <div class="year" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myInMerchan.postingDate)}"></div>
-                                        </div>
-                                    </div>
-                                    <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                    <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                    <!--                                    </div>-->
-                                    <div class="col-5" style="color: white; font-size: 0.8rem; font-weight: 530;"
-                                         th:text="myInMerchan.merchanNo">닉네임
-                                    </div>
-
-                                    <div class="col-3" style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;" th:text="${myInMerchan.formattedPostingDate}">시간</div>
-                                </div>
-                                <div class="row justify-content-center">
-                                    <div class="col-12 my-3" style="">
-                                        <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                        <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                        <!-- 썸네일 이미지 있을때  -->
-                                        <img th:if="${#lists.size(myInMerchan.merchanFiles) > 0}" th:src="@{/uploadFiles/{fileName}(fileName=${myInMerchan.merchanFiles.get(0).fileName})}" class="card-img-top" alt="썸네일 이미지">
-                                    </div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" th:text="${myInMerchan.title}">이름</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${myInMerchan.merchanInfo}">내용</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                </div>
-
-                            </div>
-
-                            <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
-                            <div class="col-3" th:if="${myInMerchans.size() <= 3}"></div>
-                            <div class="col-3" th:if="${myInMerchans.size() <= 3 || myInMerchans.size() == 4}"></div>
-                            <div class="col-3" th:if="${myInMerchans.size() <= 3 || myInMerchans.size() == 4 || myInMerchans.size() == 5}"></div>
+                                </div> <!--토글-->
+                            </form>
                         </div>
                     </div>
-                </div>
-                <div class="row justify-content-center">
-                    <!-- 페이징 -->
-                    <th:block th:if="${pages != null}">
-                        <div class="d-flex justify-content-center">
-                            <div class="btn-group">
-                                <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/in/merchan(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-                                        <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                                    </svg>
-                                </button>
-                                <th:block th:each="p : ${#numbers.sequence(1, pages)}">
-                                    <button type="button" class="btn btn-sm me-2 pages"
-                                            th:text="${p}" th:onclick="|location.href='@{/user/my/in/merchan(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
-                                </th:block>
-                                <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/in/merchan(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-                                        <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
-                                    </svg>
-                                </button>
+                    <div class="row justify-content-around">
+                        <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
+                            <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
+                                <div class="col-3 clickable-row"
+                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                     th:each="myInMerchan, iterStat : ${myInMerchans}"
+                                     th:attr="data-href=@{/introduction/merchanDetail(no=${myInMerchan.merchanNo})}"
+                                     th:if="${iterStat.index < 3}">
+                                    <div class="row justify-content-center">
+                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                             style="aspect-ratio: 1; border-radius: 5px;">
+                                            <div class="date-container px-2 py-1">
+                                                <div class="month"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myInMerchan.postingDate)}"></div>
+                                                <div class="year"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myInMerchan.postingDate)}"></div>
+                                            </div>
+                                        </div>
+                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                        <!--                                    </div>-->
+                                        <div class="col-5" style="color: white; font-size: 0.8rem; font-weight: 530;"
+                                             th:text="myInMerchan.merchanNo">닉네임
+                                        </div>
+
+                                        <div class="col-3"
+                                             style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
+                                             th:text="${myInMerchan.formattedPostingDate}">시간
+                                        </div>
+                                    </div>
+                                    <div class="row justify-content-center">
+                                        <div class="col-12 my-3" style="">
+                                            <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                            <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                            <!-- 썸네일 이미지 있을때  -->
+                                            <img th:if="${#lists.size(myInMerchan.merchanFiles) > 0}"
+                                                 th:src="@{/uploadFiles/{fileName}(fileName=${myInMerchan.merchanFiles.get(0).fileName})}"
+                                                 class="card-img-top" alt="썸네일 이미지">
+                                        </div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                             th:text="${myInMerchan.title}">이름
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                             th:text="${myInMerchan.merchanInfo}">내용
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                    </div>
+
+                                </div>
+                                <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
+                                <div class="col-3" th:if="${myInMerchans.size() == 0}"></div>
+                                <div class="col-3"
+                                     th:if="${myInMerchans.size() == 0 || myInMerchans.size() == 1}"></div>
+                                <div class="col-3"
+                                     th:if="${myInMerchans.size() == 0 || myInMerchans.size() == 1 || myInMerchans.size() == 2}"></div>
+                            </div>
+                            <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
+                                <div class="col-3 clickable-row"
+                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                     th:each="myInMerchan, iterStat : ${myInMerchans}"
+                                     th:attr="data-href=@{/introduction/merchanDetail(no=${myInMerchan.merchanNo})}"
+                                     th:if="${iterStat.index >= 3}">
+                                    <div class="row justify-content-center">
+                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                             style="aspect-ratio: 1; border-radius: 5px;">
+                                            <div class="date-container px-2 py-1">
+                                                <div class="month"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myInMerchan.postingDate)}"></div>
+                                                <div class="year"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myInMerchan.postingDate)}"></div>
+                                            </div>
+                                        </div>
+                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                        <!--                                    </div>-->
+                                        <div class="col-5" style="color: white; font-size: 0.8rem; font-weight: 530;"
+                                             th:text="myInMerchan.merchanNo">닉네임
+                                        </div>
+
+                                        <div class="col-3"
+                                             style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
+                                             th:text="${myInMerchan.formattedPostingDate}">시간
+                                        </div>
+                                    </div>
+                                    <div class="row justify-content-center">
+                                        <div class="col-12 my-3" style="">
+                                            <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                            <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                            <!-- 썸네일 이미지 있을때  -->
+                                            <img th:if="${#lists.size(myInMerchan.merchanFiles) > 0}"
+                                                 th:src="@{/uploadFiles/{fileName}(fileName=${myInMerchan.merchanFiles.get(0).fileName})}"
+                                                 class="card-img-top" alt="썸네일 이미지">
+                                        </div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                             th:text="${myInMerchan.title}">이름
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                             th:text="${myInMerchan.merchanInfo}">내용
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                    </div>
+
+                                </div>
+
+                                <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
+                                <div class="col-3" th:if="${myInMerchans.size() <= 3}"></div>
+                                <div class="col-3"
+                                     th:if="${myInMerchans.size() <= 3 || myInMerchans.size() == 4}"></div>
+                                <div class="col-3"
+                                     th:if="${myInMerchans.size() <= 3 || myInMerchans.size() == 4 || myInMerchans.size() == 5}"></div>
                             </div>
                         </div>
-                    </th:block>
-                </div>
-            </div><!--테이블 및 페이징 포함-->
+                    </div>
+                    <div class="row justify-content-center">
+                        <!-- 페이징 -->
+                        <th:block th:if="${pages != null}">
+                            <div class="d-flex justify-content-center">
+                                <div class="btn-group">
+                                    <button type="button" class="btn btn-sm previous"
+                                            th:onclick="|location.href='@{/user/my/in/merchan(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
+                                            th:disabled="${currentPage == 1}">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                             fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+                                            <path fill-rule="evenodd"
+                                                  d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                                        </svg>
+                                    </button>
+                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">
+                                        <button type="button" class="btn btn-sm me-2 pages"
+                                                th:text="${p}"
+                                                th:onclick="|location.href='@{/user/my/in/merchan(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
+                                    </th:block>
+                                    <button type="button" class="btn btn-sm  next"
+                                            th:onclick="|location.href='@{/user/my/in/merchan(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
+                                            th:disabled="${currentPage == pages}">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                             fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+                                            <path fill-rule="evenodd"
+                                                  d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                                        </svg>
+                                    </button>
+                                </div>
+                            </div>
+                        </th:block>
+                    </div>
+                </div><!--테이블 및 페이징 포함-->
+            </div> <!--본화면-->
         </div> <!--본화면-->
-    </div> <!--본화면-->
 
-    <!--수정전 -->
-<!--    <div class="col-md-9">-->
-<!--        <div class="review-list">-->
-<!--            <h2>좋아요한 굿즈</h2>-->
-<!--            <form id="filter-and-sort-form" th:action="@{/user/my/in/merchan}" method="get">-->
-<!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
-<!--                <label>-->
-<!--                    <select name="searchBy">-->
-<!--                        <option value="title" th:selected="${searchBy == 'title'}">상품제목</option>-->
-<!--                        <option value="info" th:selected="${searchBy == 'info'}">상품정보</option>-->
-<!--                        <option value="content" th:selected="${searchBy == 'content'}">상품내용</option>-->
-<!--                    </select>-->
-<!--                </label>-->
-<!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
+        <!--수정전 -->
+        <!--    <div class="col-md-9">-->
+        <!--        <div class="review-list">-->
+        <!--            <h2>좋아요한 굿즈</h2>-->
+        <!--            <form id="filter-and-sort-form" th:action="@{/user/my/in/merchan}" method="get">-->
+        <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
+        <!--                <label>-->
+        <!--                    <select name="searchBy">-->
+        <!--                        <option value="title" th:selected="${searchBy == 'title'}">상품제목</option>-->
+        <!--                        <option value="info" th:selected="${searchBy == 'info'}">상품정보</option>-->
+        <!--                        <option value="content" th:selected="${searchBy == 'content'}">상품내용</option>-->
+        <!--                    </select>-->
+        <!--                </label>-->
+        <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
 
-<!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
-<!--                <button type="submit">검색</button>-->
+        <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
+        <!--                <button type="submit">검색</button>-->
 
-<!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
-<!--                <label>-->
-<!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">품절됨-->
-<!--                </label>-->
-<!--                <label>-->
-<!--                    <select name="orderBy" onchange="submitForm()">-->
-<!--                        <option value="recentliked" th:selected="${orderBy == 'recentliked'}">최근좋아요순</option>-->
-<!--                        <option value="oldestliked" th:selected="${orderBy == 'oldestliked'}">오래된순</option>-->
+        <!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
+        <!--                <label>-->
+        <!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">품절됨-->
+        <!--                </label>-->
+        <!--                <label>-->
+        <!--                    <select name="orderBy" onchange="submitForm()">-->
+        <!--                        <option value="recentliked" th:selected="${orderBy == 'recentliked'}">최근좋아요순</option>-->
+        <!--                        <option value="oldestliked" th:selected="${orderBy == 'oldestliked'}">오래된순</option>-->
 
-<!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최신상품순</option>-->
-<!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된상품순</option>-->
+        <!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최신상품순</option>-->
+        <!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된상품순</option>-->
 
-<!--                        <option value="expensive" th:selected="${orderBy == 'expensive'}">금액높은순</option>-->
-<!--                        <option value="cheap" th:selected="${orderBy == 'cheap'}">금액낮은순</option>-->
+        <!--                        <option value="expensive" th:selected="${orderBy == 'expensive'}">금액높은순</option>-->
+        <!--                        <option value="cheap" th:selected="${orderBy == 'cheap'}">금액낮은순</option>-->
 
-<!--                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
-<!--                    </select>-->
-<!--                </label>-->
-<!--            </form>-->
-<!--            <table>-->
-<!--                <thead>-->
-<!--                <tr>-->
-<!--                    <th>좋아요 번호</th>-->
-<!--                    <th>상품 게시글 번호</th>-->
-<!--                    <th>회원번호</th>-->
-<!--                    <th>좋아요 날짜</th>-->
-<!--                    <th>상품 제목</th>-->
-<!--                    <th>정가</th>-->
-<!--                    <th>할인가</th>-->
-<!--                    <th>배송비</th>-->
-<!--                    <th>상품 정보</th>-->
-<!--                    <th>상품내용</th>-->
-<!--                    <th>게시 일시</th>-->
-<!--                </tr>-->
-<!--                </thead>-->
-<!--                <tbody>-->
-<!--                <tr th:each="myInMerchan : ${myInMerchans}" class="clickable-row" th:attr="data-href=@{/introduction/merchanDetail(no=${myInMerchan.merchanNo})}">-->
-<!--                    <td th:text="${myInMerchan.likedNo}">좋아요 번호</td>-->
-<!--                    <td th:text="${myInMerchan.merchanNo}">상품 게시글 번호</td>-->
-<!--                    <td th:text="${myInMerchan.userNo}">회원번호</td>-->
-<!--                    <td th:text="${myInMerchan.likedDate}">좋아요 날짜</td>-->
-<!--                    <td th:text="${myInMerchan.title}">상품 제목</td>-->
-<!--                    <td th:text="${myInMerchan.regularPrice}">정가</td>-->
-<!--                    <td th:text="${myInMerchan.discountPrice}">할인가</td>-->
-<!--                    <td th:text="${myInMerchan.shippingCost}">배송비</td>-->
-<!--                    <td th:text="${myInMerchan.merchanInfo}">상품 정보</td>-->
-<!--                    <td th:text="${myInMerchan.content}">상품내용</td>-->
-<!--                    <td th:text="${myInMerchan.postingDate}">게시 일시</td>-->
-<!--                </tr>-->
-<!--                </tbody>-->
-<!--            </table>-->
-<!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
-<!--            <th:block th:if="${pages != null}">-->
-<!--                <div class="d-flex justify-content-center">-->
-<!--                    <div class="btn-group">-->
-<!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/in/merchan(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
-<!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
-<!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
-<!--                            </svg>-->
-<!--                        </button>-->
-<!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
-<!--                            <button type="button" class="btn btn-sm me-2 pages"-->
-<!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/in/merchan(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
-<!--                        </th:block>-->
-<!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/in/merchan(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
-<!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
-<!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
-<!--                            </svg>-->
-<!--                        </button>-->
-<!--                    </div>-->
-<!--                </div>-->
-<!--            </th:block>-->
-<!--        </div>-->
-<!--    </div>-->
+        <!--                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
+        <!--                    </select>-->
+        <!--                </label>-->
+        <!--            </form>-->
+        <!--            <table>-->
+        <!--                <thead>-->
+        <!--                <tr>-->
+        <!--                    <th>좋아요 번호</th>-->
+        <!--                    <th>상품 게시글 번호</th>-->
+        <!--                    <th>회원번호</th>-->
+        <!--                    <th>좋아요 날짜</th>-->
+        <!--                    <th>상품 제목</th>-->
+        <!--                    <th>정가</th>-->
+        <!--                    <th>할인가</th>-->
+        <!--                    <th>배송비</th>-->
+        <!--                    <th>상품 정보</th>-->
+        <!--                    <th>상품내용</th>-->
+        <!--                    <th>게시 일시</th>-->
+        <!--                </tr>-->
+        <!--                </thead>-->
+        <!--                <tbody>-->
+        <!--                <tr th:each="myInMerchan : ${myInMerchans}" class="clickable-row" th:attr="data-href=@{/introduction/merchanDetail(no=${myInMerchan.merchanNo})}">-->
+        <!--                    <td th:text="${myInMerchan.likedNo}">좋아요 번호</td>-->
+        <!--                    <td th:text="${myInMerchan.merchanNo}">상품 게시글 번호</td>-->
+        <!--                    <td th:text="${myInMerchan.userNo}">회원번호</td>-->
+        <!--                    <td th:text="${myInMerchan.likedDate}">좋아요 날짜</td>-->
+        <!--                    <td th:text="${myInMerchan.title}">상품 제목</td>-->
+        <!--                    <td th:text="${myInMerchan.regularPrice}">정가</td>-->
+        <!--                    <td th:text="${myInMerchan.discountPrice}">할인가</td>-->
+        <!--                    <td th:text="${myInMerchan.shippingCost}">배송비</td>-->
+        <!--                    <td th:text="${myInMerchan.merchanInfo}">상품 정보</td>-->
+        <!--                    <td th:text="${myInMerchan.content}">상품내용</td>-->
+        <!--                    <td th:text="${myInMerchan.postingDate}">게시 일시</td>-->
+        <!--                </tr>-->
+        <!--                </tbody>-->
+        <!--            </table>-->
+        <!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
+        <!--            <th:block th:if="${pages != null}">-->
+        <!--                <div class="d-flex justify-content-center">-->
+        <!--                    <div class="btn-group">-->
+        <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/in/merchan(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
+        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
+        <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
+        <!--                            </svg>-->
+        <!--                        </button>-->
+        <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
+        <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
+        <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/in/merchan(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
+        <!--                        </th:block>-->
+        <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/in/merchan(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
+        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
+        <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
+        <!--                            </svg>-->
+        <!--                        </button>-->
+        <!--                    </div>-->
+        <!--                </div>-->
+        <!--            </th:block>-->
+        <!--        </div>-->
+        <!--    </div>-->
+    </div>
 </div>
 <div th:replace="common/footer.html"></div>
 </body>

--- a/src/main/resources/templates/user/mypage_in_merchan.html
+++ b/src/main/resources/templates/user/mypage_in_merchan.html
@@ -348,7 +348,7 @@
                                 }
 
                                 .search-container button i {
-                                    color: #666;
+                                    color: #A6AAB5;
                                 }
 
                                 .search-container button:hover i {

--- a/src/main/resources/templates/user/mypage_in_merchan.html
+++ b/src/main/resources/templates/user/mypage_in_merchan.html
@@ -131,7 +131,7 @@
     <div class="row">
         <aside class="col-md-3 px-4">
             <div class="row">
-                <div class="col-3"></div>
+                <div class="col-1"></div>
                 <div class="col-6">
                     <div class="panel">
                         <ul class="list-group">

--- a/src/main/resources/templates/user/mypage_in_merchan.html
+++ b/src/main/resources/templates/user/mypage_in_merchan.html
@@ -86,611 +86,640 @@
 
 <div th:replace="~{common/menubar}"></div>
 <style>
-    .jumbotron {
-    position : relative;
-    background-color : #EEEEEE;
+    html, body {
+        height: 100%;
+        margin: 0;
     }
-    .jumbotron .row {
-    position : absolute;
-    width : 100%;
-    bottom: 0%;
+    body {
+        display: flex;
+        flex-direction: column;
     }
-    .nav-link {
-            color: #828282;
+    .content-wrapper {
+        flex: 1 0 auto;
     }
-    ul {
-  list-style: none;
-  padding-left : 0px;
-  }
+    footer {
+        flex-shrink: 0;
+    }
+
 </style>
-<div class="jumbotron">
-    <div class="container">
-        <div class="row">
-            <div class="col-9">
-                <div class="row">
-                    <div class="col-md-3 px-4">
-                        <h3>나의 소식</h3>
-                    </div>
-                    <div class="col-md-9">
-                        <nav class="navbar navbar-expand-md">
-                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                                <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>
-                                <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>
-                                <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2" style="color: #000;">좋아요한
-                                    굿즈</a>
-                                </li>
-                            </ul>
-                        </nav>
+<div class="content-wrapper">
+    <style>
+        .jumbotron {
+        position : relative;
+        background-color : #EEEEEE;
+        }
+        .jumbotron .row {
+        position : absolute;
+        width : 100%;
+        bottom: 0%;
+        }
+        .nav-link {
+                color: #828282;
+        }
+        ul {
+      list-style: none;
+      padding-left : 0px;
+      }
+    </style>
+    <div class="jumbotron">
+        <div class="container">
+            <div class="row">
+                <div class="col-9">
+                    <div class="row">
+                        <div class="col-md-3 px-4">
+                            <h3>나의 소식</h3>
+                        </div>
+                        <div class="col-md-9">
+                            <nav class="navbar navbar-expand-md">
+                                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                    <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>
+                                    <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>
+                                    <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2" style="color: #000;">좋아요한
+                                        굿즈</a>
+                                    </li>
+                                </ul>
+                            </nav>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
-<div class="container" style="padding:0;">
-    <div class="row">
-        <aside class="col-md-3 px-4">
-            <div class="row">
-                <div class="col-1"></div>
-                <div class="col-8">
-                    <div class="panel">
-                        <ul class="list-group">
-                            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
-                            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-                            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
-                            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2" style="color: #03C75A;">나의
-                                소식</a></li>
-                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-                        </ul>
+    <div class="container" style="padding:0;">
+        <div class="row">
+            <aside class="col-md-3 px-4">
+                <div class="row">
+                    <div class="col-1"></div>
+                    <div class="col-8">
+                        <div class="panel">
+                            <ul class="list-group">
+                                <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
+                                <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
+                                <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2" style="color: #03C75A;">나의
+                                    소식</a></li>
+                                <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                                <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </aside>
-        <script> // toggle + sorting
-        function updateCheckboxValueAndSubmit() {
-            const checkbox = document.getElementById('isToggledCheckbox');
-            const form = document.getElementById('filter-and-sort-form');
-            // 체크박스가 체크된 상태를 확인
-            checkbox.value = checkbox.checked ? 'Y' : 'N';
-            // 폼 제출
-            form.submit();
-        }
-
-        function submitForm() {
-            document.getElementById('filter-and-sort-form').submit();
-        }
-        </script>
-        <style>
-            .form-select {
-            background-color : #FCFCFC;
-            border : none;
-            width : 100%;
-            height : 50px;
-            }
-            select {
-            color : #828282;
-            }
-            .form-control {
-            background-color : #FCFCFC;
-            border : none;
-            width : 100%;
-            height : 50px;
+            </aside>
+            <script> // toggle + sorting
+            function updateCheckboxValueAndSubmit() {
+                const checkbox = document.getElementById('isToggledCheckbox');
+                const form = document.getElementById('filter-and-sort-form');
+                // 체크박스가 체크된 상태를 확인
+                checkbox.value = checkbox.checked ? 'Y' : 'N';
+                // 폼 제출
+                form.submit();
             }
 
-
-            .form-control::placeholder {
-            color : #BBBBBB;
+            function submitForm() {
+                document.getElementById('filter-and-sort-form').submit();
             }
-
-            .date-container {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        background-color: #8E4B6E;
-        color: white;
-        border-radius: 10px;
-        text-align:center;
-        font-family: "Work Sans", sans-serif;
-    }
-
-    .month {
-        font-size: 1.1rem; /* M의 크기를 설정 */
-        font-weight: 550;
-        line-height: 1;
-    }
-
-    .year {
-        font-size: 0.65rem; /* yyyy의 크기를 설정 */
-        font-weight: 400;
-    }
-    :root {
-        --background-color-light: #FFFFFF;
-        --text-color-light: #000000;
-        --toggle-background-light: #CCCCCC;
-        --toggle-ball-light: #FFFFFF;
-
-        --background-color-dark: #333333;
-        --text-color-dark: #FFFFFF;
-        --toggle-background-dark: #03C75A;
-        --toggle-ball-dark: #FFFFFF;
-
-        --font-size-base: 32px; /* 기본 텍스트 크기 */
-        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
-    }
-
-
-
-    .toggle-switch {
-        position: relative;
-        display: inline-block;
-        width: 62px; /* 너비 조정 */
-        height: 38px; /* 높이 조정 */
-    }
-
-    .toggle-switch .checkbox {
-        opacity: 0;
-        width: 0;
-        height: 0;
-    }
-    #isToggledCheckbox {
-         opacity: 0;
-            width: 0;
-            height: 0;
-    }
-
-    .toggle-switch .label {
-        position: absolute;
-        cursor: pointer;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background-color: var(--toggle-background-light);
-        transition: background-color 0.4s;
-        border-radius: 38px; /* 둥근 모서리 반경 조정 */
-    }
-
-    .toggle-switch .label:before {
-        position: absolute;
-        content: "";
-        height: 30px; /* 내부 원 높이 조정 */
-        width: 30px; /* 내부 원 너비 조정 */
-        left: 2px;
-        bottom: 0px;
-        background-color: var(--toggle-ball-light);
-        transition: transform 0.4s;
-        border-radius: 50%;
-    }
-
-    .toggle-switch input:checked + .label {
-        background-color: var(--toggle-background-dark);
-    }
-
-    .toggle-switch input:checked + .label:before {
-        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
-    }
-
-             #absdiv {
-                position: relative;
-                top: 60px; /* Move down by 20px from its current position */
-                z-index : 1000;
-            }
-
-            #searchbutton {
-                background-color: #828282;
-            }
-
-            .card-img-top {
-                    width: 100%;
-                    height: 100px;
-                    object-fit: cover;
+            </script>
+            <style>
+                .form-select {
+                background-color : #FCFCFC;
+                border : none;
+                width : 100%;
+                height : 50px;
+                }
+                select {
+                color : #828282;
+                }
+                .form-control {
+                background-color : #FCFCFC;
+                border : none;
+                width : 100%;
+                height : 50px;
                 }
 
-        </style>
-        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
-              rel="stylesheet">
-        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
-              rel="stylesheet">
 
-        <div class="col-md-9">
-            <div class="row" style="color: #828282;">
-                <div class="col-11">
-                    <div class="row">
-                        <div class="col-12 p-0">
-                            <style>
-                                .col-4 select {
-                                    border-radius: 50px;
-                                    text-align: center;
-                                }
-                                /* 검색창 스타일 */
-                                .search-container {
-                                    width: 300px;
-                                }
+                .form-control::placeholder {
+                color : #BBBBBB;
+                }
 
-                                .search-container select {
-                                    position: absolute;
-                                    left: 0%;
-                                    width: 30%;
-                                    height: 50px;
-                                    color: #828282;
-                                    font-size: 1rem;
-                                    border-radius: 50px 0 0 50px;
-                                    outline: none;
-                                }
-                                .search-container input[type="text"] {
-                                    position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
-                                    left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
-                                    width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
-                                    height: 50px;
-                                    padding: 10px 40px 10px 15px;
-                                    font-size: 1rem;
-                                    outline: none;
-                                    border-radius: 0 50px 50px 0;
-                                    transition: border-color 0.3s, background-color 0.3s;
-                                    color: #828282; /* 입력 텍스트 색상 변경 */
-                                }
+                .date-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            background-color: #8E4B6E;
+            color: white;
+            border-radius: 10px;
+            text-align:center;
+            font-family: "Work Sans", sans-serif;
+        }
 
-                                .search-container input[type="text"]::placeholder {
-                                    color: #BBBBBB; /* placeholder 색상 변경 */
-                                }
+        .month {
+            font-size: 1.1rem; /* M의 크기를 설정 */
+            font-weight: 550;
+            line-height: 1;
+        }
+
+        .year {
+            font-size: 0.65rem; /* yyyy의 크기를 설정 */
+            font-weight: 400;
+        }
+        :root {
+            --background-color-light: #FFFFFF;
+            --text-color-light: #000000;
+            --toggle-background-light: #CCCCCC;
+            --toggle-ball-light: #FFFFFF;
+
+            --background-color-dark: #333333;
+            --text-color-dark: #FFFFFF;
+            --toggle-background-dark: #03C75A;
+            --toggle-ball-dark: #FFFFFF;
+
+            --font-size-base: 32px; /* 기본 텍스트 크기 */
+            --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+        }
 
 
-                                .search-container button {
-                                    position: absolute;
-                                    right: 1rem;
-                                    top: 25px;
-                                    background: none;
-                                    transform: translateY(-50%);
-                                    border: none;
-                                    cursor: pointer;
-                                }
 
-                                .search-container button i {
-                                    color: #A6AAB5;
-                                }
+        .toggle-switch {
+            position: relative;
+            display: inline-block;
+            width: 62px; /* 너비 조정 */
+            height: 38px; /* 높이 조정 */
+        }
 
-                                .search-container button:hover i {
-                                    color: #03C75A;
-                                }
-                            </style>
-                            <form id="filter-and-sort-form" th:action="@{/user/my/in/merchan}" method="get">
-                                <div class="row m-0">
-                                    <div class="col-7 p-0">
-                                        <div class="row justify-content-start m-0">
-                                            <div class="col-12 p-0">
-                                                <div class="search-container">
-                                                    <select class="form-select px-3" name="searchBy">
-                                                        <option value="title" th:selected="${searchBy == 'title'}">
-                                                            상품제목
+        .toggle-switch .checkbox {
+            opacity: 0;
+            width: 0;
+            height: 0;
+        }
+        #isToggledCheckbox {
+             opacity: 0;
+                width: 0;
+                height: 0;
+        }
+
+        .toggle-switch .label {
+            position: absolute;
+            cursor: pointer;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: var(--toggle-background-light);
+            transition: background-color 0.4s;
+            border-radius: 38px; /* 둥근 모서리 반경 조정 */
+        }
+
+        .toggle-switch .label:before {
+            position: absolute;
+            content: "";
+            height: 30px; /* 내부 원 높이 조정 */
+            width: 30px; /* 내부 원 너비 조정 */
+            left: 2px;
+            bottom: 0px;
+            background-color: var(--toggle-ball-light);
+            transition: transform 0.4s;
+            border-radius: 50%;
+        }
+
+        .toggle-switch input:checked + .label {
+            background-color: var(--toggle-background-dark);
+        }
+
+        .toggle-switch input:checked + .label:before {
+            transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+        }
+
+                 #absdiv {
+                    position: relative;
+                    top: 60px; /* Move down by 20px from its current position */
+                    z-index : 1000;
+                }
+
+                #searchbutton {
+                    background-color: #828282;
+                }
+
+                .card-img-top {
+                        width: 100%;
+                        height: 100px;
+                        object-fit: cover;
+                    }
+
+            </style>
+            <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+                  rel="stylesheet">
+            <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+                  rel="stylesheet">
+
+            <div class="col-md-9">
+                <div class="row" style="color: #828282;">
+                    <div class="col-11">
+                        <div class="row">
+                            <div class="col-12 p-0">
+                                <style>
+                                    .col-4 select {
+                                        border-radius: 50px;
+                                        text-align: center;
+                                    }
+                                    /* 검색창 스타일 */
+                                    .search-container {
+                                        width: 300px;
+                                    }
+
+                                    .search-container select {
+                                        position: absolute;
+                                        left: 0%;
+                                        width: 30%;
+                                        height: 50px;
+                                        color: #828282;
+                                        font-size: 1rem;
+                                        border-radius: 50px 0 0 50px;
+                                        outline: none;
+                                    }
+                                    .search-container input[type="text"] {
+                                        position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
+                                        left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
+                                        width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
+                                        height: 50px;
+                                        padding: 10px 40px 10px 15px;
+                                        font-size: 1rem;
+                                        outline: none;
+                                        border-radius: 0 50px 50px 0;
+                                        transition: border-color 0.3s, background-color 0.3s;
+                                        color: #828282; /* 입력 텍스트 색상 변경 */
+                                    }
+
+                                    .search-container input[type="text"]::placeholder {
+                                        color: #BBBBBB; /* placeholder 색상 변경 */
+                                    }
+
+
+                                    .search-container button {
+                                        position: absolute;
+                                        right: 1rem;
+                                        top: 25px;
+                                        background: none;
+                                        transform: translateY(-50%);
+                                        border: none;
+                                        cursor: pointer;
+                                    }
+
+                                    .search-container button i {
+                                        color: #A6AAB5;
+                                    }
+
+                                    .search-container button:hover i {
+                                        color: #03C75A;
+                                    }
+                                </style>
+                                <form id="filter-and-sort-form" th:action="@{/user/my/in/merchan}" method="get">
+                                    <div class="row m-0">
+                                        <div class="col-7 p-0">
+                                            <div class="row justify-content-start m-0">
+                                                <div class="col-12 p-0">
+                                                    <div class="search-container">
+                                                        <select class="form-select px-3" name="searchBy">
+                                                            <option value="title" th:selected="${searchBy == 'title'}">
+                                                                상품제목
+                                                            </option>
+                                                            <option value="info" th:selected="${searchBy == 'info'}">
+                                                                상품정보
+                                                            </option>
+                                                            <option value="content"
+                                                                    th:selected="${searchBy == 'content'}">
+                                                                상품내용
+                                                            </option>
+                                                        </select>
+                                                        <input class="form-control px-3" type="text" name="searchTerm"
+                                                               placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
+                                                        <!-- 검색 버튼 -->
+                                                        <button type="submit">
+                                                            <i class="fas fa-search"></i>
+                                                        </button>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="col-1" style=""></div>
+                                        <div class="col-4">
+                                            <div class="row justify-content-end">
+                                                <!-- 정렬 또는 토글2 -->
+                                                <label>
+                                                    <select class="form-select px-3" name="orderBy"
+                                                            onchange="submitForm()">
+                                                        <option value="recentliked"
+                                                                th:selected="${orderBy == 'recentliked'}">최근좋아요순
                                                         </option>
-                                                        <option value="info" th:selected="${searchBy == 'info'}">상품정보
+                                                        <option value="oldestliked"
+                                                                th:selected="${orderBy == 'oldestliked'}">오래된순
                                                         </option>
-                                                        <option value="content" th:selected="${searchBy == 'content'}">
-                                                            상품내용
+
+                                                        <option value="recent" th:selected="${orderBy == 'recent'}">
+                                                            최신상품순
+                                                        </option>
+                                                        <option value="oldest" th:selected="${orderBy == 'oldest'}">
+                                                            오래된상품순
+                                                        </option>
+
+                                                        <option value="expensive"
+                                                                th:selected="${orderBy == 'expensive'}">
+                                                            금액높은순
+                                                        </option>
+                                                        <option value="cheap" th:selected="${orderBy == 'cheap'}">금액낮은순
+                                                        </option>
+
+                                                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순
                                                         </option>
                                                     </select>
-                                                    <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
-                                                    <!-- 검색 버튼 -->
-                                                    <button type="submit">
-                                                        <i class="fas fa-search"></i>
-                                                    </button>
+                                                </label>
+                                            </div>
+                                        </div>
+                                    </div> <!--검색, 소팅 (토글X)-->
+                                    <div class="row justify-content-around">
+                                        <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                        <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                        <div class="col-3" style="padding: 0 1.2rem;">
+                                            <div id="absdiv" class="row justify-content-end">
+                                                <div class="col-3">
+                                                    <div class="toggle-switch">
+                                                        <!-- 정렬 또는 토글1 -->
+                                                        <input type="checkbox" name="isToggled" id="isToggledCheckbox"
+                                                               value="Y" th:checked="${isToggled == 'Y'}"
+                                                               onchange="updateCheckboxValueAndSubmit()">
+                                                        <label for="isToggledCheckbox" class="label">
+                                                            <div class="ball"></div>
+                                                        </label>
+                                                    </div>
+                                                </div>
+                                                <div class="col-8"
+                                                     style="text-align: right; padding: 0px; margin : 0px;">
+                                                    품절됨
                                                 </div>
                                             </div>
                                         </div>
-                                    </div>
-                                    <div class="col-1" style=""></div>
-                                    <div class="col-4">
-                                        <div class="row justify-content-end">
-                                            <!-- 정렬 또는 토글2 -->
-                                            <label>
-                                                <select class="form-select px-3" name="orderBy" onchange="submitForm()">
-                                                    <option value="recentliked"
-                                                            th:selected="${orderBy == 'recentliked'}">최근좋아요순
-                                                    </option>
-                                                    <option value="oldestliked"
-                                                            th:selected="${orderBy == 'oldestliked'}">오래된순
-                                                    </option>
-
-                                                    <option value="recent" th:selected="${orderBy == 'recent'}">최신상품순
-                                                    </option>
-                                                    <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된상품순
-                                                    </option>
-
-                                                    <option value="expensive" th:selected="${orderBy == 'expensive'}">
-                                                        금액높은순
-                                                    </option>
-                                                    <option value="cheap" th:selected="${orderBy == 'cheap'}">금액낮은순
-                                                    </option>
-
-                                                    <option value="title" th:selected="${orderBy == 'title'}">제목가나다순
-                                                    </option>
-                                                </select>
-                                            </label>
-                                        </div>
-                                    </div>
-                                </div> <!--검색, 소팅 (토글X)-->
-                                <div class="row justify-content-around">
-                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                    <div class="col-3" style="padding: 0 1.2rem;">
-                                        <div id="absdiv" class="row justify-content-end">
-                                            <div class="col-3">
-                                                <div class="toggle-switch">
-                                                    <!-- 정렬 또는 토글1 -->
-                                                    <input type="checkbox" name="isToggled" id="isToggledCheckbox"
-                                                           value="Y" th:checked="${isToggled == 'Y'}"
-                                                           onchange="updateCheckboxValueAndSubmit()">
-                                                    <label for="isToggledCheckbox" class="label">
-                                                        <div class="ball"></div>
-                                                    </label>
+                                    </div> <!--토글-->
+                                </form>
+                            </div>
+                        </div>
+                        <div class="row justify-content-around">
+                            <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
+                                <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
+                                    <div class="col-3 clickable-row"
+                                         style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                         th:each="myInMerchan, iterStat : ${myInMerchans}"
+                                         th:attr="data-href=@{/introduction/merchanDetail(no=${myInMerchan.merchanNo})}"
+                                         th:if="${iterStat.index < 3}">
+                                        <div class="row justify-content-center">
+                                            <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                                 style="aspect-ratio: 1; border-radius: 5px;">
+                                                <div class="date-container px-2 py-1">
+                                                    <div class="month"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myInMerchan.postingDate)}"></div>
+                                                    <div class="year"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myInMerchan.postingDate)}"></div>
                                                 </div>
                                             </div>
-                                            <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">
-                                                품절됨
+                                            <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                            <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                            <!--                                    </div>-->
+                                            <div class="col-5"
+                                                 style="color: white; font-size: 0.8rem; font-weight: 530;"
+                                                 th:text="myInMerchan.merchanNo">닉네임
+                                            </div>
+
+                                            <div class="col-3"
+                                                 style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
+                                                 th:text="${myInMerchan.formattedPostingDate}">시간
                                             </div>
                                         </div>
-                                    </div>
-                                </div> <!--토글-->
-                            </form>
-                        </div>
-                    </div>
-                    <div class="row justify-content-around">
-                        <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
-                            <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
-                                <div class="col-3 clickable-row"
-                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
-                                     th:each="myInMerchan, iterStat : ${myInMerchans}"
-                                     th:attr="data-href=@{/introduction/merchanDetail(no=${myInMerchan.merchanNo})}"
-                                     th:if="${iterStat.index < 3}">
-                                    <div class="row justify-content-center">
-                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
-                                             style="aspect-ratio: 1; border-radius: 5px;">
-                                            <div class="date-container px-2 py-1">
-                                                <div class="month"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myInMerchan.postingDate)}"></div>
-                                                <div class="year"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myInMerchan.postingDate)}"></div>
+                                        <div class="row justify-content-center">
+                                            <div class="col-12 my-3" style="">
+                                                <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                                <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                                <!-- 썸네일 이미지 있을때  -->
+                                                <img th:if="${#lists.size(myInMerchan.merchanFiles) > 0}"
+                                                     th:src="@{/uploadFiles/{fileName}(fileName=${myInMerchan.merchanFiles.get(0).fileName})}"
+                                                     class="card-img-top" alt="썸네일 이미지">
                                             </div>
                                         </div>
-                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                        <!--                                    </div>-->
-                                        <div class="col-5" style="color: white; font-size: 0.8rem; font-weight: 530;"
-                                             th:text="myInMerchan.merchanNo">닉네임
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                                 th:text="${myInMerchan.title}">이름
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                                 th:text="${myInMerchan.merchanInfo}">내용
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;"></div>
                                         </div>
 
-                                        <div class="col-3"
-                                             style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
-                                             th:text="${myInMerchan.formattedPostingDate}">시간
-                                        </div>
                                     </div>
-                                    <div class="row justify-content-center">
-                                        <div class="col-12 my-3" style="">
-                                            <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                            <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                            <!-- 썸네일 이미지 있을때  -->
-                                            <img th:if="${#lists.size(myInMerchan.merchanFiles) > 0}"
-                                                 th:src="@{/uploadFiles/{fileName}(fileName=${myInMerchan.merchanFiles.get(0).fileName})}"
-                                                 class="card-img-top" alt="썸네일 이미지">
-                                        </div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
-                                             th:text="${myInMerchan.title}">이름
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
-                                             th:text="${myInMerchan.merchanInfo}">내용
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                    </div>
-
+                                    <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
+                                    <div class="col-3" th:if="${myInMerchans.size() == 0}"></div>
+                                    <div class="col-3"
+                                         th:if="${myInMerchans.size() == 0 || myInMerchans.size() == 1}"></div>
+                                    <div class="col-3"
+                                         th:if="${myInMerchans.size() == 0 || myInMerchans.size() == 1 || myInMerchans.size() == 2}"></div>
                                 </div>
-                                <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
-                                <div class="col-3" th:if="${myInMerchans.size() == 0}"></div>
-                                <div class="col-3"
-                                     th:if="${myInMerchans.size() == 0 || myInMerchans.size() == 1}"></div>
-                                <div class="col-3"
-                                     th:if="${myInMerchans.size() == 0 || myInMerchans.size() == 1 || myInMerchans.size() == 2}"></div>
-                            </div>
-                            <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
-                                <div class="col-3 clickable-row"
-                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
-                                     th:each="myInMerchan, iterStat : ${myInMerchans}"
-                                     th:attr="data-href=@{/introduction/merchanDetail(no=${myInMerchan.merchanNo})}"
-                                     th:if="${iterStat.index >= 3}">
-                                    <div class="row justify-content-center">
-                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
-                                             style="aspect-ratio: 1; border-radius: 5px;">
-                                            <div class="date-container px-2 py-1">
-                                                <div class="month"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myInMerchan.postingDate)}"></div>
-                                                <div class="year"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myInMerchan.postingDate)}"></div>
+                                <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
+                                    <div class="col-3 clickable-row"
+                                         style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                         th:each="myInMerchan, iterStat : ${myInMerchans}"
+                                         th:attr="data-href=@{/introduction/merchanDetail(no=${myInMerchan.merchanNo})}"
+                                         th:if="${iterStat.index >= 3}">
+                                        <div class="row justify-content-center">
+                                            <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                                 style="aspect-ratio: 1; border-radius: 5px;">
+                                                <div class="date-container px-2 py-1">
+                                                    <div class="month"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myInMerchan.postingDate)}"></div>
+                                                    <div class="year"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myInMerchan.postingDate)}"></div>
+                                                </div>
+                                            </div>
+                                            <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                            <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                            <!--                                    </div>-->
+                                            <div class="col-5"
+                                                 style="color: white; font-size: 0.8rem; font-weight: 530;"
+                                                 th:text="myInMerchan.merchanNo">닉네임
+                                            </div>
+
+                                            <div class="col-3"
+                                                 style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
+                                                 th:text="${myInMerchan.formattedPostingDate}">시간
                                             </div>
                                         </div>
-                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                        <!--                                    </div>-->
-                                        <div class="col-5" style="color: white; font-size: 0.8rem; font-weight: 530;"
-                                             th:text="myInMerchan.merchanNo">닉네임
+                                        <div class="row justify-content-center">
+                                            <div class="col-12 my-3" style="">
+                                                <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                                <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                                <!-- 썸네일 이미지 있을때  -->
+                                                <img th:if="${#lists.size(myInMerchan.merchanFiles) > 0}"
+                                                     th:src="@{/uploadFiles/{fileName}(fileName=${myInMerchan.merchanFiles.get(0).fileName})}"
+                                                     class="card-img-top" alt="썸네일 이미지">
+                                            </div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                                 th:text="${myInMerchan.title}">이름
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                                 th:text="${myInMerchan.merchanInfo}">내용
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;"></div>
                                         </div>
 
-                                        <div class="col-3"
-                                             style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
-                                             th:text="${myInMerchan.formattedPostingDate}">시간
-                                        </div>
-                                    </div>
-                                    <div class="row justify-content-center">
-                                        <div class="col-12 my-3" style="">
-                                            <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                            <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                            <!-- 썸네일 이미지 있을때  -->
-                                            <img th:if="${#lists.size(myInMerchan.merchanFiles) > 0}"
-                                                 th:src="@{/uploadFiles/{fileName}(fileName=${myInMerchan.merchanFiles.get(0).fileName})}"
-                                                 class="card-img-top" alt="썸네일 이미지">
-                                        </div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
-                                             th:text="${myInMerchan.title}">이름
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
-                                             th:text="${myInMerchan.merchanInfo}">내용
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
                                     </div>
 
+                                    <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
+                                    <div class="col-3" th:if="${myInMerchans.size() <= 3}"></div>
+                                    <div class="col-3"
+                                         th:if="${myInMerchans.size() <= 3 || myInMerchans.size() == 4}"></div>
+                                    <div class="col-3"
+                                         th:if="${myInMerchans.size() <= 3 || myInMerchans.size() == 4 || myInMerchans.size() == 5}"></div>
                                 </div>
-
-                                <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
-                                <div class="col-3" th:if="${myInMerchans.size() <= 3}"></div>
-                                <div class="col-3"
-                                     th:if="${myInMerchans.size() <= 3 || myInMerchans.size() == 4}"></div>
-                                <div class="col-3"
-                                     th:if="${myInMerchans.size() <= 3 || myInMerchans.size() == 4 || myInMerchans.size() == 5}"></div>
                             </div>
                         </div>
-                    </div>
-                    <div class="row justify-content-center">
-                        <!-- 페이징 -->
-                        <th:block th:if="${pages != null}">
-                            <div class="d-flex justify-content-center">
-                                <div class="btn-group">
-                                    <button type="button" class="btn btn-sm previous"
-                                            th:onclick="|location.href='@{/user/my/in/merchan(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
-                                            th:disabled="${currentPage == 1}">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                             fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-                                            <path fill-rule="evenodd"
-                                                  d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                                        </svg>
-                                    </button>
-                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">
-                                        <button type="button" class="btn btn-sm me-2 pages"
-                                                th:text="${p}"
-                                                th:onclick="|location.href='@{/user/my/in/merchan(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
-                                    </th:block>
-                                    <button type="button" class="btn btn-sm  next"
-                                            th:onclick="|location.href='@{/user/my/in/merchan(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
-                                            th:disabled="${currentPage == pages}">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                             fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-                                            <path fill-rule="evenodd"
-                                                  d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
-                                        </svg>
-                                    </button>
+                        <div class="row justify-content-center">
+                            <!-- 페이징 -->
+                            <th:block th:if="${pages != null}">
+                                <div class="d-flex justify-content-center">
+                                    <div class="btn-group">
+                                        <button type="button" class="btn btn-sm previous"
+                                                th:onclick="|location.href='@{/user/my/in/merchan(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
+                                                th:disabled="${currentPage == 1}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                                 fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+                                                <path fill-rule="evenodd"
+                                                      d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                                            </svg>
+                                        </button>
+                                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">
+                                            <button type="button" class="btn btn-sm me-2 pages"
+                                                    th:text="${p}"
+                                                    th:onclick="|location.href='@{/user/my/in/merchan(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
+                                        </th:block>
+                                        <button type="button" class="btn btn-sm  next"
+                                                th:onclick="|location.href='@{/user/my/in/merchan(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
+                                                th:disabled="${currentPage == pages}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                                 fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+                                                <path fill-rule="evenodd"
+                                                      d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                                            </svg>
+                                        </button>
+                                    </div>
                                 </div>
-                            </div>
-                        </th:block>
-                    </div>
-                </div><!--테이블 및 페이징 포함-->
+                            </th:block>
+                        </div>
+                    </div><!--테이블 및 페이징 포함-->
+                </div> <!--본화면-->
             </div> <!--본화면-->
-        </div> <!--본화면-->
 
-        <!--수정전 -->
-        <!--    <div class="col-md-9">-->
-        <!--        <div class="review-list">-->
-        <!--            <h2>좋아요한 굿즈</h2>-->
-        <!--            <form id="filter-and-sort-form" th:action="@{/user/my/in/merchan}" method="get">-->
-        <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
-        <!--                <label>-->
-        <!--                    <select name="searchBy">-->
-        <!--                        <option value="title" th:selected="${searchBy == 'title'}">상품제목</option>-->
-        <!--                        <option value="info" th:selected="${searchBy == 'info'}">상품정보</option>-->
-        <!--                        <option value="content" th:selected="${searchBy == 'content'}">상품내용</option>-->
-        <!--                    </select>-->
-        <!--                </label>-->
-        <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
+            <!--수정전 -->
+            <!--    <div class="col-md-9">-->
+            <!--        <div class="review-list">-->
+            <!--            <h2>좋아요한 굿즈</h2>-->
+            <!--            <form id="filter-and-sort-form" th:action="@{/user/my/in/merchan}" method="get">-->
+            <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
+            <!--                <label>-->
+            <!--                    <select name="searchBy">-->
+            <!--                        <option value="title" th:selected="${searchBy == 'title'}">상품제목</option>-->
+            <!--                        <option value="info" th:selected="${searchBy == 'info'}">상품정보</option>-->
+            <!--                        <option value="content" th:selected="${searchBy == 'content'}">상품내용</option>-->
+            <!--                    </select>-->
+            <!--                </label>-->
+            <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
 
-        <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
-        <!--                <button type="submit">검색</button>-->
+            <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
+            <!--                <button type="submit">검색</button>-->
 
-        <!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
-        <!--                <label>-->
-        <!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">품절됨-->
-        <!--                </label>-->
-        <!--                <label>-->
-        <!--                    <select name="orderBy" onchange="submitForm()">-->
-        <!--                        <option value="recentliked" th:selected="${orderBy == 'recentliked'}">최근좋아요순</option>-->
-        <!--                        <option value="oldestliked" th:selected="${orderBy == 'oldestliked'}">오래된순</option>-->
+            <!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
+            <!--                <label>-->
+            <!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">품절됨-->
+            <!--                </label>-->
+            <!--                <label>-->
+            <!--                    <select name="orderBy" onchange="submitForm()">-->
+            <!--                        <option value="recentliked" th:selected="${orderBy == 'recentliked'}">최근좋아요순</option>-->
+            <!--                        <option value="oldestliked" th:selected="${orderBy == 'oldestliked'}">오래된순</option>-->
 
-        <!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최신상품순</option>-->
-        <!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된상품순</option>-->
+            <!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최신상품순</option>-->
+            <!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된상품순</option>-->
 
-        <!--                        <option value="expensive" th:selected="${orderBy == 'expensive'}">금액높은순</option>-->
-        <!--                        <option value="cheap" th:selected="${orderBy == 'cheap'}">금액낮은순</option>-->
+            <!--                        <option value="expensive" th:selected="${orderBy == 'expensive'}">금액높은순</option>-->
+            <!--                        <option value="cheap" th:selected="${orderBy == 'cheap'}">금액낮은순</option>-->
 
-        <!--                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
-        <!--                    </select>-->
-        <!--                </label>-->
-        <!--            </form>-->
-        <!--            <table>-->
-        <!--                <thead>-->
-        <!--                <tr>-->
-        <!--                    <th>좋아요 번호</th>-->
-        <!--                    <th>상품 게시글 번호</th>-->
-        <!--                    <th>회원번호</th>-->
-        <!--                    <th>좋아요 날짜</th>-->
-        <!--                    <th>상품 제목</th>-->
-        <!--                    <th>정가</th>-->
-        <!--                    <th>할인가</th>-->
-        <!--                    <th>배송비</th>-->
-        <!--                    <th>상품 정보</th>-->
-        <!--                    <th>상품내용</th>-->
-        <!--                    <th>게시 일시</th>-->
-        <!--                </tr>-->
-        <!--                </thead>-->
-        <!--                <tbody>-->
-        <!--                <tr th:each="myInMerchan : ${myInMerchans}" class="clickable-row" th:attr="data-href=@{/introduction/merchanDetail(no=${myInMerchan.merchanNo})}">-->
-        <!--                    <td th:text="${myInMerchan.likedNo}">좋아요 번호</td>-->
-        <!--                    <td th:text="${myInMerchan.merchanNo}">상품 게시글 번호</td>-->
-        <!--                    <td th:text="${myInMerchan.userNo}">회원번호</td>-->
-        <!--                    <td th:text="${myInMerchan.likedDate}">좋아요 날짜</td>-->
-        <!--                    <td th:text="${myInMerchan.title}">상품 제목</td>-->
-        <!--                    <td th:text="${myInMerchan.regularPrice}">정가</td>-->
-        <!--                    <td th:text="${myInMerchan.discountPrice}">할인가</td>-->
-        <!--                    <td th:text="${myInMerchan.shippingCost}">배송비</td>-->
-        <!--                    <td th:text="${myInMerchan.merchanInfo}">상품 정보</td>-->
-        <!--                    <td th:text="${myInMerchan.content}">상품내용</td>-->
-        <!--                    <td th:text="${myInMerchan.postingDate}">게시 일시</td>-->
-        <!--                </tr>-->
-        <!--                </tbody>-->
-        <!--            </table>-->
-        <!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
-        <!--            <th:block th:if="${pages != null}">-->
-        <!--                <div class="d-flex justify-content-center">-->
-        <!--                    <div class="btn-group">-->
-        <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/in/merchan(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
-        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
-        <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
-        <!--                            </svg>-->
-        <!--                        </button>-->
-        <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
-        <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
-        <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/in/merchan(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
-        <!--                        </th:block>-->
-        <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/in/merchan(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
-        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
-        <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
-        <!--                            </svg>-->
-        <!--                        </button>-->
-        <!--                    </div>-->
-        <!--                </div>-->
-        <!--            </th:block>-->
-        <!--        </div>-->
-        <!--    </div>-->
+            <!--                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
+            <!--                    </select>-->
+            <!--                </label>-->
+            <!--            </form>-->
+            <!--            <table>-->
+            <!--                <thead>-->
+            <!--                <tr>-->
+            <!--                    <th>좋아요 번호</th>-->
+            <!--                    <th>상품 게시글 번호</th>-->
+            <!--                    <th>회원번호</th>-->
+            <!--                    <th>좋아요 날짜</th>-->
+            <!--                    <th>상품 제목</th>-->
+            <!--                    <th>정가</th>-->
+            <!--                    <th>할인가</th>-->
+            <!--                    <th>배송비</th>-->
+            <!--                    <th>상품 정보</th>-->
+            <!--                    <th>상품내용</th>-->
+            <!--                    <th>게시 일시</th>-->
+            <!--                </tr>-->
+            <!--                </thead>-->
+            <!--                <tbody>-->
+            <!--                <tr th:each="myInMerchan : ${myInMerchans}" class="clickable-row" th:attr="data-href=@{/introduction/merchanDetail(no=${myInMerchan.merchanNo})}">-->
+            <!--                    <td th:text="${myInMerchan.likedNo}">좋아요 번호</td>-->
+            <!--                    <td th:text="${myInMerchan.merchanNo}">상품 게시글 번호</td>-->
+            <!--                    <td th:text="${myInMerchan.userNo}">회원번호</td>-->
+            <!--                    <td th:text="${myInMerchan.likedDate}">좋아요 날짜</td>-->
+            <!--                    <td th:text="${myInMerchan.title}">상품 제목</td>-->
+            <!--                    <td th:text="${myInMerchan.regularPrice}">정가</td>-->
+            <!--                    <td th:text="${myInMerchan.discountPrice}">할인가</td>-->
+            <!--                    <td th:text="${myInMerchan.shippingCost}">배송비</td>-->
+            <!--                    <td th:text="${myInMerchan.merchanInfo}">상품 정보</td>-->
+            <!--                    <td th:text="${myInMerchan.content}">상품내용</td>-->
+            <!--                    <td th:text="${myInMerchan.postingDate}">게시 일시</td>-->
+            <!--                </tr>-->
+            <!--                </tbody>-->
+            <!--            </table>-->
+            <!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
+            <!--            <th:block th:if="${pages != null}">-->
+            <!--                <div class="d-flex justify-content-center">-->
+            <!--                    <div class="btn-group">-->
+            <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/in/merchan(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
+            <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
+            <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
+            <!--                            </svg>-->
+            <!--                        </button>-->
+            <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
+            <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
+            <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/in/merchan(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
+            <!--                        </th:block>-->
+            <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/in/merchan(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
+            <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
+            <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
+            <!--                            </svg>-->
+            <!--                        </button>-->
+            <!--                    </div>-->
+            <!--                </div>-->
+            <!--            </th:block>-->
+            <!--        </div>-->
+            <!--    </div>-->
+        </div>
     </div>
 </div>
 <div th:replace="common/footer.html"></div>

--- a/src/main/resources/templates/user/mypage_rct_application.html
+++ b/src/main/resources/templates/user/mypage_rct_application.html
@@ -301,14 +301,69 @@
             <div class="row" style="color: #828282;">
                 <div class="col-11">
                     <div class="row">
-                        <div class="col-12">
+                        <div class="col-12 p-0">
+                            <style>
+                                .col-4 select {
+                                    border-radius: 50px;
+                                    text-align: center;
+                                }
+                                /* 검색창 스타일 */
+                                .search-container {
+                                    width: 300px;
+                                }
+
+                                .search-container select {
+                                    position: absolute;
+                                    left: 0%;
+                                    width: 30%;
+                                    height: 50px;
+                                    color: #828282;
+                                    font-size: 1rem;
+                                    border-radius: 50px 0 0 50px;
+                                    outline: none;
+                                }
+                                .search-container input[type="text"] {
+                                    position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
+                                    left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
+                                    width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
+                                    height: 50px;
+                                    padding: 10px 40px 10px 15px;
+                                    font-size: 1rem;
+                                    outline: none;
+                                    border-radius: 0 50px 50px 0;
+                                    transition: border-color 0.3s, background-color 0.3s;
+                                    color: #828282; /* 입력 텍스트 색상 변경 */
+                                }
+
+                                .search-container input[type="text"]::placeholder {
+                                    color: #BBBBBB; /* placeholder 색상 변경 */
+                                }
+
+
+                                .search-container button {
+                                    position: absolute;
+                                    right: 1rem;
+                                    top: 25px;
+                                    background: none;
+                                    transform: translateY(-50%);
+                                    border: none;
+                                    cursor: pointer;
+                                }
+
+                                .search-container button i {
+                                    color: #666;
+                                }
+
+                                .search-container button:hover i {
+                                    color: #03C75A;
+                                }
+                            </style>
                             <form id="filter-and-sort-form" th:action="@{/user/my/rct/apply}" method="get">
-                                <div class="row">
-                                    <div class="col-7">
+                                <div class="row m-0">
+                                    <div class="col-7 p-0">
                                         <div class="row justify-content-start m-0">
-                                            <div class="col-4">
-                                                <!-- 검색 조건 -->
-                                                <label>
+                                            <div class="col-12 p-0">
+                                                <div class="search-container">
                                                     <select class="form-select px-3" name="searchBy">
                                                         <option value="title" th:selected="${searchBy == 'title'}">
                                                             지원서제목
@@ -327,16 +382,12 @@
                                                         </option>
                                                         <!--                        <option value="jWriter" th:selected="${searchBy == 'jWriter'}">공고작성자</option>-->
                                                     </select>
-                                                </label>
-                                            </div>
-                                            <div class="col-6">
-                                                <input class="form-control px-3" type="text" name="searchTerm"
-                                                       placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
-                                            </div>
-                                            <div class="col-2">
-                                                <!-- 검색 버튼 -->
-                                                <button id="searchbutton" type="submit" class="btn btn-primary">검색
-                                                </button>
+                                                    <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
+                                                    <!-- 검색 버튼 -->
+                                                    <button type="submit">
+                                                        <i class="fas fa-search"></i>
+                                                    </button>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>

--- a/src/main/resources/templates/user/mypage_rct_application.html
+++ b/src/main/resources/templates/user/mypage_rct_application.html
@@ -351,7 +351,7 @@
                                 }
 
                                 .search-container button i {
-                                    color: #666;
+                                    color: #A6AAB5;
                                 }
 
                                 .search-container button:hover i {

--- a/src/main/resources/templates/user/mypage_rct_application.html
+++ b/src/main/resources/templates/user/mypage_rct_application.html
@@ -134,7 +134,7 @@
     <div class="row">
         <aside class="col-md-3 px-4">
             <div class="row">
-                <div class="col-3"></div>
+                <div class="col-1"></div>
                 <div class="col-6">
                     <div class="panel">
                         <ul class="list-group">

--- a/src/main/resources/templates/user/mypage_rct_application.html
+++ b/src/main/resources/templates/user/mypage_rct_application.html
@@ -86,626 +86,658 @@
 
 <div th:replace="~{common/menubar}"></div>
 <style>
-    .jumbotron {
-    position : relative;
-    background-color : #EEEEEE;
+    html, body {
+        height: 100%;
+        margin: 0;
     }
-    .jumbotron .row {
-    position : absolute;
-    width : 100%;
-    bottom: 0%;
+    body {
+        display: flex;
+        flex-direction: column;
     }
-    .nav-link {
-            color: #828282;
+    .content-wrapper {
+        flex: 1 0 auto;
     }
-    ul {
-  list-style: none;
-  padding-left : 0px;
-  }
+    footer {
+        flex-shrink: 0;
+    }
+
 </style>
-<div class="jumbotron">
-    <div class="container">
-        <div class="row">
-            <div class="col-9">
-                <div class="row">
-                    <div class="col-md-3 px-4">
-                        <h3>나의 채용</h3>
-                    </div>
-                    <div class="col-md-9">
-                        <nav class="navbar navbar-expand-md">
-                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
-                                <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2" style="color:#000;">나의 지원서
-                                    관리</a>
-                                </li>
-                                <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
-                                <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
-                                <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보
-                                    수정</a></li>
-                            </ul>
-                        </nav>
+<div class="content-wrapper">
+    <style>
+        .jumbotron {
+        position : relative;
+        background-color : #EEEEEE;
+        }
+        .jumbotron .row {
+        position : absolute;
+        width : 100%;
+        bottom: 0%;
+        }
+        .nav-link {
+                color: #828282;
+        }
+        ul {
+      list-style: none;
+      padding-left : 0px;
+      }
+    </style>
+    <div class="jumbotron">
+        <div class="container">
+            <div class="row">
+                <div class="col-9">
+                    <div class="row">
+                        <div class="col-md-3 px-4">
+                            <h3>나의 채용</h3>
+                        </div>
+                        <div class="col-md-9">
+                            <nav class="navbar navbar-expand-md">
+                                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                    <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
+                                    <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2" style="color:#000;">나의
+                                        지원서
+                                        관리</a>
+                                    </li>
+                                    <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
+                                    <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
+                                    <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보
+                                        수정</a></li>
+                                </ul>
+                            </nav>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
-<div class="container" style="padding:0;">
-    <div class="row">
-        <aside class="col-md-3 px-4">
-            <div class="row">
-                <div class="col-1"></div>
-                <div class="col-8">
-                    <div class="panel">
-                        <ul class="list-group">
-                            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
-                            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-                            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color: #03C75A;">나의 채용</a>
-                            </li>
-                            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-                        </ul>
+    <div class="container" style="padding:0;">
+        <div class="row">
+            <aside class="col-md-3 px-4">
+                <div class="row">
+                    <div class="col-1"></div>
+                    <div class="col-8">
+                        <div class="panel">
+                            <ul class="list-group">
+                                <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
+                                <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color: #03C75A;">나의
+                                    채용</a>
+                                </li>
+                                <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                                <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                                <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </aside>
-        <!--    <script>-->
-        <!--        function toggleCheckboxValue() {-->
-        <!--            const checkbox = document.getElementById('isToggledCheckbox');-->
-        <!--            if(!checkbox.checked) checkbox.value = 'N';-->
-        <!--            else checkbox.value = 'Y';-->
-        <!--            document.getElementById('filter-form').submit();-->
-        <!--        }-->
-        <!--    </script>-->
-        <script> // toggle + sorting
-        function updateCheckboxValueAndSubmit() {
-            const checkbox = document.getElementById('isToggledCheckbox');
-            const form = document.getElementById('filter-and-sort-form');
-            // 체크박스가 체크된 상태를 확인
-            checkbox.value = checkbox.checked ? 'Y' : 'N';
-            // 폼 제출
-            form.submit();
+            </aside>
+            <!--    <script>-->
+            <!--        function toggleCheckboxValue() {-->
+            <!--            const checkbox = document.getElementById('isToggledCheckbox');-->
+            <!--            if(!checkbox.checked) checkbox.value = 'N';-->
+            <!--            else checkbox.value = 'Y';-->
+            <!--            document.getElementById('filter-form').submit();-->
+            <!--        }-->
+            <!--    </script>-->
+            <script> // toggle + sorting
+            function updateCheckboxValueAndSubmit() {
+                const checkbox = document.getElementById('isToggledCheckbox');
+                const form = document.getElementById('filter-and-sort-form');
+                // 체크박스가 체크된 상태를 확인
+                checkbox.value = checkbox.checked ? 'Y' : 'N';
+                // 폼 제출
+                form.submit();
+            }
+
+            function submitForm() {
+                document.getElementById('filter-and-sort-form').submit();
+            }
+            </script>
+            <style>
+                .form-select {
+                background-color : #FCFCFC;
+                border : none;
+                width : 100%;
+                height : 50px;
+                }
+                select {
+                color : #828282;
+                }
+                .form-control {
+                background-color : #FCFCFC;
+                border : none;
+                width : 100%;
+                height : 50px;
+                }
+
+
+                .form-control::placeholder {
+                color : #BBBBBB;
+                }
+
+                .date-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            background-color: #8E4B6E;
+            color: white;
+            border-radius: 10px;
+            text-align:center;
+            font-family: "Work Sans", sans-serif;
         }
 
-        function submitForm() {
-            document.getElementById('filter-and-sort-form').submit();
+        .month {
+            font-size: 1.1rem; /* M의 크기를 설정 */
+            font-weight: 550;
+            line-height: 1;
         }
-        </script>
-        <style>
-            .form-select {
-            background-color : #FCFCFC;
-            border : none;
-            width : 100%;
-            height : 50px;
-            }
-            select {
-            color : #828282;
-            }
-            .form-control {
-            background-color : #FCFCFC;
-            border : none;
-            width : 100%;
-            height : 50px;
-            }
 
+        .year {
+            font-size: 0.65rem; /* yyyy의 크기를 설정 */
+            font-weight: 400;
+        }
+        :root {
+            --background-color-light: #FFFFFF;
+            --text-color-light: #000000;
+            --toggle-background-light: #CCCCCC;
+            --toggle-ball-light: #FFFFFF;
 
-            .form-control::placeholder {
-            color : #BBBBBB;
-            }
+            --background-color-dark: #333333;
+            --text-color-dark: #FFFFFF;
+            --toggle-background-dark: #03C75A;
+            --toggle-ball-dark: #FFFFFF;
 
-            .date-container {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        background-color: #8E4B6E;
-        color: white;
-        border-radius: 10px;
-        text-align:center;
-        font-family: "Work Sans", sans-serif;
-    }
-
-    .month {
-        font-size: 1.1rem; /* M의 크기를 설정 */
-        font-weight: 550;
-        line-height: 1;
-    }
-
-    .year {
-        font-size: 0.65rem; /* yyyy의 크기를 설정 */
-        font-weight: 400;
-    }
-    :root {
-        --background-color-light: #FFFFFF;
-        --text-color-light: #000000;
-        --toggle-background-light: #CCCCCC;
-        --toggle-ball-light: #FFFFFF;
-
-        --background-color-dark: #333333;
-        --text-color-dark: #FFFFFF;
-        --toggle-background-dark: #03C75A;
-        --toggle-ball-dark: #FFFFFF;
-
-        --font-size-base: 32px; /* 기본 텍스트 크기 */
-        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
-    }
+            --font-size-base: 32px; /* 기본 텍스트 크기 */
+            --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+        }
 
 
 
-    .toggle-switch {
-        position: relative;
-        display: inline-block;
-        width: 62px; /* 너비 조정 */
-        height: 38px; /* 높이 조정 */
-    }
+        .toggle-switch {
+            position: relative;
+            display: inline-block;
+            width: 62px; /* 너비 조정 */
+            height: 38px; /* 높이 조정 */
+        }
 
-    .toggle-switch .checkbox {
-        opacity: 0;
-        width: 0;
-        height: 0;
-    }
-    #isToggledCheckbox {
-         opacity: 0;
+        .toggle-switch .checkbox {
+            opacity: 0;
             width: 0;
             height: 0;
-    }
+        }
+        #isToggledCheckbox {
+             opacity: 0;
+                width: 0;
+                height: 0;
+        }
 
-    .toggle-switch .label {
-        position: absolute;
-        cursor: pointer;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background-color: var(--toggle-background-light);
-        transition: background-color 0.4s;
-        border-radius: 38px; /* 둥근 모서리 반경 조정 */
-    }
+        .toggle-switch .label {
+            position: absolute;
+            cursor: pointer;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: var(--toggle-background-light);
+            transition: background-color 0.4s;
+            border-radius: 38px; /* 둥근 모서리 반경 조정 */
+        }
 
-    .toggle-switch .label:before {
-        position: absolute;
-        content: "";
-        height: 30px; /* 내부 원 높이 조정 */
-        width: 30px; /* 내부 원 너비 조정 */
-        left: 2px;
-        bottom: 0px;
-        background-color: var(--toggle-ball-light);
-        transition: transform 0.4s;
-        border-radius: 50%;
-    }
+        .toggle-switch .label:before {
+            position: absolute;
+            content: "";
+            height: 30px; /* 내부 원 높이 조정 */
+            width: 30px; /* 내부 원 너비 조정 */
+            left: 2px;
+            bottom: 0px;
+            background-color: var(--toggle-ball-light);
+            transition: transform 0.4s;
+            border-radius: 50%;
+        }
 
-    .toggle-switch input:checked + .label {
-        background-color: var(--toggle-background-dark);
-    }
+        .toggle-switch input:checked + .label {
+            background-color: var(--toggle-background-dark);
+        }
 
-    .toggle-switch input:checked + .label:before {
-        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
-    }
+        .toggle-switch input:checked + .label:before {
+            transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+        }
 
-             #absdiv {
-                position: relative;
-                top: 60px; /* Move down by 20px from its current position */
-                z-index : 1000;
-            }
+                 #absdiv {
+                    position: relative;
+                    top: 60px; /* Move down by 20px from its current position */
+                    z-index : 1000;
+                }
 
-            #searchbutton {
-                background-color: #828282;
-            }
-        </style>
-        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
-              rel="stylesheet">
-        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
-              rel="stylesheet">
-        <div class="col-md-9">
-            <div class="row" style="color: #828282;">
-                <div class="col-11">
-                    <div class="row">
-                        <div class="col-12 p-0">
-                            <style>
-                                .col-4 select {
-                                    border-radius: 50px;
-                                    text-align: center;
-                                }
-                                /* 검색창 스타일 */
-                                .search-container {
-                                    width: 300px;
-                                }
+                #searchbutton {
+                    background-color: #828282;
+                }
+            </style>
+            <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+                  rel="stylesheet">
+            <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+                  rel="stylesheet">
+            <div class="col-md-9">
+                <div class="row" style="color: #828282;">
+                    <div class="col-11">
+                        <div class="row">
+                            <div class="col-12 p-0">
+                                <style>
+                                    .col-4 select {
+                                        border-radius: 50px;
+                                        text-align: center;
+                                    }
+                                    /* 검색창 스타일 */
+                                    .search-container {
+                                        width: 300px;
+                                    }
 
-                                .search-container select {
-                                    position: absolute;
-                                    left: 0%;
-                                    width: 30%;
-                                    height: 50px;
-                                    color: #828282;
-                                    font-size: 1rem;
-                                    border-radius: 50px 0 0 50px;
-                                    outline: none;
-                                }
-                                .search-container input[type="text"] {
-                                    position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
-                                    left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
-                                    width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
-                                    height: 50px;
-                                    padding: 10px 40px 10px 15px;
-                                    font-size: 1rem;
-                                    outline: none;
-                                    border-radius: 0 50px 50px 0;
-                                    transition: border-color 0.3s, background-color 0.3s;
-                                    color: #828282; /* 입력 텍스트 색상 변경 */
-                                }
+                                    .search-container select {
+                                        position: absolute;
+                                        left: 0%;
+                                        width: 30%;
+                                        height: 50px;
+                                        color: #828282;
+                                        font-size: 1rem;
+                                        border-radius: 50px 0 0 50px;
+                                        outline: none;
+                                    }
+                                    .search-container input[type="text"] {
+                                        position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
+                                        left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
+                                        width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
+                                        height: 50px;
+                                        padding: 10px 40px 10px 15px;
+                                        font-size: 1rem;
+                                        outline: none;
+                                        border-radius: 0 50px 50px 0;
+                                        transition: border-color 0.3s, background-color 0.3s;
+                                        color: #828282; /* 입력 텍스트 색상 변경 */
+                                    }
 
-                                .search-container input[type="text"]::placeholder {
-                                    color: #BBBBBB; /* placeholder 색상 변경 */
-                                }
+                                    .search-container input[type="text"]::placeholder {
+                                        color: #BBBBBB; /* placeholder 색상 변경 */
+                                    }
 
 
-                                .search-container button {
-                                    position: absolute;
-                                    right: 1rem;
-                                    top: 25px;
-                                    background: none;
-                                    transform: translateY(-50%);
-                                    border: none;
-                                    cursor: pointer;
-                                }
+                                    .search-container button {
+                                        position: absolute;
+                                        right: 1rem;
+                                        top: 25px;
+                                        background: none;
+                                        transform: translateY(-50%);
+                                        border: none;
+                                        cursor: pointer;
+                                    }
 
-                                .search-container button i {
-                                    color: #A6AAB5;
-                                }
+                                    .search-container button i {
+                                        color: #A6AAB5;
+                                    }
 
-                                .search-container button:hover i {
-                                    color: #03C75A;
-                                }
-                            </style>
-                            <form id="filter-and-sort-form" th:action="@{/user/my/rct/apply}" method="get">
-                                <div class="row m-0">
-                                    <div class="col-7 p-0">
-                                        <div class="row justify-content-start m-0">
-                                            <div class="col-12 p-0">
-                                                <div class="search-container">
-                                                    <select class="form-select px-3" name="searchBy">
-                                                        <option value="title" th:selected="${searchBy == 'title'}">
-                                                            지원서제목
+                                    .search-container button:hover i {
+                                        color: #03C75A;
+                                    }
+                                </style>
+                                <form id="filter-and-sort-form" th:action="@{/user/my/rct/apply}" method="get">
+                                    <div class="row m-0">
+                                        <div class="col-7 p-0">
+                                            <div class="row justify-content-start m-0">
+                                                <div class="col-12 p-0">
+                                                    <div class="search-container">
+                                                        <select class="form-select px-3" name="searchBy">
+                                                            <option value="title" th:selected="${searchBy == 'title'}">
+                                                                지원서제목
+                                                            </option>
+                                                            <option value="content"
+                                                                    th:selected="${searchBy == 'content'}">
+                                                                지원서내용
+                                                            </option>
+                                                            <option value="jTitle"
+                                                                    th:selected="${searchBy == 'jTitle'}">
+                                                                공고제목
+                                                            </option>
+                                                            <option value="jContent"
+                                                                    th:selected="${searchBy == 'jContent'}">공고내용
+                                                            </option>
+                                                            <option value="jLocation"
+                                                                    th:selected="${searchBy == 'jLocation'}">근무지
+                                                            </option>
+                                                            <!--                        <option value="jWriter" th:selected="${searchBy == 'jWriter'}">공고작성자</option>-->
+                                                        </select>
+                                                        <input class="form-control px-3" type="text" name="searchTerm"
+                                                               placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
+                                                        <!-- 검색 버튼 -->
+                                                        <button type="submit">
+                                                            <i class="fas fa-search"></i>
+                                                        </button>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="col-1" style=""></div>
+                                        <div class="col-4">
+                                            <div class="row justify-content-end">
+                                                <!-- 정렬 또는 토글2 -->
+                                                <label>
+                                                    <select class="form-select px-3" name="orderBy"
+                                                            onchange="submitForm()">
+                                                        <option value="recentApplication"
+                                                                th:selected="${orderBy == 'recentApplication'}">지원최근순
                                                         </option>
-                                                        <option value="content" th:selected="${searchBy == 'content'}">
-                                                            지원서내용
+                                                        <option value="oldestApplication"
+                                                                th:selected="${orderBy == 'oldestApplication'}">오래된순
                                                         </option>
-                                                        <option value="jTitle" th:selected="${searchBy == 'jTitle'}">
-                                                            공고제목
+
+                                                        <option value="recentedited"
+                                                                th:selected="${orderBy == 'recentedited'}">공고최근수정순
                                                         </option>
-                                                        <option value="jContent"
-                                                                th:selected="${searchBy == 'jContent'}">공고내용
+                                                        <option value="recent" th:selected="${orderBy == 'recent'}">
+                                                            공고최근작성순
                                                         </option>
-                                                        <option value="jLocation"
-                                                                th:selected="${searchBy == 'jLocation'}">근무지
+                                                        <option value="oldest" th:selected="${orderBy == 'oldest'}">
+                                                            공고오래된순
                                                         </option>
-                                                        <!--                        <option value="jWriter" th:selected="${searchBy == 'jWriter'}">공고작성자</option>-->
+                                                        <option value="dueSoon" th:selected="${orderBy == 'dueSoon'}">
+                                                            마감임박순
+                                                        </option>
+                                                        <option value="title" th:selected="${orderBy == 'title'}">
+                                                            공고제목가나다순
+                                                        </option>
                                                     </select>
-                                                    <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
-                                                    <!-- 검색 버튼 -->
-                                                    <button type="submit">
-                                                        <i class="fas fa-search"></i>
-                                                    </button>
+                                                </label>
+                                            </div>
+                                        </div>
+                                    </div> <!--검색, 소팅 (토글X)-->
+                                    <div class="row justify-content-around">
+                                        <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                        <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                        <div class="col-3" style="padding: 0 1.2rem;">
+                                            <div id="absdiv" class="row justify-content-end">
+                                                <div class="col-3">
+                                                    <div class="toggle-switch">
+                                                        <!-- 정렬 또는 토글1 -->
+                                                        <input type="checkbox" name="isToggled" id="isToggledCheckbox"
+                                                               value="Y" th:checked="${isToggled == 'Y'}"
+                                                               onchange="updateCheckboxValueAndSubmit()">
+                                                        <label for="isToggledCheckbox" class="label">
+                                                            <div class="ball"></div>
+                                                        </label>
+                                                    </div>
+                                                </div>
+                                                <div class="col-8"
+                                                     style="text-align: right; padding: 0px; margin : 0px;">
+                                                    마감된 공고
                                                 </div>
                                             </div>
                                         </div>
-                                    </div>
-                                    <div class="col-1" style=""></div>
-                                    <div class="col-4">
-                                        <div class="row justify-content-end">
-                                            <!-- 정렬 또는 토글2 -->
-                                            <label>
-                                                <select class="form-select px-3" name="orderBy" onchange="submitForm()">
-                                                    <option value="recentApplication"
-                                                            th:selected="${orderBy == 'recentApplication'}">지원최근순
-                                                    </option>
-                                                    <option value="oldestApplication"
-                                                            th:selected="${orderBy == 'oldestApplication'}">오래된순
-                                                    </option>
-
-                                                    <option value="recentedited"
-                                                            th:selected="${orderBy == 'recentedited'}">공고최근수정순
-                                                    </option>
-                                                    <option value="recent" th:selected="${orderBy == 'recent'}">
-                                                        공고최근작성순
-                                                    </option>
-                                                    <option value="oldest" th:selected="${orderBy == 'oldest'}">공고오래된순
-                                                    </option>
-                                                    <option value="dueSoon" th:selected="${orderBy == 'dueSoon'}">
-                                                        마감임박순
-                                                    </option>
-                                                    <option value="title" th:selected="${orderBy == 'title'}">공고제목가나다순
-                                                    </option>
-                                                </select>
-                                            </label>
-                                        </div>
-                                    </div>
-                                </div> <!--검색, 소팅 (토글X)-->
-                                <div class="row justify-content-around">
-                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                    <div class="col-3" style="padding: 0 1.2rem;">
-                                        <div id="absdiv" class="row justify-content-end">
-                                            <div class="col-3">
-                                                <div class="toggle-switch">
-                                                    <!-- 정렬 또는 토글1 -->
-                                                    <input type="checkbox" name="isToggled" id="isToggledCheckbox"
-                                                           value="Y" th:checked="${isToggled == 'Y'}"
-                                                           onchange="updateCheckboxValueAndSubmit()">
-                                                    <label for="isToggledCheckbox" class="label">
-                                                        <div class="ball"></div>
-                                                    </label>
+                                    </div> <!--토글-->
+                                </form>
+                            </div>
+                        </div>
+                        <div class="row justify-content-around">
+                            <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
+                                <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
+                                    <div class="col-3 clickable-row"
+                                         style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                         th:each="myRctApplication, iterStat : ${myRctApplications}"
+                                         th:attr="data-href=@{/recruit/job/applyView(no=${myRctApplication.applyNo})}"
+                                         th:if="${iterStat.index < 3}">
+                                        <div class="row justify-content-center">
+                                            <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                                 style="aspect-ratio: 1; border-radius: 5px;">
+                                                <div class="date-container px-2 py-1">
+                                                    <div class="month"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctApplication.applyCreatedDate)}"></div>
+                                                    <div class="year"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctApplication.applyCreatedDate)}"></div>
                                                 </div>
                                             </div>
-                                            <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">
-                                                마감된 공고
+
+                                            <div class="col-4" style="color: white;"
+                                                 th:text="${myRctApplication.applyNo}">
+                                                닉네임
+                                            </div>
+                                            <div class="col-4"
+                                                 style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD;"
+                                                 th:text="${myRctApplication.formattedApplyCreatedDate}">시간
                                             </div>
                                         </div>
-                                    </div>
-                                </div> <!--토글-->
-                            </form>
-                        </div>
-                    </div>
-                    <div class="row justify-content-around">
-                        <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
-                            <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
-                                <div class="col-3 clickable-row"
-                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
-                                     th:each="myRctApplication, iterStat : ${myRctApplications}"
-                                     th:attr="data-href=@{/recruit/job/applyView(no=${myRctApplication.applyNo})}"
-                                     th:if="${iterStat.index < 3}">
-                                    <div class="row justify-content-center">
-                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
-                                             style="aspect-ratio: 1; border-radius: 5px;">
-                                            <div class="date-container px-2 py-1">
-                                                <div class="month"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctApplication.applyCreatedDate)}"></div>
-                                                <div class="year"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctApplication.applyCreatedDate)}"></div>
+                                        <div class="row justify-content-center">
+                                            <div class="col-10" style="color: white;"
+                                                 th:text="${myRctApplication.applyNo}">
+                                                사진
                                             </div>
                                         </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                                 th:text="${myRctApplication.jobTitle}">이름
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                                 th:text="${myRctApplication.applyTitle}">내용
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                        </div>
 
-                                        <div class="col-4" style="color: white;" th:text="${myRctApplication.applyNo}">
-                                            닉네임
-                                        </div>
-                                        <div class="col-4"
-                                             style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD;"
-                                             th:text="${myRctApplication.formattedApplyCreatedDate}">시간
-                                        </div>
                                     </div>
-                                    <div class="row justify-content-center">
-                                        <div class="col-10" style="color: white;" th:text="${myRctApplication.applyNo}">
-                                            사진
-                                        </div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
-                                             th:text="${myRctApplication.jobTitle}">이름
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
-                                             th:text="${myRctApplication.applyTitle}">내용
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                    </div>
-
+                                    <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
+                                    <div class="col-3" th:if="${myRctApplications.size() == 0}"></div>
+                                    <div class="col-3"
+                                         th:if="${myRctApplications.size() == 0 || myRctApplications.size() == 1}"></div>
+                                    <div class="col-3"
+                                         th:if="${myRctApplications.size() == 0 || myRctApplications.size() == 1 || myRctApplications.size() == 2}"></div>
                                 </div>
-                                <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
-                                <div class="col-3" th:if="${myRctApplications.size() == 0}"></div>
-                                <div class="col-3"
-                                     th:if="${myRctApplications.size() == 0 || myRctApplications.size() == 1}"></div>
-                                <div class="col-3"
-                                     th:if="${myRctApplications.size() == 0 || myRctApplications.size() == 1 || myRctApplications.size() == 2}"></div>
-                            </div>
-                            <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
-                                <div class="col-3 clickable-row"
-                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
-                                     th:each="myRctApplication, iterStat : ${myRctApplications}"
-                                     th:attr="data-href=@{/recruit/job/applyView(no=${myRctApplication.applyNo})}"
-                                     th:if="${iterStat.index >= 3}">
-                                    <div class="row justify-content-center">
-                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
-                                             style="aspect-ratio: 1; border-radius: 5px;">
-                                            <div class="date-container px-2 py-1">
-                                                <div class="month"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctApplication.applyCreatedDate)}"></div>
-                                                <div class="year"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctApplication.applyCreatedDate)}"></div>
+                                <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
+                                    <div class="col-3 clickable-row"
+                                         style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                         th:each="myRctApplication, iterStat : ${myRctApplications}"
+                                         th:attr="data-href=@{/recruit/job/applyView(no=${myRctApplication.applyNo})}"
+                                         th:if="${iterStat.index >= 3}">
+                                        <div class="row justify-content-center">
+                                            <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                                 style="aspect-ratio: 1; border-radius: 5px;">
+                                                <div class="date-container px-2 py-1">
+                                                    <div class="month"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctApplication.applyCreatedDate)}"></div>
+                                                    <div class="year"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctApplication.applyCreatedDate)}"></div>
+                                                </div>
+                                            </div>
+
+                                            <div class="col-4" style="color: white;"
+                                                 th:text="${myRctApplication.applyNo}">
+                                                닉네임
+                                            </div>
+                                            <div class="col-4"
+                                                 style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD;"
+                                                 th:text="${myRctApplication.formattedApplyCreatedDate}">시간
                                             </div>
                                         </div>
+                                        <div class="row justify-content-center">
+                                            <div class="col-10" style="color: white;"
+                                                 th:text="${myRctApplication.applyNo}">
+                                                사진
+                                            </div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                                 th:text="${myRctApplication.jobTitle}">이름
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                                 th:text="${myRctApplication.applyTitle}">내용
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                        </div>
 
-                                        <div class="col-4" style="color: white;" th:text="${myRctApplication.applyNo}">
-                                            닉네임
-                                        </div>
-                                        <div class="col-4"
-                                             style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD;"
-                                             th:text="${myRctApplication.formattedApplyCreatedDate}">시간
-                                        </div>
-                                    </div>
-                                    <div class="row justify-content-center">
-                                        <div class="col-10" style="color: white;" th:text="${myRctApplication.applyNo}">
-                                            사진
-                                        </div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
-                                             th:text="${myRctApplication.jobTitle}">이름
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
-                                             th:text="${myRctApplication.applyTitle}">내용
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
                                     </div>
 
+                                    <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
+                                    <div class="col-3" th:if="${myRctApplications.size() <= 3}"></div>
+                                    <div class="col-3"
+                                         th:if="${myRctApplications.size() <= 3 || myRctApplications.size() == 4}"></div>
+                                    <div class="col-3"
+                                         th:if="${myRctApplications.size() <= 3 || myRctApplications.size() == 4 || myRctApplications.size() == 5}"></div>
                                 </div>
-
-                                <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
-                                <div class="col-3" th:if="${myRctApplications.size() <= 3}"></div>
-                                <div class="col-3"
-                                     th:if="${myRctApplications.size() <= 3 || myRctApplications.size() == 4}"></div>
-                                <div class="col-3"
-                                     th:if="${myRctApplications.size() <= 3 || myRctApplications.size() == 4 || myRctApplications.size() == 5}"></div>
                             </div>
                         </div>
-                    </div>
-                    <div class="row justify-content-center">
-                        <!-- 페이징 -->
-                        <th:block th:if="${pages != null}">
-                            <div class="d-flex justify-content-center">
-                                <div class="btn-group">
-                                    <button type="button" class="btn btn-sm previous"
-                                            th:onclick="|location.href='@{/user/my/rct/apply(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
-                                            th:disabled="${currentPage == 1}">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                             fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-                                            <path fill-rule="evenodd"
-                                                  d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                                        </svg>
-                                    </button>
-                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">
-                                        <button type="button" class="btn btn-sm me-2 pages"
-                                                th:text="${p}"
-                                                th:onclick="|location.href='@{/user/my/rct/apply(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
-                                    </th:block>
-                                    <button type="button" class="btn btn-sm  next"
-                                            th:onclick="|location.href='@{/user/my/rct/apply(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
-                                            th:disabled="${currentPage == pages}">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                             fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-                                            <path fill-rule="evenodd"
-                                                  d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
-                                        </svg>
-                                    </button>
+                        <div class="row justify-content-center">
+                            <!-- 페이징 -->
+                            <th:block th:if="${pages != null}">
+                                <div class="d-flex justify-content-center">
+                                    <div class="btn-group">
+                                        <button type="button" class="btn btn-sm previous"
+                                                th:onclick="|location.href='@{/user/my/rct/apply(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
+                                                th:disabled="${currentPage == 1}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                                 fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+                                                <path fill-rule="evenodd"
+                                                      d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                                            </svg>
+                                        </button>
+                                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">
+                                            <button type="button" class="btn btn-sm me-2 pages"
+                                                    th:text="${p}"
+                                                    th:onclick="|location.href='@{/user/my/rct/apply(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
+                                        </th:block>
+                                        <button type="button" class="btn btn-sm  next"
+                                                th:onclick="|location.href='@{/user/my/rct/apply(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
+                                                th:disabled="${currentPage == pages}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                                 fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+                                                <path fill-rule="evenodd"
+                                                      d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                                            </svg>
+                                        </button>
+                                    </div>
                                 </div>
-                            </div>
-                        </th:block>
-                    </div>
-                </div><!--테이블 및 페이징 포함-->
+                            </th:block>
+                        </div>
+                    </div><!--테이블 및 페이징 포함-->
+                </div> <!--본화면-->
             </div> <!--본화면-->
-        </div> <!--본화면-->
 
 
-        <!--수정전-->
-        <!--    <div class="col-md-9">-->
-        <!--        <div class="review-list">-->
-        <!--            <h2>나의 지원서 관리</h2>-->
-        <!--            <form id="filter-and-sort-form" th:action="@{/user/my/rct/apply}" method="get">-->
-        <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
-        <!--                <label>-->
-        <!--                    <select name="searchBy">-->
-        <!--                        <option value="title" th:selected="${searchBy == 'title'}">지원서제목</option>-->
-        <!--                        <option value="content" th:selected="${searchBy == 'content'}">지원서내용</option>-->
-        <!--                        <option value="jTitle" th:selected="${searchBy == 'jTitle'}">공고제목</option>-->
-        <!--                        <option value="jContent" th:selected="${searchBy == 'jContent'}">공고내용</option>-->
-        <!--                        <option value="jLocation" th:selected="${searchBy == 'jLocation'}">근무지</option>-->
-        <!--&lt;!&ndash;                        <option value="jWriter" th:selected="${searchBy == 'jWriter'}">공고작성자</option>&ndash;&gt;-->
-        <!--                    </select>-->
-        <!--                </label>-->
-        <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
+            <!--수정전-->
+            <!--    <div class="col-md-9">-->
+            <!--        <div class="review-list">-->
+            <!--            <h2>나의 지원서 관리</h2>-->
+            <!--            <form id="filter-and-sort-form" th:action="@{/user/my/rct/apply}" method="get">-->
+            <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
+            <!--                <label>-->
+            <!--                    <select name="searchBy">-->
+            <!--                        <option value="title" th:selected="${searchBy == 'title'}">지원서제목</option>-->
+            <!--                        <option value="content" th:selected="${searchBy == 'content'}">지원서내용</option>-->
+            <!--                        <option value="jTitle" th:selected="${searchBy == 'jTitle'}">공고제목</option>-->
+            <!--                        <option value="jContent" th:selected="${searchBy == 'jContent'}">공고내용</option>-->
+            <!--                        <option value="jLocation" th:selected="${searchBy == 'jLocation'}">근무지</option>-->
+            <!--&lt;!&ndash;                        <option value="jWriter" th:selected="${searchBy == 'jWriter'}">공고작성자</option>&ndash;&gt;-->
+            <!--                    </select>-->
+            <!--                </label>-->
+            <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
 
-        <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
-        <!--                <button type="submit">검색</button>-->
+            <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
+            <!--                <button type="submit">검색</button>-->
 
-        <!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
-        <!--                <label>-->
-        <!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">마감된 공고-->
-        <!--                </label>-->
+            <!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
+            <!--                <label>-->
+            <!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">마감된 공고-->
+            <!--                </label>-->
 
-        <!--                <label>-->
-        <!--                    <select name="orderBy" onchange="submitForm()">-->
-        <!--                        <option value="recentApplication" th:selected="${orderBy == 'recentApplication'}">지원최근순</option>-->
-        <!--                        <option value="oldestApplication" th:selected="${orderBy == 'oldestApplication'}">오래된순</option>-->
+            <!--                <label>-->
+            <!--                    <select name="orderBy" onchange="submitForm()">-->
+            <!--                        <option value="recentApplication" th:selected="${orderBy == 'recentApplication'}">지원최근순</option>-->
+            <!--                        <option value="oldestApplication" th:selected="${orderBy == 'oldestApplication'}">오래된순</option>-->
 
-        <!--                        <option value="recentedited" th:selected="${orderBy == 'recentedited'}">공고최근수정순</option>-->
-        <!--                        <option value="recent" th:selected="${orderBy == 'recent'}">공고최근작성순</option>-->
-        <!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">공고오래된순</option>-->
-        <!--                        <option value="dueSoon" th:selected="${orderBy == 'dueSoon'}">마감임박순</option>-->
-        <!--                        <option value="title" th:selected="${orderBy == 'title'}">공고제목가나다순</option>-->
-        <!--                    </select>-->
-        <!--                </label>-->
-        <!--            </form>-->
-        <!--&lt;!&ndash;            <form id="filter-form" th:action="@{/user/my/rct/apply}" method="get">&ndash;&gt;-->
-        <!--&lt;!&ndash;                <label>&ndash;&gt;-->
-        <!--&lt;!&ndash;                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="toggleCheckboxValue()">마감된 공고&ndash;&gt;-->
-        <!--&lt;!&ndash;                </label>&ndash;&gt;-->
-        <!--&lt;!&ndash;            </form>&ndash;&gt;-->
-        <!--            <table>-->
-        <!--                <thead>-->
-        <!--                <tr>-->
-        <!--                    <th>지원글 번호</th>-->
-        <!--                    <th>게시글 번호</th>-->
-        <!--                    <th>지원자</th>-->
-        <!--                    <th>제목</th>-->
-        <!--                    <th>내용</th>-->
-        <!--                    <th>이미지</th>-->
-        <!--                    <th>작성 일자</th>-->
-        <!--                    <th>조회 여부</th>-->
+            <!--                        <option value="recentedited" th:selected="${orderBy == 'recentedited'}">공고최근수정순</option>-->
+            <!--                        <option value="recent" th:selected="${orderBy == 'recent'}">공고최근작성순</option>-->
+            <!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">공고오래된순</option>-->
+            <!--                        <option value="dueSoon" th:selected="${orderBy == 'dueSoon'}">마감임박순</option>-->
+            <!--                        <option value="title" th:selected="${orderBy == 'title'}">공고제목가나다순</option>-->
+            <!--                    </select>-->
+            <!--                </label>-->
+            <!--            </form>-->
+            <!--&lt;!&ndash;            <form id="filter-form" th:action="@{/user/my/rct/apply}" method="get">&ndash;&gt;-->
+            <!--&lt;!&ndash;                <label>&ndash;&gt;-->
+            <!--&lt;!&ndash;                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="toggleCheckboxValue()">마감된 공고&ndash;&gt;-->
+            <!--&lt;!&ndash;                </label>&ndash;&gt;-->
+            <!--&lt;!&ndash;            </form>&ndash;&gt;-->
+            <!--            <table>-->
+            <!--                <thead>-->
+            <!--                <tr>-->
+            <!--                    <th>지원글 번호</th>-->
+            <!--                    <th>게시글 번호</th>-->
+            <!--                    <th>지원자</th>-->
+            <!--                    <th>제목</th>-->
+            <!--                    <th>내용</th>-->
+            <!--                    <th>이미지</th>-->
+            <!--                    <th>작성 일자</th>-->
+            <!--                    <th>조회 여부</th>-->
 
-        <!--                    <th>작성자</th>-->
-        <!--                    <th>제목</th>-->
-        <!--                    <th>내용</th>-->
-        <!--                    <th>근무지</th>-->
-        <!--                    <th>이미지</th>-->
-        <!--                    <th>작성 일자</th>-->
-        <!--                    <th>수정 일자</th>-->
-        <!--                    <th>마감 일자</th>-->
-        <!--                </tr>-->
-        <!--                </thead>-->
-        <!--                <tbody>-->
-        <!--                <tr th:each="myRctApplication : ${myRctApplications}" class="clickable-row" th:attr="data-href=@{/recruit/job/applyView(no=${myRctApplication.applyNo})}">-->
-        <!--                    <td th:text="${myRctApplication.applyNo}">지원글 번호</td>-->
-        <!--                    <td th:text="${myRctApplication.boardNo}">게시글 번호</td>-->
-        <!--                    <td th:text="${myRctApplication.writer}">지원자</td>-->
-        <!--                    <td th:text="${myRctApplication.applyTitle}">제목</td>-->
-        <!--                    <td th:text="${myRctApplication.applyContent}">내용</td>-->
-        <!--                    <td th:text="${myRctApplication.applyImg}">이미지</td>-->
-        <!--                    <td th:text="${myRctApplication.applyCreatedDate}">작성 일자</td>-->
-        <!--                    <td th:text="${myRctApplication.applyCheckStatus}">조회 여부</td>-->
+            <!--                    <th>작성자</th>-->
+            <!--                    <th>제목</th>-->
+            <!--                    <th>내용</th>-->
+            <!--                    <th>근무지</th>-->
+            <!--                    <th>이미지</th>-->
+            <!--                    <th>작성 일자</th>-->
+            <!--                    <th>수정 일자</th>-->
+            <!--                    <th>마감 일자</th>-->
+            <!--                </tr>-->
+            <!--                </thead>-->
+            <!--                <tbody>-->
+            <!--                <tr th:each="myRctApplication : ${myRctApplications}" class="clickable-row" th:attr="data-href=@{/recruit/job/applyView(no=${myRctApplication.applyNo})}">-->
+            <!--                    <td th:text="${myRctApplication.applyNo}">지원글 번호</td>-->
+            <!--                    <td th:text="${myRctApplication.boardNo}">게시글 번호</td>-->
+            <!--                    <td th:text="${myRctApplication.writer}">지원자</td>-->
+            <!--                    <td th:text="${myRctApplication.applyTitle}">제목</td>-->
+            <!--                    <td th:text="${myRctApplication.applyContent}">내용</td>-->
+            <!--                    <td th:text="${myRctApplication.applyImg}">이미지</td>-->
+            <!--                    <td th:text="${myRctApplication.applyCreatedDate}">작성 일자</td>-->
+            <!--                    <td th:text="${myRctApplication.applyCheckStatus}">조회 여부</td>-->
 
-        <!--                    <td th:text="${myRctApplication.jobWriter}">작성자</td>-->
-        <!--                    <td th:text="${myRctApplication.jobTitle}">제목</td>-->
-        <!--                    <td th:text="${myRctApplication.jobContent}">내용</td>-->
-        <!--                    <td th:text="${myRctApplication.jobLocation}">근무지</td>-->
-        <!--                    <td th:text="${myRctApplication.jobImg}">이미지</td>-->
-        <!--                    <td th:text="${myRctApplication.jobCreatedDate}">작성 일자</td>-->
-        <!--                    <td th:text="${myRctApplication.jobModifiedDate}">수정 일자</td>-->
-        <!--                    <td th:text="${myRctApplication.jobDeadLine}">마감 일자</td>-->
-        <!--                </tr>-->
-        <!--                </tbody>-->
-        <!--            </table>-->
-        <!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
-        <!--            <th:block th:if="${pages != null}">-->
-        <!--                <div class="d-flex justify-content-center">-->
-        <!--                    <div class="btn-group">-->
-        <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/rct/apply(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
-        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
-        <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
-        <!--                            </svg>-->
-        <!--                        </button>-->
-        <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
-        <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
-        <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/rct/apply(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
-        <!--                        </th:block>-->
-        <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/rct/apply(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
-        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
-        <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
-        <!--                            </svg>-->
-        <!--                        </button>-->
-        <!--                    </div>-->
-        <!--                </div>-->
-        <!--            </th:block>-->
-        <!--        </div>-->
-        <!--    </div>-->
+            <!--                    <td th:text="${myRctApplication.jobWriter}">작성자</td>-->
+            <!--                    <td th:text="${myRctApplication.jobTitle}">제목</td>-->
+            <!--                    <td th:text="${myRctApplication.jobContent}">내용</td>-->
+            <!--                    <td th:text="${myRctApplication.jobLocation}">근무지</td>-->
+            <!--                    <td th:text="${myRctApplication.jobImg}">이미지</td>-->
+            <!--                    <td th:text="${myRctApplication.jobCreatedDate}">작성 일자</td>-->
+            <!--                    <td th:text="${myRctApplication.jobModifiedDate}">수정 일자</td>-->
+            <!--                    <td th:text="${myRctApplication.jobDeadLine}">마감 일자</td>-->
+            <!--                </tr>-->
+            <!--                </tbody>-->
+            <!--            </table>-->
+            <!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
+            <!--            <th:block th:if="${pages != null}">-->
+            <!--                <div class="d-flex justify-content-center">-->
+            <!--                    <div class="btn-group">-->
+            <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/rct/apply(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
+            <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
+            <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
+            <!--                            </svg>-->
+            <!--                        </button>-->
+            <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
+            <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
+            <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/rct/apply(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
+            <!--                        </th:block>-->
+            <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/rct/apply(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
+            <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
+            <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
+            <!--                            </svg>-->
+            <!--                        </button>-->
+            <!--                    </div>-->
+            <!--                </div>-->
+            <!--            </th:block>-->
+            <!--        </div>-->
+            <!--    </div>-->
+        </div>
     </div>
 </div>
 <div th:replace="common/footer.html"></div>

--- a/src/main/resources/templates/user/mypage_rct_application.html
+++ b/src/main/resources/templates/user/mypage_rct_application.html
@@ -112,12 +112,12 @@
             <div class="col-md-9">
                 <nav class="navbar navbar-expand-md">
                     <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                        <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 등록 현황</a></li>
                         <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
                         <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2" style="color:#000;">나의 지원서 관리</a>
                         </li>
                         <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
                         <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
+                        <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보 수정</a></li>
                     </ul>
                 </nav>
             </div>

--- a/src/main/resources/templates/user/mypage_rct_application.html
+++ b/src/main/resources/templates/user/mypage_rct_application.html
@@ -104,20 +104,23 @@
   }
 </style>
 <div class="jumbotron">
-    <div class="row">
-        <div class="col-md-3 px-4">
-            <h3>나의 채용</h3>
-        </div>
-        <div class="col-md-9">
-            <nav class="navbar navbar-expand-md">
-                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                    <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
-                    <li><a th:href="@{/user/my/rct/creator}" class="nav-link px-2">창작자 등록 현황</a></li>
-                    <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2" style="color:#000;">나의 지원서 관리</a></li>
-                    <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
-                    <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
-                </ul>
-            </nav>
+    <div class="container">
+        <div class="row">
+            <div class="col-md-3 px-4">
+                <h3>나의 채용</h3>
+            </div>
+            <div class="col-md-9">
+                <nav class="navbar navbar-expand-md">
+                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                        <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
+                        <li><a th:href="@{/user/my/rct/creator}" class="nav-link px-2">창작자 등록 현황</a></li>
+                        <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2" style="color:#000;">나의 지원서 관리</a>
+                        </li>
+                        <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
+                        <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
+                    </ul>
+                </nav>
+            </div>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/user/mypage_rct_application.html
+++ b/src/main/resources/templates/user/mypage_rct_application.html
@@ -112,8 +112,8 @@
             <div class="col-md-9">
                 <nav class="navbar navbar-expand-md">
                     <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                        <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 등록 현황</a></li>
                         <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
-                        <li><a th:href="@{/user/my/rct/creator}" class="nav-link px-2">창작자 등록 현황</a></li>
                         <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2" style="color:#000;">나의 지원서 관리</a>
                         </li>
                         <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>

--- a/src/main/resources/templates/user/mypage_rct_application.html
+++ b/src/main/resources/templates/user/mypage_rct_application.html
@@ -135,7 +135,7 @@
         <aside class="col-md-3 px-4">
             <div class="row">
                 <div class="col-1"></div>
-                <div class="col-6">
+                <div class="col-8">
                     <div class="panel">
                         <ul class="list-group">
                             <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>

--- a/src/main/resources/templates/user/mypage_rct_application.html
+++ b/src/main/resources/templates/user/mypage_rct_application.html
@@ -106,20 +106,26 @@
 <div class="jumbotron">
     <div class="container">
         <div class="row">
-            <div class="col-md-3 px-4">
-                <h3>나의 채용</h3>
-            </div>
-            <div class="col-md-9">
-                <nav class="navbar navbar-expand-md">
-                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                        <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
-                        <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2" style="color:#000;">나의 지원서 관리</a>
-                        </li>
-                        <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
-                        <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
-                        <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보 수정</a></li>
-                    </ul>
-                </nav>
+            <div class="col-9">
+                <div class="row">
+                    <div class="col-md-3 px-4">
+                        <h3>나의 채용</h3>
+                    </div>
+                    <div class="col-md-9">
+                        <nav class="navbar navbar-expand-md">
+                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
+                                <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2" style="color:#000;">나의 지원서
+                                    관리</a>
+                                </li>
+                                <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
+                                <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
+                                <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보
+                                    수정</a></li>
+                            </ul>
+                        </nav>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/user/mypage_rct_application.html
+++ b/src/main/resources/templates/user/mypage_rct_application.html
@@ -124,33 +124,35 @@
         </div>
     </div>
 </div>
-<div class="row">
-    <aside class="col-md-3 px-4">
-        <div class="row">
-            <div class="col-3"></div>
-            <div class="col-6">
-                <div class="panel">
-                    <ul class="list-group">
-                        <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
-                        <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-                        <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color: #03C75A;">나의 채용</a></li>
-                        <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-                        <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                        <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-                    </ul>
+<div class="container" style="padding:0;">
+    <div class="row">
+        <aside class="col-md-3 px-4">
+            <div class="row">
+                <div class="col-3"></div>
+                <div class="col-6">
+                    <div class="panel">
+                        <ul class="list-group">
+                            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
+                            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color: #03C75A;">나의 채용</a>
+                            </li>
+                            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+                        </ul>
+                    </div>
                 </div>
             </div>
-        </div>
-    </aside>
-<!--    <script>-->
-<!--        function toggleCheckboxValue() {-->
-<!--            const checkbox = document.getElementById('isToggledCheckbox');-->
-<!--            if(!checkbox.checked) checkbox.value = 'N';-->
-<!--            else checkbox.value = 'Y';-->
-<!--            document.getElementById('filter-form').submit();-->
-<!--        }-->
-<!--    </script>-->
-    <script> // toggle + sorting
+        </aside>
+        <!--    <script>-->
+        <!--        function toggleCheckboxValue() {-->
+        <!--            const checkbox = document.getElementById('isToggledCheckbox');-->
+        <!--            if(!checkbox.checked) checkbox.value = 'N';-->
+        <!--            else checkbox.value = 'Y';-->
+        <!--            document.getElementById('filter-form').submit();-->
+        <!--        }-->
+        <!--    </script>-->
+        <script> // toggle + sorting
         function updateCheckboxValueAndSubmit() {
             const checkbox = document.getElementById('isToggledCheckbox');
             const form = document.getElementById('filter-and-sort-form');
@@ -163,408 +165,491 @@
         function submitForm() {
             document.getElementById('filter-and-sort-form').submit();
         }
-    </script>
-    <style>
-        .form-select {
-        background-color : #FCFCFC;
-        border : none;
-        width : 100%;
-        height : 50px;
-        }
-        select {
-        color : #828282;
-        }
-        .form-control {
-        background-color : #FCFCFC;
-        border : none;
-        width : 100%;
-        height : 50px;
-        }
+        </script>
+        <style>
+            .form-select {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
+            }
+            select {
+            color : #828282;
+            }
+            .form-control {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
+            }
 
 
-        .form-control::placeholder {
-        color : #BBBBBB;
-        }
+            .form-control::placeholder {
+            color : #BBBBBB;
+            }
 
-        .date-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    background-color: #8E4B6E;
-    color: white;
-    border-radius: 10px;
-    text-align:center;
-    font-family: "Work Sans", sans-serif;
-}
+            .date-container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        background-color: #8E4B6E;
+        color: white;
+        border-radius: 10px;
+        text-align:center;
+        font-family: "Work Sans", sans-serif;
+    }
 
-.month {
-    font-size: 1.1rem; /* M의 크기를 설정 */
-    font-weight: 550;
-    line-height: 1;
-}
+    .month {
+        font-size: 1.1rem; /* M의 크기를 설정 */
+        font-weight: 550;
+        line-height: 1;
+    }
 
-.year {
-    font-size: 0.65rem; /* yyyy의 크기를 설정 */
-    font-weight: 400;
-}
-:root {
-    --background-color-light: #FFFFFF;
-    --text-color-light: #000000;
-    --toggle-background-light: #CCCCCC;
-    --toggle-ball-light: #FFFFFF;
+    .year {
+        font-size: 0.65rem; /* yyyy의 크기를 설정 */
+        font-weight: 400;
+    }
+    :root {
+        --background-color-light: #FFFFFF;
+        --text-color-light: #000000;
+        --toggle-background-light: #CCCCCC;
+        --toggle-ball-light: #FFFFFF;
 
-    --background-color-dark: #333333;
-    --text-color-dark: #FFFFFF;
-    --toggle-background-dark: #03C75A;
-    --toggle-ball-dark: #FFFFFF;
+        --background-color-dark: #333333;
+        --text-color-dark: #FFFFFF;
+        --toggle-background-dark: #03C75A;
+        --toggle-ball-dark: #FFFFFF;
 
-    --font-size-base: 32px; /* 기본 텍스트 크기 */
-    --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
-}
+        --font-size-base: 32px; /* 기본 텍스트 크기 */
+        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+    }
 
 
 
-.toggle-switch {
-    position: relative;
-    display: inline-block;
-    width: 62px; /* 너비 조정 */
-    height: 38px; /* 높이 조정 */
-}
+    .toggle-switch {
+        position: relative;
+        display: inline-block;
+        width: 62px; /* 너비 조정 */
+        height: 38px; /* 높이 조정 */
+    }
 
-.toggle-switch .checkbox {
-    opacity: 0;
-    width: 0;
-    height: 0;
-}
-#isToggledCheckbox {
-     opacity: 0;
+    .toggle-switch .checkbox {
+        opacity: 0;
         width: 0;
         height: 0;
-}
+    }
+    #isToggledCheckbox {
+         opacity: 0;
+            width: 0;
+            height: 0;
+    }
 
-.toggle-switch .label {
-    position: absolute;
-    cursor: pointer;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: var(--toggle-background-light);
-    transition: background-color 0.4s;
-    border-radius: 38px; /* 둥근 모서리 반경 조정 */
-}
+    .toggle-switch .label {
+        position: absolute;
+        cursor: pointer;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: var(--toggle-background-light);
+        transition: background-color 0.4s;
+        border-radius: 38px; /* 둥근 모서리 반경 조정 */
+    }
 
-.toggle-switch .label:before {
-    position: absolute;
-    content: "";
-    height: 30px; /* 내부 원 높이 조정 */
-    width: 30px; /* 내부 원 너비 조정 */
-    left: 2px;
-    bottom: 0px;
-    background-color: var(--toggle-ball-light);
-    transition: transform 0.4s;
-    border-radius: 50%;
-}
+    .toggle-switch .label:before {
+        position: absolute;
+        content: "";
+        height: 30px; /* 내부 원 높이 조정 */
+        width: 30px; /* 내부 원 너비 조정 */
+        left: 2px;
+        bottom: 0px;
+        background-color: var(--toggle-ball-light);
+        transition: transform 0.4s;
+        border-radius: 50%;
+    }
 
-.toggle-switch input:checked + .label {
-    background-color: var(--toggle-background-dark);
-}
+    .toggle-switch input:checked + .label {
+        background-color: var(--toggle-background-dark);
+    }
 
-.toggle-switch input:checked + .label:before {
-    transform: translateX(28px); /* 내부 원 이동 거리 조정 */
-}
+    .toggle-switch input:checked + .label:before {
+        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+    }
 
-         #absdiv {
-            position: relative;
-            top: 60px; /* Move down by 20px from its current position */
-            z-index : 1000;
-        }
+             #absdiv {
+                position: relative;
+                top: 60px; /* Move down by 20px from its current position */
+                z-index : 1000;
+            }
 
-        #searchbutton {
-            background-color: #828282;
-        }
-    </style>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
-    <div class="col-md-9">
-        <div class="row" style="color: #828282;">
-            <div class="col-11">
-                <div class="row">
-                    <div class="col-12">
-                        <form id="filter-and-sort-form" th:action="@{/user/my/rct/apply}" method="get">
-                            <div class="row">
-                                <div class="col-7">
-                                    <div class="row justify-content-start m-0">
-                                        <div class="col-4">
-                                            <!-- 검색 조건 -->
+            #searchbutton {
+                background-color: #828282;
+            }
+        </style>
+        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+              rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+              rel="stylesheet">
+        <div class="col-md-9">
+            <div class="row" style="color: #828282;">
+                <div class="col-11">
+                    <div class="row">
+                        <div class="col-12">
+                            <form id="filter-and-sort-form" th:action="@{/user/my/rct/apply}" method="get">
+                                <div class="row">
+                                    <div class="col-7">
+                                        <div class="row justify-content-start m-0">
+                                            <div class="col-4">
+                                                <!-- 검색 조건 -->
+                                                <label>
+                                                    <select class="form-select px-3" name="searchBy">
+                                                        <option value="title" th:selected="${searchBy == 'title'}">
+                                                            지원서제목
+                                                        </option>
+                                                        <option value="content" th:selected="${searchBy == 'content'}">
+                                                            지원서내용
+                                                        </option>
+                                                        <option value="jTitle" th:selected="${searchBy == 'jTitle'}">
+                                                            공고제목
+                                                        </option>
+                                                        <option value="jContent"
+                                                                th:selected="${searchBy == 'jContent'}">공고내용
+                                                        </option>
+                                                        <option value="jLocation"
+                                                                th:selected="${searchBy == 'jLocation'}">근무지
+                                                        </option>
+                                                        <!--                        <option value="jWriter" th:selected="${searchBy == 'jWriter'}">공고작성자</option>-->
+                                                    </select>
+                                                </label>
+                                            </div>
+                                            <div class="col-6">
+                                                <input class="form-control px-3" type="text" name="searchTerm"
+                                                       placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
+                                            </div>
+                                            <div class="col-2">
+                                                <!-- 검색 버튼 -->
+                                                <button id="searchbutton" type="submit" class="btn btn-primary">검색
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-1" style=""></div>
+                                    <div class="col-4">
+                                        <div class="row justify-content-end">
+                                            <!-- 정렬 또는 토글2 -->
                                             <label>
-                                                <select class="form-select px-3" name="searchBy">
-                                                    <option value="title" th:selected="${searchBy == 'title'}">지원서제목</option>
-                                                    <option value="content" th:selected="${searchBy == 'content'}">지원서내용</option>
-                                                    <option value="jTitle" th:selected="${searchBy == 'jTitle'}">공고제목</option>
-                                                    <option value="jContent" th:selected="${searchBy == 'jContent'}">공고내용</option>
-                                                    <option value="jLocation" th:selected="${searchBy == 'jLocation'}">근무지</option>
-                                                    <!--                        <option value="jWriter" th:selected="${searchBy == 'jWriter'}">공고작성자</option>-->
+                                                <select class="form-select px-3" name="orderBy" onchange="submitForm()">
+                                                    <option value="recentApplication"
+                                                            th:selected="${orderBy == 'recentApplication'}">지원최근순
+                                                    </option>
+                                                    <option value="oldestApplication"
+                                                            th:selected="${orderBy == 'oldestApplication'}">오래된순
+                                                    </option>
+
+                                                    <option value="recentedited"
+                                                            th:selected="${orderBy == 'recentedited'}">공고최근수정순
+                                                    </option>
+                                                    <option value="recent" th:selected="${orderBy == 'recent'}">
+                                                        공고최근작성순
+                                                    </option>
+                                                    <option value="oldest" th:selected="${orderBy == 'oldest'}">공고오래된순
+                                                    </option>
+                                                    <option value="dueSoon" th:selected="${orderBy == 'dueSoon'}">
+                                                        마감임박순
+                                                    </option>
+                                                    <option value="title" th:selected="${orderBy == 'title'}">공고제목가나다순
+                                                    </option>
                                                 </select>
                                             </label>
                                         </div>
-                                        <div class="col-6">
-                                            <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
-                                        </div>
-                                        <div class="col-2">
-                                            <!-- 검색 버튼 -->
-                                            <button id="searchbutton" type="submit" class="btn btn-primary">검색</button>
-                                        </div>
                                     </div>
-                                </div>
-                                <div class="col-1" style=""></div>
-                                <div class="col-4">
-                                    <div class="row justify-content-end">
-                                        <!-- 정렬 또는 토글2 -->
-                                        <label>
-                                            <select class="form-select px-3" name="orderBy" onchange="submitForm()">
-                                                <option value="recentApplication" th:selected="${orderBy == 'recentApplication'}">지원최근순</option>
-                                                <option value="oldestApplication" th:selected="${orderBy == 'oldestApplication'}">오래된순</option>
-
-                                                <option value="recentedited" th:selected="${orderBy == 'recentedited'}">공고최근수정순</option>
-                                                <option value="recent" th:selected="${orderBy == 'recent'}">공고최근작성순</option>
-                                                <option value="oldest" th:selected="${orderBy == 'oldest'}">공고오래된순</option>
-                                                <option value="dueSoon" th:selected="${orderBy == 'dueSoon'}">마감임박순</option>
-                                                <option value="title" th:selected="${orderBy == 'title'}">공고제목가나다순</option>
-                                            </select>
-                                        </label>
-                                    </div>
-                                </div>
-                            </div> <!--검색, 소팅 (토글X)-->
-                            <div class="row justify-content-around">
-                                <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                <div class="col-3" style="padding: 0 1.2rem;">
-                                    <div id="absdiv" class="row justify-content-end">
-                                        <div class="col-3">
-                                            <div class="toggle-switch">
-                                                <!-- 정렬 또는 토글1 -->
-                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">
-                                                <label for="isToggledCheckbox" class="label">
-                                                    <div class="ball"></div>
-                                                </label>
+                                </div> <!--검색, 소팅 (토글X)-->
+                                <div class="row justify-content-around">
+                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                    <div class="col-3" style="padding: 0 1.2rem;">
+                                        <div id="absdiv" class="row justify-content-end">
+                                            <div class="col-3">
+                                                <div class="toggle-switch">
+                                                    <!-- 정렬 또는 토글1 -->
+                                                    <input type="checkbox" name="isToggled" id="isToggledCheckbox"
+                                                           value="Y" th:checked="${isToggled == 'Y'}"
+                                                           onchange="updateCheckboxValueAndSubmit()">
+                                                    <label for="isToggledCheckbox" class="label">
+                                                        <div class="ball"></div>
+                                                    </label>
+                                                </div>
+                                            </div>
+                                            <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">
+                                                마감된 공고
                                             </div>
                                         </div>
-                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">마감된 공고</div>
                                     </div>
-                                </div>
-                            </div> <!--토글-->
-                        </form>
-                    </div>
-                </div>
-                <div class="row justify-content-around">
-                    <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
-                        <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
-                            <div class="col-3 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:each="myRctApplication, iterStat : ${myRctApplications}" th:attr="data-href=@{/recruit/job/applyView(no=${myRctApplication.applyNo})}" th:if="${iterStat.index < 3}">
-                                <div class="row justify-content-center">
-                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                        <div class="date-container px-2 py-1">
-                                            <div class="month" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctApplication.applyCreatedDate)}"></div>
-                                            <div class="year" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctApplication.applyCreatedDate)}"></div>
-                                        </div>
-                                    </div>
-
-                                    <div class="col-4" style="color: white;" th:text="${myRctApplication.applyNo}">닉네임</div>
-                                    <div class="col-4" style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD;" th:text="${myRctApplication.formattedApplyCreatedDate}">시간</div>
-                                </div>
-                                <div class="row justify-content-center">
-                                    <div class="col-10" style="color: white;" th:text="${myRctApplication.applyNo}">사진</div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" th:text="${myRctApplication.jobTitle}">이름</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${myRctApplication.applyTitle}">내용</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                </div>
-
-                            </div>
-                            <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
-                            <div class="col-3" th:if="${myRctApplications.size() == 0}"></div>
-                            <div class="col-3" th:if="${myRctApplications.size() == 0 || myRctApplications.size() == 1}"></div>
-                            <div class="col-3" th:if="${myRctApplications.size() == 0 || myRctApplications.size() == 1 || myRctApplications.size() == 2}"></div>
-                        </div>
-                        <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
-                            <div class="col-3 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:each="myRctApplication, iterStat : ${myRctApplications}" th:attr="data-href=@{/recruit/job/applyView(no=${myRctApplication.applyNo})}" th:if="${iterStat.index >= 3}">
-                                <div class="row justify-content-center">
-                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                        <div class="date-container px-2 py-1">
-                                            <div class="month" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctApplication.applyCreatedDate)}"></div>
-                                            <div class="year" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctApplication.applyCreatedDate)}"></div>
-                                        </div>
-                                    </div>
-
-                                    <div class="col-4" style="color: white;" th:text="${myRctApplication.applyNo}">닉네임</div>
-                                    <div class="col-4" style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD;" th:text="${myRctApplication.formattedApplyCreatedDate}">시간</div>
-                                </div>
-                                <div class="row justify-content-center">
-                                    <div class="col-10" style="color: white;" th:text="${myRctApplication.applyNo}">사진</div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" th:text="${myRctApplication.jobTitle}">이름</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${myRctApplication.applyTitle}">내용</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                </div>
-
-                            </div>
-
-                            <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
-                            <div class="col-3" th:if="${myRctApplications.size() <= 3}"></div>
-                            <div class="col-3" th:if="${myRctApplications.size() <= 3 || myRctApplications.size() == 4}"></div>
-                            <div class="col-3" th:if="${myRctApplications.size() <= 3 || myRctApplications.size() == 4 || myRctApplications.size() == 5}"></div>
+                                </div> <!--토글-->
+                            </form>
                         </div>
                     </div>
-                </div>
-                <div class="row justify-content-center">
-                    <!-- 페이징 -->
-                    <th:block th:if="${pages != null}">
-                        <div class="d-flex justify-content-center">
-                            <div class="btn-group">
-                                <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/rct/apply(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-                                        <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                                    </svg>
-                                </button>
-                                <th:block th:each="p : ${#numbers.sequence(1, pages)}">
-                                    <button type="button" class="btn btn-sm me-2 pages"
-                                            th:text="${p}" th:onclick="|location.href='@{/user/my/rct/apply(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
-                                </th:block>
-                                <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/rct/apply(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-                                        <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
-                                    </svg>
-                                </button>
+                    <div class="row justify-content-around">
+                        <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
+                            <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
+                                <div class="col-3 clickable-row"
+                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                     th:each="myRctApplication, iterStat : ${myRctApplications}"
+                                     th:attr="data-href=@{/recruit/job/applyView(no=${myRctApplication.applyNo})}"
+                                     th:if="${iterStat.index < 3}">
+                                    <div class="row justify-content-center">
+                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                             style="aspect-ratio: 1; border-radius: 5px;">
+                                            <div class="date-container px-2 py-1">
+                                                <div class="month"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctApplication.applyCreatedDate)}"></div>
+                                                <div class="year"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctApplication.applyCreatedDate)}"></div>
+                                            </div>
+                                        </div>
+
+                                        <div class="col-4" style="color: white;" th:text="${myRctApplication.applyNo}">
+                                            닉네임
+                                        </div>
+                                        <div class="col-4"
+                                             style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD;"
+                                             th:text="${myRctApplication.formattedApplyCreatedDate}">시간
+                                        </div>
+                                    </div>
+                                    <div class="row justify-content-center">
+                                        <div class="col-10" style="color: white;" th:text="${myRctApplication.applyNo}">
+                                            사진
+                                        </div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                             th:text="${myRctApplication.jobTitle}">이름
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                             th:text="${myRctApplication.applyTitle}">내용
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                    </div>
+
+                                </div>
+                                <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
+                                <div class="col-3" th:if="${myRctApplications.size() == 0}"></div>
+                                <div class="col-3"
+                                     th:if="${myRctApplications.size() == 0 || myRctApplications.size() == 1}"></div>
+                                <div class="col-3"
+                                     th:if="${myRctApplications.size() == 0 || myRctApplications.size() == 1 || myRctApplications.size() == 2}"></div>
+                            </div>
+                            <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
+                                <div class="col-3 clickable-row"
+                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                     th:each="myRctApplication, iterStat : ${myRctApplications}"
+                                     th:attr="data-href=@{/recruit/job/applyView(no=${myRctApplication.applyNo})}"
+                                     th:if="${iterStat.index >= 3}">
+                                    <div class="row justify-content-center">
+                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                             style="aspect-ratio: 1; border-radius: 5px;">
+                                            <div class="date-container px-2 py-1">
+                                                <div class="month"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctApplication.applyCreatedDate)}"></div>
+                                                <div class="year"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctApplication.applyCreatedDate)}"></div>
+                                            </div>
+                                        </div>
+
+                                        <div class="col-4" style="color: white;" th:text="${myRctApplication.applyNo}">
+                                            닉네임
+                                        </div>
+                                        <div class="col-4"
+                                             style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD;"
+                                             th:text="${myRctApplication.formattedApplyCreatedDate}">시간
+                                        </div>
+                                    </div>
+                                    <div class="row justify-content-center">
+                                        <div class="col-10" style="color: white;" th:text="${myRctApplication.applyNo}">
+                                            사진
+                                        </div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                             th:text="${myRctApplication.jobTitle}">이름
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                             th:text="${myRctApplication.applyTitle}">내용
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                    </div>
+
+                                </div>
+
+                                <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
+                                <div class="col-3" th:if="${myRctApplications.size() <= 3}"></div>
+                                <div class="col-3"
+                                     th:if="${myRctApplications.size() <= 3 || myRctApplications.size() == 4}"></div>
+                                <div class="col-3"
+                                     th:if="${myRctApplications.size() <= 3 || myRctApplications.size() == 4 || myRctApplications.size() == 5}"></div>
                             </div>
                         </div>
-                    </th:block>
-                </div>
-            </div><!--테이블 및 페이징 포함-->
+                    </div>
+                    <div class="row justify-content-center">
+                        <!-- 페이징 -->
+                        <th:block th:if="${pages != null}">
+                            <div class="d-flex justify-content-center">
+                                <div class="btn-group">
+                                    <button type="button" class="btn btn-sm previous"
+                                            th:onclick="|location.href='@{/user/my/rct/apply(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
+                                            th:disabled="${currentPage == 1}">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                             fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+                                            <path fill-rule="evenodd"
+                                                  d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                                        </svg>
+                                    </button>
+                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">
+                                        <button type="button" class="btn btn-sm me-2 pages"
+                                                th:text="${p}"
+                                                th:onclick="|location.href='@{/user/my/rct/apply(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
+                                    </th:block>
+                                    <button type="button" class="btn btn-sm  next"
+                                            th:onclick="|location.href='@{/user/my/rct/apply(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
+                                            th:disabled="${currentPage == pages}">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                             fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+                                            <path fill-rule="evenodd"
+                                                  d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                                        </svg>
+                                    </button>
+                                </div>
+                            </div>
+                        </th:block>
+                    </div>
+                </div><!--테이블 및 페이징 포함-->
+            </div> <!--본화면-->
         </div> <!--본화면-->
-    </div> <!--본화면-->
 
 
+        <!--수정전-->
+        <!--    <div class="col-md-9">-->
+        <!--        <div class="review-list">-->
+        <!--            <h2>나의 지원서 관리</h2>-->
+        <!--            <form id="filter-and-sort-form" th:action="@{/user/my/rct/apply}" method="get">-->
+        <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
+        <!--                <label>-->
+        <!--                    <select name="searchBy">-->
+        <!--                        <option value="title" th:selected="${searchBy == 'title'}">지원서제목</option>-->
+        <!--                        <option value="content" th:selected="${searchBy == 'content'}">지원서내용</option>-->
+        <!--                        <option value="jTitle" th:selected="${searchBy == 'jTitle'}">공고제목</option>-->
+        <!--                        <option value="jContent" th:selected="${searchBy == 'jContent'}">공고내용</option>-->
+        <!--                        <option value="jLocation" th:selected="${searchBy == 'jLocation'}">근무지</option>-->
+        <!--&lt;!&ndash;                        <option value="jWriter" th:selected="${searchBy == 'jWriter'}">공고작성자</option>&ndash;&gt;-->
+        <!--                    </select>-->
+        <!--                </label>-->
+        <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
 
-<!--수정전-->
-<!--    <div class="col-md-9">-->
-<!--        <div class="review-list">-->
-<!--            <h2>나의 지원서 관리</h2>-->
-<!--            <form id="filter-and-sort-form" th:action="@{/user/my/rct/apply}" method="get">-->
-<!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
-<!--                <label>-->
-<!--                    <select name="searchBy">-->
-<!--                        <option value="title" th:selected="${searchBy == 'title'}">지원서제목</option>-->
-<!--                        <option value="content" th:selected="${searchBy == 'content'}">지원서내용</option>-->
-<!--                        <option value="jTitle" th:selected="${searchBy == 'jTitle'}">공고제목</option>-->
-<!--                        <option value="jContent" th:selected="${searchBy == 'jContent'}">공고내용</option>-->
-<!--                        <option value="jLocation" th:selected="${searchBy == 'jLocation'}">근무지</option>-->
-<!--&lt;!&ndash;                        <option value="jWriter" th:selected="${searchBy == 'jWriter'}">공고작성자</option>&ndash;&gt;-->
-<!--                    </select>-->
-<!--                </label>-->
-<!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
+        <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
+        <!--                <button type="submit">검색</button>-->
 
-<!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
-<!--                <button type="submit">검색</button>-->
+        <!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
+        <!--                <label>-->
+        <!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">마감된 공고-->
+        <!--                </label>-->
 
-<!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
-<!--                <label>-->
-<!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">마감된 공고-->
-<!--                </label>-->
+        <!--                <label>-->
+        <!--                    <select name="orderBy" onchange="submitForm()">-->
+        <!--                        <option value="recentApplication" th:selected="${orderBy == 'recentApplication'}">지원최근순</option>-->
+        <!--                        <option value="oldestApplication" th:selected="${orderBy == 'oldestApplication'}">오래된순</option>-->
 
-<!--                <label>-->
-<!--                    <select name="orderBy" onchange="submitForm()">-->
-<!--                        <option value="recentApplication" th:selected="${orderBy == 'recentApplication'}">지원최근순</option>-->
-<!--                        <option value="oldestApplication" th:selected="${orderBy == 'oldestApplication'}">오래된순</option>-->
+        <!--                        <option value="recentedited" th:selected="${orderBy == 'recentedited'}">공고최근수정순</option>-->
+        <!--                        <option value="recent" th:selected="${orderBy == 'recent'}">공고최근작성순</option>-->
+        <!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">공고오래된순</option>-->
+        <!--                        <option value="dueSoon" th:selected="${orderBy == 'dueSoon'}">마감임박순</option>-->
+        <!--                        <option value="title" th:selected="${orderBy == 'title'}">공고제목가나다순</option>-->
+        <!--                    </select>-->
+        <!--                </label>-->
+        <!--            </form>-->
+        <!--&lt;!&ndash;            <form id="filter-form" th:action="@{/user/my/rct/apply}" method="get">&ndash;&gt;-->
+        <!--&lt;!&ndash;                <label>&ndash;&gt;-->
+        <!--&lt;!&ndash;                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="toggleCheckboxValue()">마감된 공고&ndash;&gt;-->
+        <!--&lt;!&ndash;                </label>&ndash;&gt;-->
+        <!--&lt;!&ndash;            </form>&ndash;&gt;-->
+        <!--            <table>-->
+        <!--                <thead>-->
+        <!--                <tr>-->
+        <!--                    <th>지원글 번호</th>-->
+        <!--                    <th>게시글 번호</th>-->
+        <!--                    <th>지원자</th>-->
+        <!--                    <th>제목</th>-->
+        <!--                    <th>내용</th>-->
+        <!--                    <th>이미지</th>-->
+        <!--                    <th>작성 일자</th>-->
+        <!--                    <th>조회 여부</th>-->
 
-<!--                        <option value="recentedited" th:selected="${orderBy == 'recentedited'}">공고최근수정순</option>-->
-<!--                        <option value="recent" th:selected="${orderBy == 'recent'}">공고최근작성순</option>-->
-<!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">공고오래된순</option>-->
-<!--                        <option value="dueSoon" th:selected="${orderBy == 'dueSoon'}">마감임박순</option>-->
-<!--                        <option value="title" th:selected="${orderBy == 'title'}">공고제목가나다순</option>-->
-<!--                    </select>-->
-<!--                </label>-->
-<!--            </form>-->
-<!--&lt;!&ndash;            <form id="filter-form" th:action="@{/user/my/rct/apply}" method="get">&ndash;&gt;-->
-<!--&lt;!&ndash;                <label>&ndash;&gt;-->
-<!--&lt;!&ndash;                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="toggleCheckboxValue()">마감된 공고&ndash;&gt;-->
-<!--&lt;!&ndash;                </label>&ndash;&gt;-->
-<!--&lt;!&ndash;            </form>&ndash;&gt;-->
-<!--            <table>-->
-<!--                <thead>-->
-<!--                <tr>-->
-<!--                    <th>지원글 번호</th>-->
-<!--                    <th>게시글 번호</th>-->
-<!--                    <th>지원자</th>-->
-<!--                    <th>제목</th>-->
-<!--                    <th>내용</th>-->
-<!--                    <th>이미지</th>-->
-<!--                    <th>작성 일자</th>-->
-<!--                    <th>조회 여부</th>-->
+        <!--                    <th>작성자</th>-->
+        <!--                    <th>제목</th>-->
+        <!--                    <th>내용</th>-->
+        <!--                    <th>근무지</th>-->
+        <!--                    <th>이미지</th>-->
+        <!--                    <th>작성 일자</th>-->
+        <!--                    <th>수정 일자</th>-->
+        <!--                    <th>마감 일자</th>-->
+        <!--                </tr>-->
+        <!--                </thead>-->
+        <!--                <tbody>-->
+        <!--                <tr th:each="myRctApplication : ${myRctApplications}" class="clickable-row" th:attr="data-href=@{/recruit/job/applyView(no=${myRctApplication.applyNo})}">-->
+        <!--                    <td th:text="${myRctApplication.applyNo}">지원글 번호</td>-->
+        <!--                    <td th:text="${myRctApplication.boardNo}">게시글 번호</td>-->
+        <!--                    <td th:text="${myRctApplication.writer}">지원자</td>-->
+        <!--                    <td th:text="${myRctApplication.applyTitle}">제목</td>-->
+        <!--                    <td th:text="${myRctApplication.applyContent}">내용</td>-->
+        <!--                    <td th:text="${myRctApplication.applyImg}">이미지</td>-->
+        <!--                    <td th:text="${myRctApplication.applyCreatedDate}">작성 일자</td>-->
+        <!--                    <td th:text="${myRctApplication.applyCheckStatus}">조회 여부</td>-->
 
-<!--                    <th>작성자</th>-->
-<!--                    <th>제목</th>-->
-<!--                    <th>내용</th>-->
-<!--                    <th>근무지</th>-->
-<!--                    <th>이미지</th>-->
-<!--                    <th>작성 일자</th>-->
-<!--                    <th>수정 일자</th>-->
-<!--                    <th>마감 일자</th>-->
-<!--                </tr>-->
-<!--                </thead>-->
-<!--                <tbody>-->
-<!--                <tr th:each="myRctApplication : ${myRctApplications}" class="clickable-row" th:attr="data-href=@{/recruit/job/applyView(no=${myRctApplication.applyNo})}">-->
-<!--                    <td th:text="${myRctApplication.applyNo}">지원글 번호</td>-->
-<!--                    <td th:text="${myRctApplication.boardNo}">게시글 번호</td>-->
-<!--                    <td th:text="${myRctApplication.writer}">지원자</td>-->
-<!--                    <td th:text="${myRctApplication.applyTitle}">제목</td>-->
-<!--                    <td th:text="${myRctApplication.applyContent}">내용</td>-->
-<!--                    <td th:text="${myRctApplication.applyImg}">이미지</td>-->
-<!--                    <td th:text="${myRctApplication.applyCreatedDate}">작성 일자</td>-->
-<!--                    <td th:text="${myRctApplication.applyCheckStatus}">조회 여부</td>-->
-
-<!--                    <td th:text="${myRctApplication.jobWriter}">작성자</td>-->
-<!--                    <td th:text="${myRctApplication.jobTitle}">제목</td>-->
-<!--                    <td th:text="${myRctApplication.jobContent}">내용</td>-->
-<!--                    <td th:text="${myRctApplication.jobLocation}">근무지</td>-->
-<!--                    <td th:text="${myRctApplication.jobImg}">이미지</td>-->
-<!--                    <td th:text="${myRctApplication.jobCreatedDate}">작성 일자</td>-->
-<!--                    <td th:text="${myRctApplication.jobModifiedDate}">수정 일자</td>-->
-<!--                    <td th:text="${myRctApplication.jobDeadLine}">마감 일자</td>-->
-<!--                </tr>-->
-<!--                </tbody>-->
-<!--            </table>-->
-<!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
-<!--            <th:block th:if="${pages != null}">-->
-<!--                <div class="d-flex justify-content-center">-->
-<!--                    <div class="btn-group">-->
-<!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/rct/apply(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
-<!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
-<!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
-<!--                            </svg>-->
-<!--                        </button>-->
-<!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
-<!--                            <button type="button" class="btn btn-sm me-2 pages"-->
-<!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/rct/apply(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
-<!--                        </th:block>-->
-<!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/rct/apply(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
-<!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
-<!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
-<!--                            </svg>-->
-<!--                        </button>-->
-<!--                    </div>-->
-<!--                </div>-->
-<!--            </th:block>-->
-<!--        </div>-->
-<!--    </div>-->
+        <!--                    <td th:text="${myRctApplication.jobWriter}">작성자</td>-->
+        <!--                    <td th:text="${myRctApplication.jobTitle}">제목</td>-->
+        <!--                    <td th:text="${myRctApplication.jobContent}">내용</td>-->
+        <!--                    <td th:text="${myRctApplication.jobLocation}">근무지</td>-->
+        <!--                    <td th:text="${myRctApplication.jobImg}">이미지</td>-->
+        <!--                    <td th:text="${myRctApplication.jobCreatedDate}">작성 일자</td>-->
+        <!--                    <td th:text="${myRctApplication.jobModifiedDate}">수정 일자</td>-->
+        <!--                    <td th:text="${myRctApplication.jobDeadLine}">마감 일자</td>-->
+        <!--                </tr>-->
+        <!--                </tbody>-->
+        <!--            </table>-->
+        <!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
+        <!--            <th:block th:if="${pages != null}">-->
+        <!--                <div class="d-flex justify-content-center">-->
+        <!--                    <div class="btn-group">-->
+        <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/rct/apply(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
+        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
+        <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
+        <!--                            </svg>-->
+        <!--                        </button>-->
+        <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
+        <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
+        <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/rct/apply(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
+        <!--                        </th:block>-->
+        <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/rct/apply(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
+        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
+        <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
+        <!--                            </svg>-->
+        <!--                        </button>-->
+        <!--                    </div>-->
+        <!--                </div>-->
+        <!--            </th:block>-->
+        <!--        </div>-->
+        <!--    </div>-->
+    </div>
 </div>
 <div th:replace="common/footer.html"></div>
 </body>

--- a/src/main/resources/templates/user/mypage_rct_creator.html
+++ b/src/main/resources/templates/user/mypage_rct_creator.html
@@ -134,7 +134,7 @@
         <aside class="col-md-3 px-4">
             <div class="row">
                 <div class="col-1"></div>
-                <div class="col-6">
+                <div class="col-8">
                     <div class="panel">
                         <ul class="list-group">
                             <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>

--- a/src/main/resources/templates/user/mypage_rct_creator.html
+++ b/src/main/resources/templates/user/mypage_rct_creator.html
@@ -104,20 +104,23 @@
   }
 </style>
 <div class="jumbotron">
-    <div class="row">
-        <div class="col-md-3 px-4">
-            <h3>나의 채용</h3>
-        </div>
-        <div class="col-md-9">
-            <nav class="navbar navbar-expand-md">
-                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                    <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
-                    <li><a th:href="@{/user/my/rct/creator}" class="nav-link px-2" style="color:#000;">창작자 등록 현황</a></li>
-                    <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a></li>
-                    <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
-                    <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
-                </ul>
-            </nav>
+    <div class="container">
+        <div class="row">
+            <div class="col-md-3 px-4">
+                <h3>나의 채용</h3>
+            </div>
+            <div class="col-md-9">
+                <nav class="navbar navbar-expand-md">
+                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                        <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
+                        <li><a th:href="@{/user/my/rct/creator}" class="nav-link px-2" style="color:#000;">창작자 등록 현황</a>
+                        </li>
+                        <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a></li>
+                        <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
+                        <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
+                    </ul>
+                </nav>
+            </div>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/user/mypage_rct_creator.html
+++ b/src/main/resources/templates/user/mypage_rct_creator.html
@@ -86,103 +86,123 @@
 
 <div th:replace="~{common/menubar}"></div>
 <style>
-    .jumbotron {
-    position : relative;
-    background-color : #EEEEEE;
+    html, body {
+        height: 100%;
+        margin: 0;
     }
-    .jumbotron .row {
-    position : absolute;
-    width : 100%;
-    bottom: 0%;
+    body {
+        display: flex;
+        flex-direction: column;
     }
-    .nav-link {
-            color: #828282;
+    .content-wrapper {
+        flex: 1 0 auto;
     }
-    ul {
-  list-style: none;
-  padding-left : 0px;
-  }
+    footer {
+        flex-shrink: 0;
+    }
+
 </style>
-<div class="jumbotron">
-    <div class="container">
-        <div class="row">
-            <div class="col-9">
-                <div class="row">
-                    <div class="col-md-3 px-4">
-                        <h3>나의 채용</h3>
-                    </div>
-                    <div class="col-md-9">
-                        <nav class="navbar navbar-expand-md">
-                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
-                                <li><a th:href="@{/user/my/rct/creator}" class="nav-link px-2" style="color:#000;">창작자
-                                    등록 현황</a>
-                                </li>
-                                <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a></li>
-                                <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
-                                <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
-                            </ul>
-                        </nav>
+<div class="content-wrapper">
+    <style>
+        .jumbotron {
+        position : relative;
+        background-color : #EEEEEE;
+        }
+        .jumbotron .row {
+        position : absolute;
+        width : 100%;
+        bottom: 0%;
+        }
+        .nav-link {
+                color: #828282;
+        }
+        ul {
+      list-style: none;
+      padding-left : 0px;
+      }
+    </style>
+    <div class="jumbotron">
+        <div class="container">
+            <div class="row">
+                <div class="col-9">
+                    <div class="row">
+                        <div class="col-md-3 px-4">
+                            <h3>나의 채용</h3>
+                        </div>
+                        <div class="col-md-9">
+                            <nav class="navbar navbar-expand-md">
+                                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                    <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
+                                    <li><a th:href="@{/user/my/rct/creator}" class="nav-link px-2" style="color:#000;">창작자
+                                        등록 현황</a>
+                                    </li>
+                                    <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a></li>
+                                    <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
+                                    <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
+                                </ul>
+                            </nav>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
-<div class="container" style="padding:0;">
-    <div class="row">
-        <aside class="col-md-3 px-4">
-            <div class="row">
-                <div class="col-1"></div>
-                <div class="col-8">
-                    <div class="panel">
-                        <ul class="list-group">
-                            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
-                            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-                            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color: #03C75A;">나의 채용</a>
-                            </li>
-                            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-                        </ul>
+    <div class="container" style="padding:0;">
+        <div class="row">
+            <aside class="col-md-3 px-4">
+                <div class="row">
+                    <div class="col-1"></div>
+                    <div class="col-8">
+                        <div class="panel">
+                            <ul class="list-group">
+                                <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
+                                <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color: #03C75A;">나의
+                                    채용</a>
+                                </li>
+                                <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                                <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                                <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </aside>
-        <div class="col-md-9">
-            <div class="review-list">
-                <h2>창작자 등록 현황</h2>
-                <th:block th:if="${!auth_code.equals('C')}">
-                    <a th:href="@{/recruit/creator/choice}">창작자 등록 신청</a>
-                </th:block>
-                <th:block th:if="${auth_code.equals('C')}">
-                    <button type="button" onclick="">등록증 확인(미구현)</button>
-                </th:block>
-                <br>
-                <table>
-                    <thead>
-                    <tr>
-                        <th>창작자 번호</th>
-                        <th>회원 번호</th>
-                        <th>내용</th>
-                        <th>이미지</th>
-                        <th>사업자 등록번호</th>
-                        <th>심사 현황</th>
-                        <th>등록 유형 코드</th>
-                    </tr>
-                    </thead>
-                    <tbody>
-                    <tr th:each="myRctCreator : ${myRctCreators}" class="clickable-row">
-                        <td th:text="${myRctCreator.creatorNo}">창작자 번호</td>
-                        <td th:text="${myRctCreator.memberNo}">회원 번호</td>
-                        <td th:text="${myRctCreator.content}">내용</td>
-                        <td th:text="${myRctCreator.img}">이미지</td>
-                        <td th:text="${myRctCreator.registNo}">사업자 등록번호</td>
-                        <td th:text="${myRctCreator.status}">심사 현황</td>
-                        <td th:text="${myRctCreator.typeCode}">등록 유형 코드</td>
-                    </tr>
-                    </tbody>
-                </table>
+            </aside>
+            <div class="col-md-9">
+                <div class="review-list">
+                    <h2>창작자 등록 현황</h2>
+                    <th:block th:if="${!auth_code.equals('C')}">
+                        <a th:href="@{/recruit/creator/choice}">창작자 등록 신청</a>
+                    </th:block>
+                    <th:block th:if="${auth_code.equals('C')}">
+                        <button type="button" onclick="">등록증 확인(미구현)</button>
+                    </th:block>
+                    <br>
+                    <table>
+                        <thead>
+                        <tr>
+                            <th>창작자 번호</th>
+                            <th>회원 번호</th>
+                            <th>내용</th>
+                            <th>이미지</th>
+                            <th>사업자 등록번호</th>
+                            <th>심사 현황</th>
+                            <th>등록 유형 코드</th>
+                        </tr>
+                        </thead>
+                        <tbody>
+                        <tr th:each="myRctCreator : ${myRctCreators}" class="clickable-row">
+                            <td th:text="${myRctCreator.creatorNo}">창작자 번호</td>
+                            <td th:text="${myRctCreator.memberNo}">회원 번호</td>
+                            <td th:text="${myRctCreator.content}">내용</td>
+                            <td th:text="${myRctCreator.img}">이미지</td>
+                            <td th:text="${myRctCreator.registNo}">사업자 등록번호</td>
+                            <td th:text="${myRctCreator.status}">심사 현황</td>
+                            <td th:text="${myRctCreator.typeCode}">등록 유형 코드</td>
+                        </tr>
+                        </tbody>
+                    </table>
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/user/mypage_rct_creator.html
+++ b/src/main/resources/templates/user/mypage_rct_creator.html
@@ -106,20 +106,25 @@
 <div class="jumbotron">
     <div class="container">
         <div class="row">
-            <div class="col-md-3 px-4">
-                <h3>나의 채용</h3>
-            </div>
-            <div class="col-md-9">
-                <nav class="navbar navbar-expand-md">
-                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                        <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
-                        <li><a th:href="@{/user/my/rct/creator}" class="nav-link px-2" style="color:#000;">창작자 등록 현황</a>
-                        </li>
-                        <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a></li>
-                        <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
-                        <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
-                    </ul>
-                </nav>
+            <div class="col-9">
+                <div class="row">
+                    <div class="col-md-3 px-4">
+                        <h3>나의 채용</h3>
+                    </div>
+                    <div class="col-md-9">
+                        <nav class="navbar navbar-expand-md">
+                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
+                                <li><a th:href="@{/user/my/rct/creator}" class="nav-link px-2" style="color:#000;">창작자
+                                    등록 현황</a>
+                                </li>
+                                <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a></li>
+                                <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
+                                <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
+                            </ul>
+                        </nav>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/user/mypage_rct_creator.html
+++ b/src/main/resources/templates/user/mypage_rct_creator.html
@@ -124,57 +124,61 @@
         </div>
     </div>
 </div>
-<div class="row">
-    <aside class="col-md-3 px-4">
-        <div class="row">
-            <div class="col-3"></div>
-            <div class="col-6">
-                <div class="panel">
-                    <ul class="list-group">
-                        <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
-                        <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-                        <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color: #03C75A;">나의 채용</a></li>
-                        <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-                        <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                        <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-                    </ul>
+<div class="container" style="padding:0;">
+    <div class="row">
+        <aside class="col-md-3 px-4">
+            <div class="row">
+                <div class="col-3"></div>
+                <div class="col-6">
+                    <div class="panel">
+                        <ul class="list-group">
+                            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
+                            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color: #03C75A;">나의 채용</a>
+                            </li>
+                            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+                        </ul>
+                    </div>
                 </div>
             </div>
-        </div>
-    </aside>
-    <div class="col-md-9">
-        <div class="review-list">
-            <h2>창작자 등록 현황</h2>
-            <th:block th:if="${!auth_code.equals('C')}">
-                <a th:href="@{/recruit/creator/choice}">창작자 등록 신청</a>
-            </th:block>
-            <th:block th:if="${auth_code.equals('C')}">
-                <button type="button" onclick="">등록증 확인(미구현)</button>
-            </th:block><br>
-            <table>
-                <thead>
-                <tr>
-                    <th>창작자 번호</th>
-                    <th>회원 번호</th>
-                    <th>내용</th>
-                    <th>이미지</th>
-                    <th>사업자 등록번호</th>
-                    <th>심사 현황</th>
-                    <th>등록 유형 코드</th>
-                </tr>
-                </thead>
-                <tbody>
-                <tr th:each="myRctCreator : ${myRctCreators}" class="clickable-row">
-                    <td th:text="${myRctCreator.creatorNo}">창작자 번호</td>
-                    <td th:text="${myRctCreator.memberNo}">회원 번호</td>
-                    <td th:text="${myRctCreator.content}">내용</td>
-                    <td th:text="${myRctCreator.img}">이미지</td>
-                    <td th:text="${myRctCreator.registNo}">사업자 등록번호</td>
-                    <td th:text="${myRctCreator.status}">심사 현황</td>
-                    <td th:text="${myRctCreator.typeCode}">등록 유형 코드</td>
-                </tr>
-                </tbody>
-            </table>
+        </aside>
+        <div class="col-md-9">
+            <div class="review-list">
+                <h2>창작자 등록 현황</h2>
+                <th:block th:if="${!auth_code.equals('C')}">
+                    <a th:href="@{/recruit/creator/choice}">창작자 등록 신청</a>
+                </th:block>
+                <th:block th:if="${auth_code.equals('C')}">
+                    <button type="button" onclick="">등록증 확인(미구현)</button>
+                </th:block>
+                <br>
+                <table>
+                    <thead>
+                    <tr>
+                        <th>창작자 번호</th>
+                        <th>회원 번호</th>
+                        <th>내용</th>
+                        <th>이미지</th>
+                        <th>사업자 등록번호</th>
+                        <th>심사 현황</th>
+                        <th>등록 유형 코드</th>
+                    </tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="myRctCreator : ${myRctCreators}" class="clickable-row">
+                        <td th:text="${myRctCreator.creatorNo}">창작자 번호</td>
+                        <td th:text="${myRctCreator.memberNo}">회원 번호</td>
+                        <td th:text="${myRctCreator.content}">내용</td>
+                        <td th:text="${myRctCreator.img}">이미지</td>
+                        <td th:text="${myRctCreator.registNo}">사업자 등록번호</td>
+                        <td th:text="${myRctCreator.status}">심사 현황</td>
+                        <td th:text="${myRctCreator.typeCode}">등록 유형 코드</td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/user/mypage_rct_creator.html
+++ b/src/main/resources/templates/user/mypage_rct_creator.html
@@ -133,7 +133,7 @@
     <div class="row">
         <aside class="col-md-3 px-4">
             <div class="row">
-                <div class="col-3"></div>
+                <div class="col-1"></div>
                 <div class="col-6">
                     <div class="panel">
                         <ul class="list-group">

--- a/src/main/resources/templates/user/mypage_rct_free.html
+++ b/src/main/resources/templates/user/mypage_rct_free.html
@@ -134,7 +134,7 @@
     <div class="row">
         <aside class="col-md-3 px-4">
             <div class="row">
-                <div class="col-3"></div>
+                <div class="col-1"></div>
                 <div class="col-6">
                     <div class="panel">
                         <ul class="list-group">

--- a/src/main/resources/templates/user/mypage_rct_free.html
+++ b/src/main/resources/templates/user/mypage_rct_free.html
@@ -86,592 +86,621 @@
 
 <div th:replace="~{common/menubar}"></div>
 <style>
-    .jumbotron {
-    position : relative;
-    background-color : #EEEEEE;
+    html, body {
+        height: 100%;
+        margin: 0;
     }
-    .jumbotron .row {
-    position : absolute;
-    width : 100%;
-    bottom: 0%;
+    body {
+        display: flex;
+        flex-direction: column;
     }
-    .nav-link {
-            color: #828282;
+    .content-wrapper {
+        flex: 1 0 auto;
     }
-    ul {
-  list-style: none;
-  padding-left : 0px;
-  }
+    footer {
+        flex-shrink: 0;
+    }
+
 </style>
-<div class="jumbotron">
-    <div class="container">
-        <div class="row">
-            <div class="col-9">
-                <div class="row">
-                    <div class="col-md-3 px-4">
-                        <h3>나의 채용</h3>
-                    </div>
-                    <div class="col-md-9">
-                        <nav class="navbar navbar-expand-md">
-                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
-                                <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a>
-                                </li>
-                                <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2" style="color:#000;">프리랜서 게시글
-                                    관리</a></li>
-                                <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
-                                <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보
-                                    수정</a></li>
-                            </ul>
-                        </nav>
+<div class="content-wrapper">
+    <style>
+        .jumbotron {
+        position : relative;
+        background-color : #EEEEEE;
+        }
+        .jumbotron .row {
+        position : absolute;
+        width : 100%;
+        bottom: 0%;
+        }
+        .nav-link {
+                color: #828282;
+        }
+        ul {
+      list-style: none;
+      padding-left : 0px;
+      }
+    </style>
+    <div class="jumbotron">
+        <div class="container">
+            <div class="row">
+                <div class="col-9">
+                    <div class="row">
+                        <div class="col-md-3 px-4">
+                            <h3>나의 채용</h3>
+                        </div>
+                        <div class="col-md-9">
+                            <nav class="navbar navbar-expand-md">
+                                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                    <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
+                                    <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a>
+                                    </li>
+                                    <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2" style="color:#000;">프리랜서
+                                        게시글
+                                        관리</a></li>
+                                    <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
+                                    <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보
+                                        수정</a></li>
+                                </ul>
+                            </nav>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
-<div class="container" style="padding:0;">
-    <div class="row">
-        <aside class="col-md-3 px-4">
-            <div class="row">
-                <div class="col-1"></div>
-                <div class="col-8">
-                    <div class="panel">
-                        <ul class="list-group">
-                            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
-                            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-                            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color: #03C75A;">나의 채용</a>
-                            </li>
-                            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-                        </ul>
+    <div class="container" style="padding:0;">
+        <div class="row">
+            <aside class="col-md-3 px-4">
+                <div class="row">
+                    <div class="col-1"></div>
+                    <div class="col-8">
+                        <div class="panel">
+                            <ul class="list-group">
+                                <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
+                                <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color: #03C75A;">나의
+                                    채용</a>
+                                </li>
+                                <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                                <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                                <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </aside>
-        <style>
-            .form-select {
-            background-color : #FCFCFC;
-            border : none;
-            width : 100%;
-            height : 50px;
-            }
-            select {
-            color : #828282;
-            }
-            .form-control {
-            background-color : #FCFCFC;
-            border : none;
-            width : 100%;
-            height : 50px;
-            }
-
-
-            .form-control::placeholder {
-            color : #BBBBBB;
-            }
-
-            .date-container {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        background-color: #8E4B6E;
-        color: white;
-        border-radius: 10px;
-        text-align:center;
-        font-family: "Work Sans", sans-serif;
-    }
-
-    .platform-1 {
-        background-color: #03C75A;
-    }
-
-    .platform-2 {
-        background-color: #F5BF41;
-    }
-
-    .month {
-        font-size: 1.1rem; /* M의 크기를 설정 */
-        font-weight: 550;
-        line-height: 1;
-    }
-
-    .year {
-        font-size: 0.65rem; /* yyyy의 크기를 설정 */
-        font-weight: 400;
-    }
-    :root {
-        --background-color-light: #FFFFFF;
-        --text-color-light: #000000;
-        --toggle-background-light: #CCCCCC;
-        --toggle-ball-light: #FFFFFF;
-
-        --background-color-dark: #333333;
-        --text-color-dark: #FFFFFF;
-        --toggle-background-dark: #03C75A;
-        --toggle-ball-dark: #FFFFFF;
-
-        --font-size-base: 32px; /* 기본 텍스트 크기 */
-        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
-    }
-
-
-
-    .toggle-switch {
-        position: relative;
-        display: inline-block;
-        width: 62px; /* 너비 조정 */
-        height: 38px; /* 높이 조정 */
-    }
-
-    .toggle-switch .checkbox {
-        opacity: 0;
-        width: 0;
-        height: 0;
-    }
-    #isToggledCheckbox {
-         opacity: 0;
-            width: 0;
-            height: 0;
-    }
-
-    .toggle-switch .label {
-        position: absolute;
-        cursor: pointer;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background-color: var(--toggle-background-light);
-        transition: background-color 0.4s;
-        border-radius: 38px; /* 둥근 모서리 반경 조정 */
-    }
-
-    .toggle-switch .label:before {
-        position: absolute;
-        content: "";
-        height: 30px; /* 내부 원 높이 조정 */
-        width: 30px; /* 내부 원 너비 조정 */
-        left: 2px;
-        bottom: 0px;
-        background-color: var(--toggle-ball-light);
-        transition: transform 0.4s;
-        border-radius: 50%;
-    }
-
-    .toggle-switch input:checked + .label {
-        background-color: var(--toggle-background-dark);
-    }
-
-    .toggle-switch input:checked + .label:before {
-        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
-    }
-
-             #absdiv {
-                position: relative;
-                top: 60px; /* Move down by 20px from its current position */
-                z-index : 1000;
-            }
-
-            #searchbutton {
-                background-color: #828282;
-            }
-
-            .card-img-top {
-                    width: 100%;
-                    height: 100px;
-                    object-fit: cover;
+            </aside>
+            <style>
+                .form-select {
+                background-color : #FCFCFC;
+                border : none;
+                width : 100%;
+                height : 50px;
+                }
+                select {
+                color : #828282;
+                }
+                .form-control {
+                background-color : #FCFCFC;
+                border : none;
+                width : 100%;
+                height : 50px;
                 }
 
-        </style>
-        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
-              rel="stylesheet">
-        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
-              rel="stylesheet">
+
+                .form-control::placeholder {
+                color : #BBBBBB;
+                }
+
+                .date-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            background-color: #8E4B6E;
+            color: white;
+            border-radius: 10px;
+            text-align:center;
+            font-family: "Work Sans", sans-serif;
+        }
+
+        .platform-1 {
+            background-color: #03C75A;
+        }
+
+        .platform-2 {
+            background-color: #F5BF41;
+        }
+
+        .month {
+            font-size: 1.1rem; /* M의 크기를 설정 */
+            font-weight: 550;
+            line-height: 1;
+        }
+
+        .year {
+            font-size: 0.65rem; /* yyyy의 크기를 설정 */
+            font-weight: 400;
+        }
+        :root {
+            --background-color-light: #FFFFFF;
+            --text-color-light: #000000;
+            --toggle-background-light: #CCCCCC;
+            --toggle-ball-light: #FFFFFF;
+
+            --background-color-dark: #333333;
+            --text-color-dark: #FFFFFF;
+            --toggle-background-dark: #03C75A;
+            --toggle-ball-dark: #FFFFFF;
+
+            --font-size-base: 32px; /* 기본 텍스트 크기 */
+            --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+        }
 
 
-        <div class="col-md-9">
-            <div class="row" style="color: #828282;">
-                <div class="col-11">
-                    <div class="row mb-4">
-                        <div class="col-12 p-0">
-                            <style>
-                                .col-4 select {
-                                    border-radius: 50px;
-                                    text-align: center;
-                                }
-                                /* 검색창 스타일 */
-                                .search-container {
-                                    width: 300px;
-                                }
 
-                                .search-container select {
-                                    position: absolute;
-                                    left: 0%;
-                                    width: 30%;
-                                    height: 50px;
-                                    color: #828282;
-                                    font-size: 1rem;
-                                    border-radius: 50px 0 0 50px;
-                                    outline: none;
-                                }
-                                .search-container input[type="text"] {
-                                    position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
-                                    left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
-                                    width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
-                                    height: 50px;
-                                    padding: 10px 40px 10px 15px;
-                                    font-size: 1rem;
-                                    outline: none;
-                                    border-radius: 0 50px 50px 0;
-                                    transition: border-color 0.3s, background-color 0.3s;
-                                    color: #828282; /* 입력 텍스트 색상 변경 */
-                                }
+        .toggle-switch {
+            position: relative;
+            display: inline-block;
+            width: 62px; /* 너비 조정 */
+            height: 38px; /* 높이 조정 */
+        }
 
-                                .search-container input[type="text"]::placeholder {
-                                    color: #BBBBBB; /* placeholder 색상 변경 */
-                                }
+        .toggle-switch .checkbox {
+            opacity: 0;
+            width: 0;
+            height: 0;
+        }
+        #isToggledCheckbox {
+             opacity: 0;
+                width: 0;
+                height: 0;
+        }
+
+        .toggle-switch .label {
+            position: absolute;
+            cursor: pointer;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: var(--toggle-background-light);
+            transition: background-color 0.4s;
+            border-radius: 38px; /* 둥근 모서리 반경 조정 */
+        }
+
+        .toggle-switch .label:before {
+            position: absolute;
+            content: "";
+            height: 30px; /* 내부 원 높이 조정 */
+            width: 30px; /* 내부 원 너비 조정 */
+            left: 2px;
+            bottom: 0px;
+            background-color: var(--toggle-ball-light);
+            transition: transform 0.4s;
+            border-radius: 50%;
+        }
+
+        .toggle-switch input:checked + .label {
+            background-color: var(--toggle-background-dark);
+        }
+
+        .toggle-switch input:checked + .label:before {
+            transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+        }
+
+                 #absdiv {
+                    position: relative;
+                    top: 60px; /* Move down by 20px from its current position */
+                    z-index : 1000;
+                }
+
+                #searchbutton {
+                    background-color: #828282;
+                }
+
+                .card-img-top {
+                        width: 100%;
+                        height: 100px;
+                        object-fit: cover;
+                    }
+
+            </style>
+            <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+                  rel="stylesheet">
+            <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+                  rel="stylesheet">
 
 
-                                .search-container button {
-                                    position: absolute;
-                                    right: 1rem;
-                                    top: 25px;
-                                    background: none;
-                                    transform: translateY(-50%);
-                                    border: none;
-                                    cursor: pointer;
-                                }
+            <div class="col-md-9">
+                <div class="row" style="color: #828282;">
+                    <div class="col-11">
+                        <div class="row mb-4">
+                            <div class="col-12 p-0">
+                                <style>
+                                    .col-4 select {
+                                        border-radius: 50px;
+                                        text-align: center;
+                                    }
+                                    /* 검색창 스타일 */
+                                    .search-container {
+                                        width: 300px;
+                                    }
 
-                                .search-container button i {
-                                    color: #A6AAB5;
-                                }
+                                    .search-container select {
+                                        position: absolute;
+                                        left: 0%;
+                                        width: 30%;
+                                        height: 50px;
+                                        color: #828282;
+                                        font-size: 1rem;
+                                        border-radius: 50px 0 0 50px;
+                                        outline: none;
+                                    }
+                                    .search-container input[type="text"] {
+                                        position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
+                                        left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
+                                        width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
+                                        height: 50px;
+                                        padding: 10px 40px 10px 15px;
+                                        font-size: 1rem;
+                                        outline: none;
+                                        border-radius: 0 50px 50px 0;
+                                        transition: border-color 0.3s, background-color 0.3s;
+                                        color: #828282; /* 입력 텍스트 색상 변경 */
+                                    }
 
-                                .search-container button:hover i {
-                                    color: #03C75A;
-                                }
-                            </style>
-                            <form id="sort-form" th:action="@{/user/my/rct/free}" method="get">
-                                <div class="row m-0">
-                                    <div class="col-7 p-0">
-                                        <div class="row justify-content-start m-0">
-                                            <div class="col-12 p-0">
-                                                <div class="search-container">
-                                                    <select class="form-select px-3" name="searchBy">
-                                                        <option value="title" th:selected="${searchBy == 'title'}">제목
-                                                        </option>
-                                                        <option value="content" th:selected="${searchBy == 'content'}">
-                                                            내용
-                                                        </option>
-                                                    </select>
-                                                    <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
-                                                    <!-- 검색 버튼 -->
-                                                    <button type="submit">
-                                                        <i class="fas fa-search"></i>
-                                                    </button>
+                                    .search-container input[type="text"]::placeholder {
+                                        color: #BBBBBB; /* placeholder 색상 변경 */
+                                    }
+
+
+                                    .search-container button {
+                                        position: absolute;
+                                        right: 1rem;
+                                        top: 25px;
+                                        background: none;
+                                        transform: translateY(-50%);
+                                        border: none;
+                                        cursor: pointer;
+                                    }
+
+                                    .search-container button i {
+                                        color: #A6AAB5;
+                                    }
+
+                                    .search-container button:hover i {
+                                        color: #03C75A;
+                                    }
+                                </style>
+                                <form id="sort-form" th:action="@{/user/my/rct/free}" method="get">
+                                    <div class="row m-0">
+                                        <div class="col-7 p-0">
+                                            <div class="row justify-content-start m-0">
+                                                <div class="col-12 p-0">
+                                                    <div class="search-container">
+                                                        <select class="form-select px-3" name="searchBy">
+                                                            <option value="title" th:selected="${searchBy == 'title'}">
+                                                                제목
+                                                            </option>
+                                                            <option value="content"
+                                                                    th:selected="${searchBy == 'content'}">
+                                                                내용
+                                                            </option>
+                                                        </select>
+                                                        <input class="form-control px-3" type="text" name="searchTerm"
+                                                               placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
+                                                        <!-- 검색 버튼 -->
+                                                        <button type="submit">
+                                                            <i class="fas fa-search"></i>
+                                                        </button>
+                                                    </div>
                                                 </div>
                                             </div>
                                         </div>
-                                    </div>
-                                    <div class="col-1" style=""></div>
-                                    <div class="col-4">
-                                        <div class="row justify-content-end">
-                                            <!-- 정렬 또는 토글2 -->
-                                            <label>
-                                                <select class="form-select px-3" name="orderBy"
-                                                        onchange="this.form.submit()">
-                                                    <option value="recentedited"
-                                                            th:selected="${orderBy == 'recentedited'}">최근수정순
-                                                    </option>
+                                        <div class="col-1" style=""></div>
+                                        <div class="col-4">
+                                            <div class="row justify-content-end">
+                                                <!-- 정렬 또는 토글2 -->
+                                                <label>
+                                                    <select class="form-select px-3" name="orderBy"
+                                                            onchange="this.form.submit()">
+                                                        <option value="recentedited"
+                                                                th:selected="${orderBy == 'recentedited'}">최근수정순
+                                                        </option>
 
-                                                    <option value="recent" th:selected="${orderBy == 'recent'}">최근작성순
-                                                    </option>
-                                                    <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순
-                                                    </option>
+                                                        <option value="recent" th:selected="${orderBy == 'recent'}">
+                                                            최근작성순
+                                                        </option>
+                                                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순
+                                                        </option>
 
-                                                    <option value="topRated" th:selected="${orderBy == 'topRated'}">
-                                                        평점높은순
-                                                    </option>
-                                                    <option value="lowRated" th:selected="${orderBy == 'lowRated'}">
-                                                        평점낮은순
-                                                    </option>
-                                                    <option value="reviews" th:selected="${orderBy == 'reviews'}">
-                                                        리뷰많은순
-                                                    </option>
+                                                        <option value="topRated" th:selected="${orderBy == 'topRated'}">
+                                                            평점높은순
+                                                        </option>
+                                                        <option value="lowRated" th:selected="${orderBy == 'lowRated'}">
+                                                            평점낮은순
+                                                        </option>
+                                                        <option value="reviews" th:selected="${orderBy == 'reviews'}">
+                                                            리뷰많은순
+                                                        </option>
 
-                                                    <option value="title" th:selected="${orderBy == 'title'}">제목가나다순
-                                                    </option>
-                                                </select>
-                                            </label>
-                                        </div>
-                                    </div>
-                                </div> <!--검색, 소팅 (토글X)-->
-                                <div class="row justify-content-around">
-                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                    <div class="col-3" style="padding: 0 1.2rem;">
-                                        <div id="absdiv" class="row justify-content-end">
-                                            <!--                                        <div class="col-3">-->
-                                            <!--                                            <div class="toggle-switch">-->
-                                            <!--                                                &lt;!&ndash; 정렬 또는 토글1 &ndash;&gt;-->
-                                            <!--                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">-->
-                                            <!--                                                <label for="isToggledCheckbox" class="label">-->
-                                            <!--                                                    <div class="ball"></div>-->
-                                            <!--                                                </label>-->
-                                            <!--                                            </div>-->
-                                            <!--                                        </div>-->
-                                            <!--                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">진행중인 행사</div>-->
-                                        </div>
-                                    </div>
-                                </div> <!--토글-->
-                            </form>
-                        </div>
-                    </div>
-                    <div class="row justify-content-around mt-4">
-                        <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
-                            <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
-                                <div class="col-3 clickable-row"
-                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
-                                     th:each="myRctFree, iterStat : ${myRctFrees}"
-                                     th:attr="data-href=@{/user/my/rct/free/order(boardNo=${myRctFree.boardNo})}"
-                                     th:if="${iterStat.index < 3}">
-                                    <div class="row justify-content-center">
-                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
-                                             style="aspect-ratio: 1; border-radius: 5px;">
-                                            <div class="date-container px-2 py-1">
-                                                <div class="month"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctFree.createdDate)}"></div>
-                                                <div class="year"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctFree.createdDate)}"></div>
+                                                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순
+                                                        </option>
+                                                    </select>
+                                                </label>
                                             </div>
                                         </div>
-                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                        <!--                                    </div>-->
-                                        <div class="col-5" style="color: white; font-size: 0.8rem; font-weight: 530;"
-                                             th:text="${myRctFree.boardNo}">닉네임
-                                        </div>
-
-                                        <div class="col-3"
-                                             style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
-                                             th:text="${myRctFree.formattedCreatedDate}">시간
-                                        </div>
-                                    </div>
-                                    <div class="row justify-content-center">
-                                        <div class="col-12 my-3" style="">
-                                            <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                            <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                            <!-- 썸네일 이미지 있을때  -->
-                                            <!--                                        <img th:if="${mySoReview.thumbnailUrl != null}" th:src="${mySoReview.thumbnailUrl}" class="card-img-top" alt="썸네일 이미지">-->
-                                        </div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
-                                             th:text="${myRctFree.title}">이름
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
-                                             th:text="${myRctFree.content}">내용
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                    </div>
-
-                                </div>
-                                <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
-                                <div class="col-3" th:if="${myRctFrees.size() == 0}"></div>
-                                <div class="col-3" th:if="${myRctFrees.size() == 0 || myRctFrees.size() == 1}"></div>
-                                <div class="col-3"
-                                     th:if="${myRctFrees.size() == 0 || myRctFrees.size() == 1 || myRctFrees.size() == 2}"></div>
-                            </div>
-                            <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
-                                <div class="col-3 clickable-row"
-                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
-                                     th:each="myRctFree, iterStat : ${myRctFrees}"
-                                     th:attr="data-href=@{/user/my/rct/free/order(boardNo=${myRctFree.boardNo})}"
-                                     th:if="${iterStat.index >= 3}">
-                                    <div class="row justify-content-center">
-                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
-                                             style="aspect-ratio: 1; border-radius: 5px;">
-                                            <div class="date-container px-2 py-1">
-                                                <div class="month"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctFree.createdDate)}"></div>
-                                                <div class="year"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctFree.createdDate)}"></div>
+                                    </div> <!--검색, 소팅 (토글X)-->
+                                    <div class="row justify-content-around">
+                                        <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                        <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                        <div class="col-3" style="padding: 0 1.2rem;">
+                                            <div id="absdiv" class="row justify-content-end">
+                                                <!--                                        <div class="col-3">-->
+                                                <!--                                            <div class="toggle-switch">-->
+                                                <!--                                                &lt;!&ndash; 정렬 또는 토글1 &ndash;&gt;-->
+                                                <!--                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">-->
+                                                <!--                                                <label for="isToggledCheckbox" class="label">-->
+                                                <!--                                                    <div class="ball"></div>-->
+                                                <!--                                                </label>-->
+                                                <!--                                            </div>-->
+                                                <!--                                        </div>-->
+                                                <!--                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">진행중인 행사</div>-->
                                             </div>
                                         </div>
-                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                        <!--                                    </div>-->
-                                        <div class="col-5" style="color: white; font-size: 0.8rem; font-weight: 530;"
-                                             th:text="${myRctFree.boardNo}">닉네임
-                                        </div>
-
-                                        <div class="col-3"
-                                             style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
-                                             th:text="${myRctFree.formattedCreatedDate}">시간
-                                        </div>
-                                    </div>
-                                    <div class="row justify-content-center">
-                                        <div class="col-12 my-3" style="">
-                                            <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                            <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                            <!-- 썸네일 이미지 있을때  -->
-                                            <!--                                        <img th:if="${mySoReview.thumbnailUrl != null}" th:src="${mySoReview.thumbnailUrl}" class="card-img-top" alt="썸네일 이미지">-->
-                                        </div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
-                                             th:text="${myRctFree.title}">이름
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
-                                             th:text="${myRctFree.content}">내용
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                    </div>
-
-                                </div>
-
-                                <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
-                                <div class="col-3" th:if="${myRctFrees.size() <= 3}"></div>
-                                <div class="col-3" th:if="${myRctFrees.size() <= 3 || myRctFrees.size() == 4}"></div>
-                                <div class="col-3"
-                                     th:if="${myRctFrees.size() <= 3 || myRctFrees.size() == 4 || myRctFrees.size() == 5}"></div>
+                                    </div> <!--토글-->
+                                </form>
                             </div>
                         </div>
-                    </div>
-                    <div class="row justify-content-center">
-                        <!-- 페이징 -->
-                        <th:block th:if="${pages != null}">
-                            <div class="d-flex justify-content-center">
-                                <div class="btn-group">
-                                    <button type="button" class="btn btn-sm previous"
-                                            th:onclick="|location.href='@{/user/my/rct/free(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
-                                            th:disabled="${currentPage == 1}">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                             fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-                                            <path fill-rule="evenodd"
-                                                  d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                                        </svg>
-                                    </button>
-                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">
-                                        <button type="button" class="btn btn-sm me-2 pages"
-                                                th:text="${p}"
-                                                th:onclick="|location.href='@{/user/my/rct/free(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
-                                    </th:block>
-                                    <button type="button" class="btn btn-sm  next"
-                                            th:onclick="|location.href='@{/user/my/rct/free(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
-                                            th:disabled="${currentPage == pages}">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                             fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-                                            <path fill-rule="evenodd"
-                                                  d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
-                                        </svg>
-                                    </button>
+                        <div class="row justify-content-around mt-4">
+                            <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
+                                <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
+                                    <div class="col-3 clickable-row"
+                                         style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                         th:each="myRctFree, iterStat : ${myRctFrees}"
+                                         th:attr="data-href=@{/user/my/rct/free/order(boardNo=${myRctFree.boardNo})}"
+                                         th:if="${iterStat.index < 3}">
+                                        <div class="row justify-content-center">
+                                            <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                                 style="aspect-ratio: 1; border-radius: 5px;">
+                                                <div class="date-container px-2 py-1">
+                                                    <div class="month"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctFree.createdDate)}"></div>
+                                                    <div class="year"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctFree.createdDate)}"></div>
+                                                </div>
+                                            </div>
+                                            <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                            <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                            <!--                                    </div>-->
+                                            <div class="col-5"
+                                                 style="color: white; font-size: 0.8rem; font-weight: 530;"
+                                                 th:text="${myRctFree.boardNo}">닉네임
+                                            </div>
+
+                                            <div class="col-3"
+                                                 style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
+                                                 th:text="${myRctFree.formattedCreatedDate}">시간
+                                            </div>
+                                        </div>
+                                        <div class="row justify-content-center">
+                                            <div class="col-12 my-3" style="">
+                                                <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                                <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                                <!-- 썸네일 이미지 있을때  -->
+                                                <!--                                        <img th:if="${mySoReview.thumbnailUrl != null}" th:src="${mySoReview.thumbnailUrl}" class="card-img-top" alt="썸네일 이미지">-->
+                                            </div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                                 th:text="${myRctFree.title}">이름
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                                 th:text="${myRctFree.content}">내용
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                        </div>
+
+                                    </div>
+                                    <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
+                                    <div class="col-3" th:if="${myRctFrees.size() == 0}"></div>
+                                    <div class="col-3"
+                                         th:if="${myRctFrees.size() == 0 || myRctFrees.size() == 1}"></div>
+                                    <div class="col-3"
+                                         th:if="${myRctFrees.size() == 0 || myRctFrees.size() == 1 || myRctFrees.size() == 2}"></div>
+                                </div>
+                                <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
+                                    <div class="col-3 clickable-row"
+                                         style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                         th:each="myRctFree, iterStat : ${myRctFrees}"
+                                         th:attr="data-href=@{/user/my/rct/free/order(boardNo=${myRctFree.boardNo})}"
+                                         th:if="${iterStat.index >= 3}">
+                                        <div class="row justify-content-center">
+                                            <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                                 style="aspect-ratio: 1; border-radius: 5px;">
+                                                <div class="date-container px-2 py-1">
+                                                    <div class="month"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctFree.createdDate)}"></div>
+                                                    <div class="year"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctFree.createdDate)}"></div>
+                                                </div>
+                                            </div>
+                                            <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                            <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                            <!--                                    </div>-->
+                                            <div class="col-5"
+                                                 style="color: white; font-size: 0.8rem; font-weight: 530;"
+                                                 th:text="${myRctFree.boardNo}">닉네임
+                                            </div>
+
+                                            <div class="col-3"
+                                                 style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
+                                                 th:text="${myRctFree.formattedCreatedDate}">시간
+                                            </div>
+                                        </div>
+                                        <div class="row justify-content-center">
+                                            <div class="col-12 my-3" style="">
+                                                <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                                <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                                <!-- 썸네일 이미지 있을때  -->
+                                                <!--                                        <img th:if="${mySoReview.thumbnailUrl != null}" th:src="${mySoReview.thumbnailUrl}" class="card-img-top" alt="썸네일 이미지">-->
+                                            </div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                                 th:text="${myRctFree.title}">이름
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                                 th:text="${myRctFree.content}">내용
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                        </div>
+
+                                    </div>
+
+                                    <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
+                                    <div class="col-3" th:if="${myRctFrees.size() <= 3}"></div>
+                                    <div class="col-3"
+                                         th:if="${myRctFrees.size() <= 3 || myRctFrees.size() == 4}"></div>
+                                    <div class="col-3"
+                                         th:if="${myRctFrees.size() <= 3 || myRctFrees.size() == 4 || myRctFrees.size() == 5}"></div>
                                 </div>
                             </div>
-                        </th:block>
-                    </div>
-                </div><!--테이블 및 페이징 포함-->
+                        </div>
+                        <div class="row justify-content-center">
+                            <!-- 페이징 -->
+                            <th:block th:if="${pages != null}">
+                                <div class="d-flex justify-content-center">
+                                    <div class="btn-group">
+                                        <button type="button" class="btn btn-sm previous"
+                                                th:onclick="|location.href='@{/user/my/rct/free(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
+                                                th:disabled="${currentPage == 1}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                                 fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+                                                <path fill-rule="evenodd"
+                                                      d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                                            </svg>
+                                        </button>
+                                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">
+                                            <button type="button" class="btn btn-sm me-2 pages"
+                                                    th:text="${p}"
+                                                    th:onclick="|location.href='@{/user/my/rct/free(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
+                                        </th:block>
+                                        <button type="button" class="btn btn-sm  next"
+                                                th:onclick="|location.href='@{/user/my/rct/free(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
+                                                th:disabled="${currentPage == pages}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                                 fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+                                                <path fill-rule="evenodd"
+                                                      d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                                            </svg>
+                                        </button>
+                                    </div>
+                                </div>
+                            </th:block>
+                        </div>
+                    </div><!--테이블 및 페이징 포함-->
+                </div> <!--본화면-->
             </div> <!--본화면-->
-        </div> <!--본화면-->
 
-        <!--수정전-->
-        <!--    <div class="col-md-9">-->
-        <!--        <div class="review-list">-->
-        <!--            <h2>프리랜서 게시글 관리</h2>-->
-        <!--            <form id="sort-form" th:action="@{/user/my/rct/free}" method="get">-->
-        <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
-        <!--                <label>-->
-        <!--                    <select name="searchBy">-->
-        <!--                        <option value="title" th:selected="${searchBy == 'title'}">제목</option>-->
-        <!--                        <option value="content" th:selected="${searchBy == 'content'}">내용</option>-->
-        <!--                    </select>-->
-        <!--                </label>-->
-        <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
+            <!--수정전-->
+            <!--    <div class="col-md-9">-->
+            <!--        <div class="review-list">-->
+            <!--            <h2>프리랜서 게시글 관리</h2>-->
+            <!--            <form id="sort-form" th:action="@{/user/my/rct/free}" method="get">-->
+            <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
+            <!--                <label>-->
+            <!--                    <select name="searchBy">-->
+            <!--                        <option value="title" th:selected="${searchBy == 'title'}">제목</option>-->
+            <!--                        <option value="content" th:selected="${searchBy == 'content'}">내용</option>-->
+            <!--                    </select>-->
+            <!--                </label>-->
+            <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
 
-        <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
-        <!--                <button type="submit">검색</button>-->
+            <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
+            <!--                <button type="submit">검색</button>-->
 
-        <!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
-        <!--                <label>-->
-        <!--                    <select name="orderBy" onchange="this.form.submit()">-->
-        <!--                        <option value="recentedited" th:selected="${orderBy == 'recentedited'}">최근수정순</option>-->
+            <!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
+            <!--                <label>-->
+            <!--                    <select name="orderBy" onchange="this.form.submit()">-->
+            <!--                        <option value="recentedited" th:selected="${orderBy == 'recentedited'}">최근수정순</option>-->
 
-        <!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최근작성순</option>-->
-        <!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
+            <!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최근작성순</option>-->
+            <!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
 
-        <!--                        <option value="topRated" th:selected="${orderBy == 'topRated'}">평점높은순</option>-->
-        <!--                        <option value="lowRated" th:selected="${orderBy == 'lowRated'}">평점낮은순</option>-->
-        <!--                        <option value="reviews" th:selected="${orderBy == 'reviews'}">리뷰많은순</option>-->
+            <!--                        <option value="topRated" th:selected="${orderBy == 'topRated'}">평점높은순</option>-->
+            <!--                        <option value="lowRated" th:selected="${orderBy == 'lowRated'}">평점낮은순</option>-->
+            <!--                        <option value="reviews" th:selected="${orderBy == 'reviews'}">리뷰많은순</option>-->
 
-        <!--                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
-        <!--                    </select>-->
-        <!--                </label>-->
-        <!--            </form>-->
-        <!--            <table>-->
-        <!--                <thead>-->
-        <!--                <tr>-->
-        <!--                    <th>게시글 번호</th>-->
-        <!--                    <th>작성자</th>-->
-        <!--                    <th>제목</th>-->
-        <!--                    <th>내용</th>-->
-        <!--                    <th>이미지</th>-->
-        <!--                    <th>가격</th>-->
-        <!--                    <th>작성 일자</th>-->
-        <!--                    <th>수정 일자</th>-->
-        <!--                    <th>평점</th>-->
-        <!--                    <th>리뷰 개수</th>-->
-        <!--                </tr>-->
-        <!--                </thead>-->
-        <!--                <tbody>-->
-        <!--                <tr th:each="myRctFree : ${myRctFrees}" class="clickable-row" th:attr="data-href=@{/recruit/free/view(no=${myRctFree.boardNo})}">-->
-        <!--                    <td th:text="${myRctFree.boardNo}">게시글 번호</td>-->
-        <!--                    <td th:text="${myRctFree.writer}">작성자</td>-->
-        <!--                    <td th:text="${myRctFree.title}">제목</td>-->
-        <!--                    <td th:text="${myRctFree.content}">내용</td>-->
-        <!--                    <td th:text="${myRctFree.img}">이미지</td>-->
-        <!--                    <td th:text="${myRctFree.price}">가격</td>-->
-        <!--                    <td th:text="${myRctFree.createdDate}">작성 일자</td>-->
-        <!--                    <td th:text="${myRctFree.modifiedDate}">수정 일자</td>-->
-        <!--                    <td th:text="${myRctFree.averageRating}">평점</td>-->
-        <!--                    <td th:text="${myRctFree.reviewCount}">리뷰 개수</td>-->
-        <!--                </tr>-->
-        <!--                </tbody>-->
-        <!--            </table>-->
-        <!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
-        <!--            <th:block th:if="${pages != null}">-->
-        <!--                <div class="d-flex justify-content-center">-->
-        <!--                    <div class="btn-group">-->
-        <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/rct/free(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
-        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
-        <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
-        <!--                            </svg>-->
-        <!--                        </button>-->
-        <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
-        <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
-        <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/rct/free(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
-        <!--                        </th:block>-->
-        <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/rct/free(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
-        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
-        <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
-        <!--                            </svg>-->
-        <!--                        </button>-->
-        <!--                    </div>-->
-        <!--                </div>-->
-        <!--            </th:block>-->
-        <!--        </div>-->
-        <!--    </div>-->
+            <!--                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
+            <!--                    </select>-->
+            <!--                </label>-->
+            <!--            </form>-->
+            <!--            <table>-->
+            <!--                <thead>-->
+            <!--                <tr>-->
+            <!--                    <th>게시글 번호</th>-->
+            <!--                    <th>작성자</th>-->
+            <!--                    <th>제목</th>-->
+            <!--                    <th>내용</th>-->
+            <!--                    <th>이미지</th>-->
+            <!--                    <th>가격</th>-->
+            <!--                    <th>작성 일자</th>-->
+            <!--                    <th>수정 일자</th>-->
+            <!--                    <th>평점</th>-->
+            <!--                    <th>리뷰 개수</th>-->
+            <!--                </tr>-->
+            <!--                </thead>-->
+            <!--                <tbody>-->
+            <!--                <tr th:each="myRctFree : ${myRctFrees}" class="clickable-row" th:attr="data-href=@{/recruit/free/view(no=${myRctFree.boardNo})}">-->
+            <!--                    <td th:text="${myRctFree.boardNo}">게시글 번호</td>-->
+            <!--                    <td th:text="${myRctFree.writer}">작성자</td>-->
+            <!--                    <td th:text="${myRctFree.title}">제목</td>-->
+            <!--                    <td th:text="${myRctFree.content}">내용</td>-->
+            <!--                    <td th:text="${myRctFree.img}">이미지</td>-->
+            <!--                    <td th:text="${myRctFree.price}">가격</td>-->
+            <!--                    <td th:text="${myRctFree.createdDate}">작성 일자</td>-->
+            <!--                    <td th:text="${myRctFree.modifiedDate}">수정 일자</td>-->
+            <!--                    <td th:text="${myRctFree.averageRating}">평점</td>-->
+            <!--                    <td th:text="${myRctFree.reviewCount}">리뷰 개수</td>-->
+            <!--                </tr>-->
+            <!--                </tbody>-->
+            <!--            </table>-->
+            <!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
+            <!--            <th:block th:if="${pages != null}">-->
+            <!--                <div class="d-flex justify-content-center">-->
+            <!--                    <div class="btn-group">-->
+            <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/rct/free(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
+            <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
+            <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
+            <!--                            </svg>-->
+            <!--                        </button>-->
+            <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
+            <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
+            <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/rct/free(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
+            <!--                        </th:block>-->
+            <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/rct/free(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
+            <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
+            <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
+            <!--                            </svg>-->
+            <!--                        </button>-->
+            <!--                    </div>-->
+            <!--                </div>-->
+            <!--            </th:block>-->
+            <!--        </div>-->
+            <!--    </div>-->
+        </div>
     </div>
 </div>
 <div th:replace="common/footer.html"></div>

--- a/src/main/resources/templates/user/mypage_rct_free.html
+++ b/src/main/resources/templates/user/mypage_rct_free.html
@@ -104,20 +104,23 @@
   }
 </style>
 <div class="jumbotron">
-    <div class="row">
-        <div class="col-md-3 px-4">
-            <h3>나의 채용</h3>
-        </div>
-        <div class="col-md-9">
-            <nav class="navbar navbar-expand-md">
-                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                    <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
-                    <li><a th:href="@{/user/my/rct/creator}" class="nav-link px-2">창작자 등록 현황</a></li>
-                    <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a></li>
-                    <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2" style="color:#000;">프리랜서 게시글 관리</a></li>
-                    <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
-                </ul>
-            </nav>
+    <div class="container">
+        <div class="row">
+            <div class="col-md-3 px-4">
+                <h3>나의 채용</h3>
+            </div>
+            <div class="col-md-9">
+                <nav class="navbar navbar-expand-md">
+                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                        <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
+                        <li><a th:href="@{/user/my/rct/creator}" class="nav-link px-2">창작자 등록 현황</a></li>
+                        <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a></li>
+                        <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2" style="color:#000;">프리랜서 게시글 관리</a>
+                        </li>
+                        <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
+                    </ul>
+                </nav>
+            </div>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/user/mypage_rct_free.html
+++ b/src/main/resources/templates/user/mypage_rct_free.html
@@ -124,433 +124,498 @@
         </div>
     </div>
 </div>
-<div class="row">
-    <aside class="col-md-3 px-4">
-        <div class="row">
-            <div class="col-3"></div>
-            <div class="col-6">
-                <div class="panel">
-                    <ul class="list-group">
-                        <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
-                        <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-                        <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color: #03C75A;">나의 채용</a></li>
-                        <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-                        <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                        <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-                    </ul>
+<div class="container" style="padding:0;">
+    <div class="row">
+        <aside class="col-md-3 px-4">
+            <div class="row">
+                <div class="col-3"></div>
+                <div class="col-6">
+                    <div class="panel">
+                        <ul class="list-group">
+                            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
+                            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color: #03C75A;">나의 채용</a>
+                            </li>
+                            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+                        </ul>
+                    </div>
                 </div>
             </div>
-        </div>
-    </aside>
-    <style>
-        .form-select {
-        background-color : #FCFCFC;
-        border : none;
-        width : 100%;
-        height : 50px;
-        }
-        select {
-        color : #828282;
-        }
-        .form-control {
-        background-color : #FCFCFC;
-        border : none;
-        width : 100%;
-        height : 50px;
-        }
-
-
-        .form-control::placeholder {
-        color : #BBBBBB;
-        }
-
-        .date-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    background-color: #8E4B6E;
-    color: white;
-    border-radius: 10px;
-    text-align:center;
-    font-family: "Work Sans", sans-serif;
-}
-
-.platform-1 {
-    background-color: #03C75A;
-}
-
-.platform-2 {
-    background-color: #F5BF41;
-}
-
-.month {
-    font-size: 1.1rem; /* M의 크기를 설정 */
-    font-weight: 550;
-    line-height: 1;
-}
-
-.year {
-    font-size: 0.65rem; /* yyyy의 크기를 설정 */
-    font-weight: 400;
-}
-:root {
-    --background-color-light: #FFFFFF;
-    --text-color-light: #000000;
-    --toggle-background-light: #CCCCCC;
-    --toggle-ball-light: #FFFFFF;
-
-    --background-color-dark: #333333;
-    --text-color-dark: #FFFFFF;
-    --toggle-background-dark: #03C75A;
-    --toggle-ball-dark: #FFFFFF;
-
-    --font-size-base: 32px; /* 기본 텍스트 크기 */
-    --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
-}
-
-
-
-.toggle-switch {
-    position: relative;
-    display: inline-block;
-    width: 62px; /* 너비 조정 */
-    height: 38px; /* 높이 조정 */
-}
-
-.toggle-switch .checkbox {
-    opacity: 0;
-    width: 0;
-    height: 0;
-}
-#isToggledCheckbox {
-     opacity: 0;
-        width: 0;
-        height: 0;
-}
-
-.toggle-switch .label {
-    position: absolute;
-    cursor: pointer;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: var(--toggle-background-light);
-    transition: background-color 0.4s;
-    border-radius: 38px; /* 둥근 모서리 반경 조정 */
-}
-
-.toggle-switch .label:before {
-    position: absolute;
-    content: "";
-    height: 30px; /* 내부 원 높이 조정 */
-    width: 30px; /* 내부 원 너비 조정 */
-    left: 2px;
-    bottom: 0px;
-    background-color: var(--toggle-ball-light);
-    transition: transform 0.4s;
-    border-radius: 50%;
-}
-
-.toggle-switch input:checked + .label {
-    background-color: var(--toggle-background-dark);
-}
-
-.toggle-switch input:checked + .label:before {
-    transform: translateX(28px); /* 내부 원 이동 거리 조정 */
-}
-
-         #absdiv {
-            position: relative;
-            top: 60px; /* Move down by 20px from its current position */
-            z-index : 1000;
-        }
-
-        #searchbutton {
-            background-color: #828282;
-        }
-
-        .card-img-top {
-                width: 100%;
-                height: 100px;
-                object-fit: cover;
+        </aside>
+        <style>
+            .form-select {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
+            }
+            select {
+            color : #828282;
+            }
+            .form-control {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
             }
 
-    </style>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+
+            .form-control::placeholder {
+            color : #BBBBBB;
+            }
+
+            .date-container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        background-color: #8E4B6E;
+        color: white;
+        border-radius: 10px;
+        text-align:center;
+        font-family: "Work Sans", sans-serif;
+    }
+
+    .platform-1 {
+        background-color: #03C75A;
+    }
+
+    .platform-2 {
+        background-color: #F5BF41;
+    }
+
+    .month {
+        font-size: 1.1rem; /* M의 크기를 설정 */
+        font-weight: 550;
+        line-height: 1;
+    }
+
+    .year {
+        font-size: 0.65rem; /* yyyy의 크기를 설정 */
+        font-weight: 400;
+    }
+    :root {
+        --background-color-light: #FFFFFF;
+        --text-color-light: #000000;
+        --toggle-background-light: #CCCCCC;
+        --toggle-ball-light: #FFFFFF;
+
+        --background-color-dark: #333333;
+        --text-color-dark: #FFFFFF;
+        --toggle-background-dark: #03C75A;
+        --toggle-ball-dark: #FFFFFF;
+
+        --font-size-base: 32px; /* 기본 텍스트 크기 */
+        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+    }
 
 
-    <div class="col-md-9">
-        <div class="row" style="color: #828282;">
-            <div class="col-11">
-                <div class="row mb-4">
-                    <div class="col-12">
-                        <form id="sort-form" th:action="@{/user/my/rct/free}" method="get">
-                            <div class="row">
-                                <div class="col-7">
-                                    <div class="row justify-content-start m-0">
-                                        <div class="col-4">
-                                            <!-- 검색 조건 -->
+
+    .toggle-switch {
+        position: relative;
+        display: inline-block;
+        width: 62px; /* 너비 조정 */
+        height: 38px; /* 높이 조정 */
+    }
+
+    .toggle-switch .checkbox {
+        opacity: 0;
+        width: 0;
+        height: 0;
+    }
+    #isToggledCheckbox {
+         opacity: 0;
+            width: 0;
+            height: 0;
+    }
+
+    .toggle-switch .label {
+        position: absolute;
+        cursor: pointer;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: var(--toggle-background-light);
+        transition: background-color 0.4s;
+        border-radius: 38px; /* 둥근 모서리 반경 조정 */
+    }
+
+    .toggle-switch .label:before {
+        position: absolute;
+        content: "";
+        height: 30px; /* 내부 원 높이 조정 */
+        width: 30px; /* 내부 원 너비 조정 */
+        left: 2px;
+        bottom: 0px;
+        background-color: var(--toggle-ball-light);
+        transition: transform 0.4s;
+        border-radius: 50%;
+    }
+
+    .toggle-switch input:checked + .label {
+        background-color: var(--toggle-background-dark);
+    }
+
+    .toggle-switch input:checked + .label:before {
+        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+    }
+
+             #absdiv {
+                position: relative;
+                top: 60px; /* Move down by 20px from its current position */
+                z-index : 1000;
+            }
+
+            #searchbutton {
+                background-color: #828282;
+            }
+
+            .card-img-top {
+                    width: 100%;
+                    height: 100px;
+                    object-fit: cover;
+                }
+
+        </style>
+        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+              rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+              rel="stylesheet">
+
+
+        <div class="col-md-9">
+            <div class="row" style="color: #828282;">
+                <div class="col-11">
+                    <div class="row mb-4">
+                        <div class="col-12">
+                            <form id="sort-form" th:action="@{/user/my/rct/free}" method="get">
+                                <div class="row">
+                                    <div class="col-7">
+                                        <div class="row justify-content-start m-0">
+                                            <div class="col-4">
+                                                <!-- 검색 조건 -->
+                                                <label>
+                                                    <select class="form-select px-3" name="searchBy">
+                                                        <option value="title" th:selected="${searchBy == 'title'}">제목
+                                                        </option>
+                                                        <option value="content" th:selected="${searchBy == 'content'}">
+                                                            내용
+                                                        </option>
+                                                    </select>
+                                                </label>
+                                            </div>
+                                            <div class="col-6">
+                                                <input class="form-control px-3" type="text" name="searchTerm"
+                                                       placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
+                                            </div>
+                                            <div class="col-2">
+                                                <!-- 검색 버튼 -->
+                                                <button id="searchbutton" type="submit" class="btn btn-primary">검색
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-1" style=""></div>
+                                    <div class="col-4">
+                                        <div class="row justify-content-end">
+                                            <!-- 정렬 또는 토글2 -->
                                             <label>
-                                                <select class="form-select px-3" name="searchBy">
-                                                    <option value="title" th:selected="${searchBy == 'title'}">제목</option>
-                                                    <option value="content" th:selected="${searchBy == 'content'}">내용</option>
+                                                <select class="form-select px-3" name="orderBy"
+                                                        onchange="this.form.submit()">
+                                                    <option value="recentedited"
+                                                            th:selected="${orderBy == 'recentedited'}">최근수정순
+                                                    </option>
+
+                                                    <option value="recent" th:selected="${orderBy == 'recent'}">최근작성순
+                                                    </option>
+                                                    <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순
+                                                    </option>
+
+                                                    <option value="topRated" th:selected="${orderBy == 'topRated'}">
+                                                        평점높은순
+                                                    </option>
+                                                    <option value="lowRated" th:selected="${orderBy == 'lowRated'}">
+                                                        평점낮은순
+                                                    </option>
+                                                    <option value="reviews" th:selected="${orderBy == 'reviews'}">
+                                                        리뷰많은순
+                                                    </option>
+
+                                                    <option value="title" th:selected="${orderBy == 'title'}">제목가나다순
+                                                    </option>
                                                 </select>
                                             </label>
                                         </div>
-                                        <div class="col-6">
-                                            <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
-                                        </div>
-                                        <div class="col-2">
-                                            <!-- 검색 버튼 -->
-                                            <button id="searchbutton" type="submit" class="btn btn-primary">검색</button>
-                                        </div>
                                     </div>
-                                </div>
-                                <div class="col-1" style=""></div>
-                                <div class="col-4">
-                                    <div class="row justify-content-end">
-                                        <!-- 정렬 또는 토글2 -->
-                                        <label>
-                                            <select class="form-select px-3" name="orderBy" onchange="this.form.submit()">
-                                                <option value="recentedited" th:selected="${orderBy == 'recentedited'}">최근수정순</option>
-
-                                                <option value="recent" th:selected="${orderBy == 'recent'}">최근작성순</option>
-                                                <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>
-
-                                                <option value="topRated" th:selected="${orderBy == 'topRated'}">평점높은순</option>
-                                                <option value="lowRated" th:selected="${orderBy == 'lowRated'}">평점낮은순</option>
-                                                <option value="reviews" th:selected="${orderBy == 'reviews'}">리뷰많은순</option>
-
-                                                <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>
-                                            </select>
-                                        </label>
-                                    </div>
-                                </div>
-                            </div> <!--검색, 소팅 (토글X)-->
-                            <div class="row justify-content-around">
-                                <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                <div class="col-3" style="padding: 0 1.2rem;">
-                                    <div id="absdiv" class="row justify-content-end">
-                                        <!--                                        <div class="col-3">-->
-                                        <!--                                            <div class="toggle-switch">-->
-                                        <!--                                                &lt;!&ndash; 정렬 또는 토글1 &ndash;&gt;-->
-                                        <!--                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">-->
-                                        <!--                                                <label for="isToggledCheckbox" class="label">-->
-                                        <!--                                                    <div class="ball"></div>-->
-                                        <!--                                                </label>-->
-                                        <!--                                            </div>-->
-                                        <!--                                        </div>-->
-                                        <!--                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">진행중인 행사</div>-->
-                                    </div>
-                                </div>
-                            </div> <!--토글-->
-                        </form>
-                    </div>
-                </div>
-                <div class="row justify-content-around mt-4">
-                    <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
-                        <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
-                            <div class="col-3 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:each="myRctFree, iterStat : ${myRctFrees}" th:attr="data-href=@{/user/my/rct/free/order(boardNo=${myRctFree.boardNo})}" th:if="${iterStat.index < 3}">
-                                <div class="row justify-content-center">
-                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                        <div class="date-container px-2 py-1">
-                                            <div class="month" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctFree.createdDate)}"></div>
-                                            <div class="year" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctFree.createdDate)}"></div>
+                                </div> <!--검색, 소팅 (토글X)-->
+                                <div class="row justify-content-around">
+                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                    <div class="col-3" style="padding: 0 1.2rem;">
+                                        <div id="absdiv" class="row justify-content-end">
+                                            <!--                                        <div class="col-3">-->
+                                            <!--                                            <div class="toggle-switch">-->
+                                            <!--                                                &lt;!&ndash; 정렬 또는 토글1 &ndash;&gt;-->
+                                            <!--                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">-->
+                                            <!--                                                <label for="isToggledCheckbox" class="label">-->
+                                            <!--                                                    <div class="ball"></div>-->
+                                            <!--                                                </label>-->
+                                            <!--                                            </div>-->
+                                            <!--                                        </div>-->
+                                            <!--                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">진행중인 행사</div>-->
                                         </div>
                                     </div>
-                                    <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                    <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                    <!--                                    </div>-->
-                                    <div class="col-5" style="color: white; font-size: 0.8rem; font-weight: 530;"
-                                         th:text="${myRctFree.boardNo}">닉네임
-                                    </div>
-
-                                    <div class="col-3" style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;" th:text="${myRctFree.formattedCreatedDate}">시간</div>
-                                </div>
-                                <div class="row justify-content-center">
-                                    <div class="col-12 my-3" style="">
-                                        <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                        <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                        <!-- 썸네일 이미지 있을때  -->
-<!--                                        <img th:if="${mySoReview.thumbnailUrl != null}" th:src="${mySoReview.thumbnailUrl}" class="card-img-top" alt="썸네일 이미지">-->
-                                    </div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" th:text="${myRctFree.title}">이름</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${myRctFree.content}">내용</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                </div>
-
-                            </div>
-                            <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
-                            <div class="col-3" th:if="${myRctFrees.size() == 0}"></div>
-                            <div class="col-3" th:if="${myRctFrees.size() == 0 || myRctFrees.size() == 1}"></div>
-                            <div class="col-3" th:if="${myRctFrees.size() == 0 || myRctFrees.size() == 1 || myRctFrees.size() == 2}"></div>
-                        </div>
-                        <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
-                            <div class="col-3 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:each="myRctFree, iterStat : ${myRctFrees}" th:attr="data-href=@{/user/my/rct/free/order(boardNo=${myRctFree.boardNo})}" th:if="${iterStat.index >= 3}">
-                                <div class="row justify-content-center">
-                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                        <div class="date-container px-2 py-1">
-                                            <div class="month" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctFree.createdDate)}"></div>
-                                            <div class="year" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctFree.createdDate)}"></div>
-                                        </div>
-                                    </div>
-                                    <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                    <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                    <!--                                    </div>-->
-                                    <div class="col-5" style="color: white; font-size: 0.8rem; font-weight: 530;"
-                                         th:text="${myRctFree.boardNo}">닉네임
-                                    </div>
-
-                                    <div class="col-3" style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;" th:text="${myRctFree.formattedCreatedDate}">시간</div>
-                                </div>
-                                <div class="row justify-content-center">
-                                    <div class="col-12 my-3" style="">
-                                        <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                        <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                        <!-- 썸네일 이미지 있을때  -->
-                                        <!--                                        <img th:if="${mySoReview.thumbnailUrl != null}" th:src="${mySoReview.thumbnailUrl}" class="card-img-top" alt="썸네일 이미지">-->
-                                    </div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" th:text="${myRctFree.title}">이름</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${myRctFree.content}">내용</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                </div>
-
-                            </div>
-
-                            <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
-                            <div class="col-3" th:if="${myRctFrees.size() <= 3}"></div>
-                            <div class="col-3" th:if="${myRctFrees.size() <= 3 || myRctFrees.size() == 4}"></div>
-                            <div class="col-3" th:if="${myRctFrees.size() <= 3 || myRctFrees.size() == 4 || myRctFrees.size() == 5}"></div>
+                                </div> <!--토글-->
+                            </form>
                         </div>
                     </div>
-                </div>
-                <div class="row justify-content-center">
-                    <!-- 페이징 -->
-                    <th:block th:if="${pages != null}">
-                        <div class="d-flex justify-content-center">
-                            <div class="btn-group">
-                                <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/rct/free(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-                                        <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                                    </svg>
-                                </button>
-                                <th:block th:each="p : ${#numbers.sequence(1, pages)}">
-                                    <button type="button" class="btn btn-sm me-2 pages"
-                                            th:text="${p}" th:onclick="|location.href='@{/user/my/rct/free(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
-                                </th:block>
-                                <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/rct/free(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-                                        <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
-                                    </svg>
-                                </button>
+                    <div class="row justify-content-around mt-4">
+                        <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
+                            <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
+                                <div class="col-3 clickable-row"
+                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                     th:each="myRctFree, iterStat : ${myRctFrees}"
+                                     th:attr="data-href=@{/user/my/rct/free/order(boardNo=${myRctFree.boardNo})}"
+                                     th:if="${iterStat.index < 3}">
+                                    <div class="row justify-content-center">
+                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                             style="aspect-ratio: 1; border-radius: 5px;">
+                                            <div class="date-container px-2 py-1">
+                                                <div class="month"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctFree.createdDate)}"></div>
+                                                <div class="year"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctFree.createdDate)}"></div>
+                                            </div>
+                                        </div>
+                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                        <!--                                    </div>-->
+                                        <div class="col-5" style="color: white; font-size: 0.8rem; font-weight: 530;"
+                                             th:text="${myRctFree.boardNo}">닉네임
+                                        </div>
+
+                                        <div class="col-3"
+                                             style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
+                                             th:text="${myRctFree.formattedCreatedDate}">시간
+                                        </div>
+                                    </div>
+                                    <div class="row justify-content-center">
+                                        <div class="col-12 my-3" style="">
+                                            <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                            <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                            <!-- 썸네일 이미지 있을때  -->
+                                            <!--                                        <img th:if="${mySoReview.thumbnailUrl != null}" th:src="${mySoReview.thumbnailUrl}" class="card-img-top" alt="썸네일 이미지">-->
+                                        </div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                             th:text="${myRctFree.title}">이름
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                             th:text="${myRctFree.content}">내용
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                    </div>
+
+                                </div>
+                                <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
+                                <div class="col-3" th:if="${myRctFrees.size() == 0}"></div>
+                                <div class="col-3" th:if="${myRctFrees.size() == 0 || myRctFrees.size() == 1}"></div>
+                                <div class="col-3"
+                                     th:if="${myRctFrees.size() == 0 || myRctFrees.size() == 1 || myRctFrees.size() == 2}"></div>
+                            </div>
+                            <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
+                                <div class="col-3 clickable-row"
+                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                     th:each="myRctFree, iterStat : ${myRctFrees}"
+                                     th:attr="data-href=@{/user/my/rct/free/order(boardNo=${myRctFree.boardNo})}"
+                                     th:if="${iterStat.index >= 3}">
+                                    <div class="row justify-content-center">
+                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                             style="aspect-ratio: 1; border-radius: 5px;">
+                                            <div class="date-container px-2 py-1">
+                                                <div class="month"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctFree.createdDate)}"></div>
+                                                <div class="year"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctFree.createdDate)}"></div>
+                                            </div>
+                                        </div>
+                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                        <!--                                    </div>-->
+                                        <div class="col-5" style="color: white; font-size: 0.8rem; font-weight: 530;"
+                                             th:text="${myRctFree.boardNo}">닉네임
+                                        </div>
+
+                                        <div class="col-3"
+                                             style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
+                                             th:text="${myRctFree.formattedCreatedDate}">시간
+                                        </div>
+                                    </div>
+                                    <div class="row justify-content-center">
+                                        <div class="col-12 my-3" style="">
+                                            <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                            <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                            <!-- 썸네일 이미지 있을때  -->
+                                            <!--                                        <img th:if="${mySoReview.thumbnailUrl != null}" th:src="${mySoReview.thumbnailUrl}" class="card-img-top" alt="썸네일 이미지">-->
+                                        </div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                             th:text="${myRctFree.title}">이름
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                             th:text="${myRctFree.content}">내용
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                    </div>
+
+                                </div>
+
+                                <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
+                                <div class="col-3" th:if="${myRctFrees.size() <= 3}"></div>
+                                <div class="col-3" th:if="${myRctFrees.size() <= 3 || myRctFrees.size() == 4}"></div>
+                                <div class="col-3"
+                                     th:if="${myRctFrees.size() <= 3 || myRctFrees.size() == 4 || myRctFrees.size() == 5}"></div>
                             </div>
                         </div>
-                    </th:block>
-                </div>
-            </div><!--테이블 및 페이징 포함-->
+                    </div>
+                    <div class="row justify-content-center">
+                        <!-- 페이징 -->
+                        <th:block th:if="${pages != null}">
+                            <div class="d-flex justify-content-center">
+                                <div class="btn-group">
+                                    <button type="button" class="btn btn-sm previous"
+                                            th:onclick="|location.href='@{/user/my/rct/free(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
+                                            th:disabled="${currentPage == 1}">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                             fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+                                            <path fill-rule="evenodd"
+                                                  d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                                        </svg>
+                                    </button>
+                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">
+                                        <button type="button" class="btn btn-sm me-2 pages"
+                                                th:text="${p}"
+                                                th:onclick="|location.href='@{/user/my/rct/free(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
+                                    </th:block>
+                                    <button type="button" class="btn btn-sm  next"
+                                            th:onclick="|location.href='@{/user/my/rct/free(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
+                                            th:disabled="${currentPage == pages}">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                             fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+                                            <path fill-rule="evenodd"
+                                                  d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                                        </svg>
+                                    </button>
+                                </div>
+                            </div>
+                        </th:block>
+                    </div>
+                </div><!--테이블 및 페이징 포함-->
+            </div> <!--본화면-->
         </div> <!--본화면-->
-    </div> <!--본화면-->
 
-    <!--수정전-->
-<!--    <div class="col-md-9">-->
-<!--        <div class="review-list">-->
-<!--            <h2>프리랜서 게시글 관리</h2>-->
-<!--            <form id="sort-form" th:action="@{/user/my/rct/free}" method="get">-->
-<!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
-<!--                <label>-->
-<!--                    <select name="searchBy">-->
-<!--                        <option value="title" th:selected="${searchBy == 'title'}">제목</option>-->
-<!--                        <option value="content" th:selected="${searchBy == 'content'}">내용</option>-->
-<!--                    </select>-->
-<!--                </label>-->
-<!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
+        <!--수정전-->
+        <!--    <div class="col-md-9">-->
+        <!--        <div class="review-list">-->
+        <!--            <h2>프리랜서 게시글 관리</h2>-->
+        <!--            <form id="sort-form" th:action="@{/user/my/rct/free}" method="get">-->
+        <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
+        <!--                <label>-->
+        <!--                    <select name="searchBy">-->
+        <!--                        <option value="title" th:selected="${searchBy == 'title'}">제목</option>-->
+        <!--                        <option value="content" th:selected="${searchBy == 'content'}">내용</option>-->
+        <!--                    </select>-->
+        <!--                </label>-->
+        <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
 
-<!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
-<!--                <button type="submit">검색</button>-->
+        <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
+        <!--                <button type="submit">검색</button>-->
 
-<!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
-<!--                <label>-->
-<!--                    <select name="orderBy" onchange="this.form.submit()">-->
-<!--                        <option value="recentedited" th:selected="${orderBy == 'recentedited'}">최근수정순</option>-->
+        <!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
+        <!--                <label>-->
+        <!--                    <select name="orderBy" onchange="this.form.submit()">-->
+        <!--                        <option value="recentedited" th:selected="${orderBy == 'recentedited'}">최근수정순</option>-->
 
-<!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최근작성순</option>-->
-<!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
+        <!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최근작성순</option>-->
+        <!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
 
-<!--                        <option value="topRated" th:selected="${orderBy == 'topRated'}">평점높은순</option>-->
-<!--                        <option value="lowRated" th:selected="${orderBy == 'lowRated'}">평점낮은순</option>-->
-<!--                        <option value="reviews" th:selected="${orderBy == 'reviews'}">리뷰많은순</option>-->
+        <!--                        <option value="topRated" th:selected="${orderBy == 'topRated'}">평점높은순</option>-->
+        <!--                        <option value="lowRated" th:selected="${orderBy == 'lowRated'}">평점낮은순</option>-->
+        <!--                        <option value="reviews" th:selected="${orderBy == 'reviews'}">리뷰많은순</option>-->
 
-<!--                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
-<!--                    </select>-->
-<!--                </label>-->
-<!--            </form>-->
-<!--            <table>-->
-<!--                <thead>-->
-<!--                <tr>-->
-<!--                    <th>게시글 번호</th>-->
-<!--                    <th>작성자</th>-->
-<!--                    <th>제목</th>-->
-<!--                    <th>내용</th>-->
-<!--                    <th>이미지</th>-->
-<!--                    <th>가격</th>-->
-<!--                    <th>작성 일자</th>-->
-<!--                    <th>수정 일자</th>-->
-<!--                    <th>평점</th>-->
-<!--                    <th>리뷰 개수</th>-->
-<!--                </tr>-->
-<!--                </thead>-->
-<!--                <tbody>-->
-<!--                <tr th:each="myRctFree : ${myRctFrees}" class="clickable-row" th:attr="data-href=@{/recruit/free/view(no=${myRctFree.boardNo})}">-->
-<!--                    <td th:text="${myRctFree.boardNo}">게시글 번호</td>-->
-<!--                    <td th:text="${myRctFree.writer}">작성자</td>-->
-<!--                    <td th:text="${myRctFree.title}">제목</td>-->
-<!--                    <td th:text="${myRctFree.content}">내용</td>-->
-<!--                    <td th:text="${myRctFree.img}">이미지</td>-->
-<!--                    <td th:text="${myRctFree.price}">가격</td>-->
-<!--                    <td th:text="${myRctFree.createdDate}">작성 일자</td>-->
-<!--                    <td th:text="${myRctFree.modifiedDate}">수정 일자</td>-->
-<!--                    <td th:text="${myRctFree.averageRating}">평점</td>-->
-<!--                    <td th:text="${myRctFree.reviewCount}">리뷰 개수</td>-->
-<!--                </tr>-->
-<!--                </tbody>-->
-<!--            </table>-->
-<!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
-<!--            <th:block th:if="${pages != null}">-->
-<!--                <div class="d-flex justify-content-center">-->
-<!--                    <div class="btn-group">-->
-<!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/rct/free(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
-<!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
-<!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
-<!--                            </svg>-->
-<!--                        </button>-->
-<!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
-<!--                            <button type="button" class="btn btn-sm me-2 pages"-->
-<!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/rct/free(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
-<!--                        </th:block>-->
-<!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/rct/free(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
-<!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
-<!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
-<!--                            </svg>-->
-<!--                        </button>-->
-<!--                    </div>-->
-<!--                </div>-->
-<!--            </th:block>-->
-<!--        </div>-->
-<!--    </div>-->
+        <!--                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
+        <!--                    </select>-->
+        <!--                </label>-->
+        <!--            </form>-->
+        <!--            <table>-->
+        <!--                <thead>-->
+        <!--                <tr>-->
+        <!--                    <th>게시글 번호</th>-->
+        <!--                    <th>작성자</th>-->
+        <!--                    <th>제목</th>-->
+        <!--                    <th>내용</th>-->
+        <!--                    <th>이미지</th>-->
+        <!--                    <th>가격</th>-->
+        <!--                    <th>작성 일자</th>-->
+        <!--                    <th>수정 일자</th>-->
+        <!--                    <th>평점</th>-->
+        <!--                    <th>리뷰 개수</th>-->
+        <!--                </tr>-->
+        <!--                </thead>-->
+        <!--                <tbody>-->
+        <!--                <tr th:each="myRctFree : ${myRctFrees}" class="clickable-row" th:attr="data-href=@{/recruit/free/view(no=${myRctFree.boardNo})}">-->
+        <!--                    <td th:text="${myRctFree.boardNo}">게시글 번호</td>-->
+        <!--                    <td th:text="${myRctFree.writer}">작성자</td>-->
+        <!--                    <td th:text="${myRctFree.title}">제목</td>-->
+        <!--                    <td th:text="${myRctFree.content}">내용</td>-->
+        <!--                    <td th:text="${myRctFree.img}">이미지</td>-->
+        <!--                    <td th:text="${myRctFree.price}">가격</td>-->
+        <!--                    <td th:text="${myRctFree.createdDate}">작성 일자</td>-->
+        <!--                    <td th:text="${myRctFree.modifiedDate}">수정 일자</td>-->
+        <!--                    <td th:text="${myRctFree.averageRating}">평점</td>-->
+        <!--                    <td th:text="${myRctFree.reviewCount}">리뷰 개수</td>-->
+        <!--                </tr>-->
+        <!--                </tbody>-->
+        <!--            </table>-->
+        <!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
+        <!--            <th:block th:if="${pages != null}">-->
+        <!--                <div class="d-flex justify-content-center">-->
+        <!--                    <div class="btn-group">-->
+        <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/rct/free(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
+        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
+        <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
+        <!--                            </svg>-->
+        <!--                        </button>-->
+        <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
+        <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
+        <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/rct/free(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
+        <!--                        </th:block>-->
+        <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/rct/free(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
+        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
+        <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
+        <!--                            </svg>-->
+        <!--                        </button>-->
+        <!--                    </div>-->
+        <!--                </div>-->
+        <!--            </th:block>-->
+        <!--        </div>-->
+        <!--    </div>-->
+    </div>
 </div>
 <div th:replace="common/footer.html"></div>
 </body>

--- a/src/main/resources/templates/user/mypage_rct_free.html
+++ b/src/main/resources/templates/user/mypage_rct_free.html
@@ -106,20 +106,26 @@
 <div class="jumbotron">
     <div class="container">
         <div class="row">
-            <div class="col-md-3 px-4">
-                <h3>나의 채용</h3>
-            </div>
-            <div class="col-md-9">
-                <nav class="navbar navbar-expand-md">
-                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                        <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
-                        <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a>
-                        </li>
-                        <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2" style="color:#000;">프리랜서 게시글 관리</a></li>
-                        <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
-                        <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보 수정</a></li>
-                    </ul>
-                </nav>
+            <div class="col-9">
+                <div class="row">
+                    <div class="col-md-3 px-4">
+                        <h3>나의 채용</h3>
+                    </div>
+                    <div class="col-md-9">
+                        <nav class="navbar navbar-expand-md">
+                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
+                                <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a>
+                                </li>
+                                <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2" style="color:#000;">프리랜서 게시글
+                                    관리</a></li>
+                                <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
+                                <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보
+                                    수정</a></li>
+                            </ul>
+                        </nav>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/user/mypage_rct_free.html
+++ b/src/main/resources/templates/user/mypage_rct_free.html
@@ -135,7 +135,7 @@
         <aside class="col-md-3 px-4">
             <div class="row">
                 <div class="col-1"></div>
-                <div class="col-6">
+                <div class="col-8">
                     <div class="panel">
                         <ul class="list-group">
                             <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>

--- a/src/main/resources/templates/user/mypage_rct_free.html
+++ b/src/main/resources/templates/user/mypage_rct_free.html
@@ -112,11 +112,11 @@
             <div class="col-md-9">
                 <nav class="navbar navbar-expand-md">
                     <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                        <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 등록 현황</a></li>
                         <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
-                        <li><a th:href="@{/user/my/rct/creator}" class="nav-link px-2">창작자 등록 현황</a></li>
-                        <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a></li>
-                        <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2" style="color:#000;">프리랜서 게시글 관리</a>
+                        <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a>
                         </li>
+                        <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2" style="color:#000;">프리랜서 게시글 관리</a></li>
                         <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
                     </ul>
                 </nav>

--- a/src/main/resources/templates/user/mypage_rct_free.html
+++ b/src/main/resources/templates/user/mypage_rct_free.html
@@ -346,7 +346,7 @@
                                 }
 
                                 .search-container button i {
-                                    color: #666;
+                                    color: #A6AAB5;
                                 }
 
                                 .search-container button:hover i {

--- a/src/main/resources/templates/user/mypage_rct_free.html
+++ b/src/main/resources/templates/user/mypage_rct_free.html
@@ -112,12 +112,12 @@
             <div class="col-md-9">
                 <nav class="navbar navbar-expand-md">
                     <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                        <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 등록 현황</a></li>
                         <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
                         <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a>
                         </li>
                         <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2" style="color:#000;">프리랜서 게시글 관리</a></li>
                         <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
+                        <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보 수정</a></li>
                     </ul>
                 </nav>
             </div>

--- a/src/main/resources/templates/user/mypage_rct_free.html
+++ b/src/main/resources/templates/user/mypage_rct_free.html
@@ -296,14 +296,69 @@
             <div class="row" style="color: #828282;">
                 <div class="col-11">
                     <div class="row mb-4">
-                        <div class="col-12">
+                        <div class="col-12 p-0">
+                            <style>
+                                .col-4 select {
+                                    border-radius: 50px;
+                                    text-align: center;
+                                }
+                                /* 검색창 스타일 */
+                                .search-container {
+                                    width: 300px;
+                                }
+
+                                .search-container select {
+                                    position: absolute;
+                                    left: 0%;
+                                    width: 30%;
+                                    height: 50px;
+                                    color: #828282;
+                                    font-size: 1rem;
+                                    border-radius: 50px 0 0 50px;
+                                    outline: none;
+                                }
+                                .search-container input[type="text"] {
+                                    position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
+                                    left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
+                                    width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
+                                    height: 50px;
+                                    padding: 10px 40px 10px 15px;
+                                    font-size: 1rem;
+                                    outline: none;
+                                    border-radius: 0 50px 50px 0;
+                                    transition: border-color 0.3s, background-color 0.3s;
+                                    color: #828282; /* 입력 텍스트 색상 변경 */
+                                }
+
+                                .search-container input[type="text"]::placeholder {
+                                    color: #BBBBBB; /* placeholder 색상 변경 */
+                                }
+
+
+                                .search-container button {
+                                    position: absolute;
+                                    right: 1rem;
+                                    top: 25px;
+                                    background: none;
+                                    transform: translateY(-50%);
+                                    border: none;
+                                    cursor: pointer;
+                                }
+
+                                .search-container button i {
+                                    color: #666;
+                                }
+
+                                .search-container button:hover i {
+                                    color: #03C75A;
+                                }
+                            </style>
                             <form id="sort-form" th:action="@{/user/my/rct/free}" method="get">
-                                <div class="row">
-                                    <div class="col-7">
+                                <div class="row m-0">
+                                    <div class="col-7 p-0">
                                         <div class="row justify-content-start m-0">
-                                            <div class="col-4">
-                                                <!-- 검색 조건 -->
-                                                <label>
+                                            <div class="col-12 p-0">
+                                                <div class="search-container">
                                                     <select class="form-select px-3" name="searchBy">
                                                         <option value="title" th:selected="${searchBy == 'title'}">제목
                                                         </option>
@@ -311,16 +366,12 @@
                                                             내용
                                                         </option>
                                                     </select>
-                                                </label>
-                                            </div>
-                                            <div class="col-6">
-                                                <input class="form-control px-3" type="text" name="searchTerm"
-                                                       placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
-                                            </div>
-                                            <div class="col-2">
-                                                <!-- 검색 버튼 -->
-                                                <button id="searchbutton" type="submit" class="btn btn-primary">검색
-                                                </button>
+                                                    <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
+                                                    <!-- 검색 버튼 -->
+                                                    <button type="submit">
+                                                        <i class="fas fa-search"></i>
+                                                    </button>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>

--- a/src/main/resources/templates/user/mypage_rct_free_orderlist.html
+++ b/src/main/resources/templates/user/mypage_rct_free_orderlist.html
@@ -134,7 +134,7 @@
     <div class="row">
         <aside class="col-md-3 px-4">
             <div class="row">
-                <div class="col-3"></div>
+                <div class="col-1"></div>
                 <div class="col-6">
                     <div class="panel">
                         <ul class="list-group">

--- a/src/main/resources/templates/user/mypage_rct_free_orderlist.html
+++ b/src/main/resources/templates/user/mypage_rct_free_orderlist.html
@@ -352,7 +352,7 @@
                                 }
 
                                 .search-container button i {
-                                    color: #666;
+                                    color: #A6AAB5;
                                 }
 
                                 .search-container button:hover i {

--- a/src/main/resources/templates/user/mypage_rct_free_orderlist.html
+++ b/src/main/resources/templates/user/mypage_rct_free_orderlist.html
@@ -104,20 +104,23 @@
   }
 </style>
 <div class="jumbotron">
-    <div class="row">
-        <div class="col-md-3 px-4">
-            <h3>나의 채용</h3>
-        </div>
-        <div class="col-md-9">
-            <nav class="navbar navbar-expand-md">
-                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                    <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
-                    <li><a th:href="@{/user/my/rct/creator}" class="nav-link px-2">창작자 등록 현황</a></li>
-                    <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a></li>
-                    <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2" style="color:#000;">프리랜서 게시글 관리</a></li>
-                    <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
-                </ul>
-            </nav>
+    <div class="container">
+        <div class="row">
+            <div class="col-md-3 px-4">
+                <h3>나의 채용</h3>
+            </div>
+            <div class="col-md-9">
+                <nav class="navbar navbar-expand-md">
+                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                        <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
+                        <li><a th:href="@{/user/my/rct/creator}" class="nav-link px-2">창작자 등록 현황</a></li>
+                        <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a></li>
+                        <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2" style="color:#000;">프리랜서 게시글 관리</a>
+                        </li>
+                        <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
+                    </ul>
+                </nav>
+            </div>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/user/mypage_rct_free_orderlist.html
+++ b/src/main/resources/templates/user/mypage_rct_free_orderlist.html
@@ -106,20 +106,26 @@
 <div class="jumbotron">
     <div class="container">
         <div class="row">
-            <div class="col-md-3 px-4">
-                <h3>나의 채용</h3>
-            </div>
-            <div class="col-md-9">
-                <nav class="navbar navbar-expand-md">
-                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                        <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
-                        <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a>
-                        </li>
-                        <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2" style="color:#000;">프리랜서 게시글 관리</a></li>
-                        <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
-                        <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보 수정</a></li>
-                    </ul>
-                </nav>
+            <div class="col-9">
+                <div class="row">
+                    <div class="col-md-3 px-4">
+                        <h3>나의 채용</h3>
+                    </div>
+                    <div class="col-md-9">
+                        <nav class="navbar navbar-expand-md">
+                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
+                                <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a>
+                                </li>
+                                <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2" style="color:#000;">프리랜서 게시글
+                                    관리</a></li>
+                                <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
+                                <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보
+                                    수정</a></li>
+                            </ul>
+                        </nav>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/user/mypage_rct_free_orderlist.html
+++ b/src/main/resources/templates/user/mypage_rct_free_orderlist.html
@@ -135,7 +135,7 @@
         <aside class="col-md-3 px-4">
             <div class="row">
                 <div class="col-1"></div>
-                <div class="col-6">
+                <div class="col-8">
                     <div class="panel">
                         <ul class="list-group">
                             <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>

--- a/src/main/resources/templates/user/mypage_rct_free_orderlist.html
+++ b/src/main/resources/templates/user/mypage_rct_free_orderlist.html
@@ -86,457 +86,488 @@
 
 <div th:replace="~{common/menubar}"></div>
 <style>
-    .jumbotron {
-    position : relative;
-    background-color : #EEEEEE;
+    html, body {
+        height: 100%;
+        margin: 0;
     }
-    .jumbotron .row {
-    position : absolute;
-    width : 100%;
-    bottom: 0%;
+    body {
+        display: flex;
+        flex-direction: column;
     }
-    .nav-link {
-            color: #828282;
+    .content-wrapper {
+        flex: 1 0 auto;
     }
-    ul {
-  list-style: none;
-  padding-left : 0px;
-  }
+    footer {
+        flex-shrink: 0;
+    }
+
 </style>
-<div class="jumbotron">
-    <div class="container">
-        <div class="row">
-            <div class="col-9">
-                <div class="row">
-                    <div class="col-md-3 px-4">
-                        <h3>나의 채용</h3>
-                    </div>
-                    <div class="col-md-9">
-                        <nav class="navbar navbar-expand-md">
-                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
-                                <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a>
-                                </li>
-                                <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2" style="color:#000;">프리랜서 게시글
-                                    관리</a></li>
-                                <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
-                                <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보
-                                    수정</a></li>
-                            </ul>
-                        </nav>
+<div class="content-wrapper">
+    <style>
+        .jumbotron {
+        position : relative;
+        background-color : #EEEEEE;
+        }
+        .jumbotron .row {
+        position : absolute;
+        width : 100%;
+        bottom: 0%;
+        }
+        .nav-link {
+                color: #828282;
+        }
+        ul {
+      list-style: none;
+      padding-left : 0px;
+      }
+    </style>
+    <div class="jumbotron">
+        <div class="container">
+            <div class="row">
+                <div class="col-9">
+                    <div class="row">
+                        <div class="col-md-3 px-4">
+                            <h3>나의 채용</h3>
+                        </div>
+                        <div class="col-md-9">
+                            <nav class="navbar navbar-expand-md">
+                                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                    <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
+                                    <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a>
+                                    </li>
+                                    <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2" style="color:#000;">프리랜서
+                                        게시글
+                                        관리</a></li>
+                                    <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
+                                    <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보
+                                        수정</a></li>
+                                </ul>
+                            </nav>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
-<div class="container" style="padding:0;">
-    <div class="row">
-        <aside class="col-md-3 px-4">
-            <div class="row">
-                <div class="col-1"></div>
-                <div class="col-8">
-                    <div class="panel">
-                        <ul class="list-group">
-                            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
-                            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-                            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color: #03C75A;">나의 채용</a>
-                            </li>
-                            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-        </aside>
-        <!--    <script>-->
-        <!--        function toggleCheckboxValue() {-->
-        <!--            const checkbox = document.getElementById('isToggledCheckbox');-->
-        <!--            if(!checkbox.checked) checkbox.value = 'N';-->
-        <!--            else checkbox.value = 'Y';-->
-        <!--            document.getElementById('filter-form').submit();-->
-        <!--        }-->
-        <!--    </script>-->
-        <script> // toggle + sorting
-        function updateCheckboxValueAndSubmit() {
-            const checkbox = document.getElementById('isToggledCheckbox');
-            const form = document.getElementById('filter-and-sort-form');
-            // 체크박스가 체크된 상태를 확인
-            checkbox.value = checkbox.checked ? 'Y' : 'N';
-            // 폼 제출
-            form.submit();
-        }
-
-        function submitForm() {
-            document.getElementById('filter-and-sort-form').submit();
-        }
-        </script>
-        <style>
-            .form-select {
-            background-color : #FCFCFC;
-            border : none;
-            width : 100%;
-            height : 50px;
-            }
-            select {
-            color : #828282;
-            }
-            .form-control {
-            background-color : #FCFCFC;
-            border : none;
-            width : 100%;
-            height : 50px;
-            }
-
-
-            .form-control::placeholder {
-            color : #BBBBBB;
-            }
-
-            .date-container {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        background-color: #8E4B6E;
-        color: white;
-        border-radius: 10px;
-        text-align:center;
-        font-family: "Work Sans", sans-serif;
-    }
-
-    .month {
-        font-size: 1.1rem; /* M의 크기를 설정 */
-        font-weight: 550;
-        line-height: 1;
-    }
-
-    .year {
-        font-size: 0.65rem; /* yyyy의 크기를 설정 */
-        font-weight: 400;
-    }
-    :root {
-        --background-color-light: #FFFFFF;
-        --text-color-light: #000000;
-        --toggle-background-light: #CCCCCC;
-        --toggle-ball-light: #FFFFFF;
-
-        --background-color-dark: #333333;
-        --text-color-dark: #FFFFFF;
-        --toggle-background-dark: #03C75A;
-        --toggle-ball-dark: #FFFFFF;
-
-        --font-size-base: 32px; /* 기본 텍스트 크기 */
-        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
-    }
-
-
-
-    .toggle-switch {
-        position: relative;
-        display: inline-block;
-        width: 62px; /* 너비 조정 */
-        height: 38px; /* 높이 조정 */
-    }
-
-    .toggle-switch .checkbox {
-        opacity: 0;
-        width: 0;
-        height: 0;
-    }
-    #isToggledCheckbox {
-         opacity: 0;
-            width: 0;
-            height: 0;
-    }
-
-    .toggle-switch .label {
-        position: absolute;
-        cursor: pointer;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background-color: var(--toggle-background-light);
-        transition: background-color 0.4s;
-        border-radius: 38px; /* 둥근 모서리 반경 조정 */
-    }
-
-    .toggle-switch .label:before {
-        position: absolute;
-        content: "";
-        height: 30px; /* 내부 원 높이 조정 */
-        width: 30px; /* 내부 원 너비 조정 */
-        left: 2px;
-        bottom: 0px;
-        background-color: var(--toggle-ball-light);
-        transition: transform 0.4s;
-        border-radius: 50%;
-    }
-
-    .toggle-switch input:checked + .label {
-        background-color: var(--toggle-background-dark);
-    }
-
-    .toggle-switch input:checked + .label:before {
-        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
-    }
-
-             .absdiv {
-                position: relative;
-                top: 60px; /* Move down by 20px from its current position */
-                z-index : 1000;
-            }
-
-            #searchbutton {
-                background-color: #828282;
-            }
-        </style>
-        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
-              rel="stylesheet">
-        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
-              rel="stylesheet">
-        <!--수정후-->
-        <div class="col-md-9">
-            <div class="row" style="color: #828282;">
-                <div class="col-11">
-                    <div class="row">
-                        <div class="col-12 p-0">
-                            <style>
-                                .col-4 select {
-                                    border-radius: 50px;
-                                    text-align: center;
-                                }
-                                /* 검색창 스타일 */
-                                .search-container {
-                                    width: 300px;
-                                }
-
-                                .search-container select {
-                                    position: absolute;
-                                    left: 0%;
-                                    width: 30%;
-                                    height: 50px;
-                                    color: #828282;
-                                    font-size: 1rem;
-                                    border-radius: 50px 0 0 50px;
-                                    outline: none;
-                                }
-                                .search-container input[type="text"] {
-                                    position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
-                                    left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
-                                    width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
-                                    height: 50px;
-                                    padding: 10px 40px 10px 15px;
-                                    font-size: 1rem;
-                                    outline: none;
-                                    border-radius: 0 50px 50px 0;
-                                    transition: border-color 0.3s, background-color 0.3s;
-                                    color: #828282; /* 입력 텍스트 색상 변경 */
-                                }
-
-                                .search-container input[type="text"]::placeholder {
-                                    color: #BBBBBB; /* placeholder 색상 변경 */
-                                }
-
-
-                                .search-container button {
-                                    position: absolute;
-                                    right: 1rem;
-                                    top: 25px;
-                                    background: none;
-                                    transform: translateY(-50%);
-                                    border: none;
-                                    cursor: pointer;
-                                }
-
-                                .search-container button i {
-                                    color: #A6AAB5;
-                                }
-
-                                .search-container button:hover i {
-                                    color: #03C75A;
-                                }
-                            </style>
-                            <form id="filter-and-sort-form" th:action="@{/user/my/rct/free/order(boardNo=${boardNo})}" method="get">
-                                <div class="row m-0">
-                                    <div class="col-7 p-0">
-                                        <div class="row justify-content-start m-0">
-                                            <div class="col-12 p-0">
-                                                <div class="search-container">
-                                                    <select class="form-select px-3" name="searchBy">
-                                                        <option value="boardNo" th:selected="${searchBy == 'boardNo'}">
-                                                            구매상품번호
-                                                        </option>
-                                                    </select>
-                                                    <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
-                                                    <!-- 검색 버튼 -->
-                                                    <input type="hidden" name="boardNo" th:value="${boardNo}"/>
-                                                    <button type="submit">
-                                                        <i class="fas fa-search"></i>
-                                                    </button>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="col-1" style=""></div>
-                                    <div class="col-4">
-                                        <div class="row justify-content-end">
-                                            <!-- 정렬 또는 토글2 -->
-                                            <label>
-                                                <select class="form-select px-3" name="orderBy" onchange="submitForm()">
-                                                    <option value="recent" th:selected="${orderBy == 'recent'}">최근주문순
-                                                    </option>
-                                                    <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순
-                                                    </option>
-                                                    <option value="expensive" th:selected="${orderBy == 'expensive'}">
-                                                        결제금액높은순
-                                                    </option>
-                                                    <option value="cheap" th:selected="${orderBy == 'cheap'}">결제금액낮은순
-                                                    </option>
-                                                </select>
-                                            </label>
-                                        </div>
-                                    </div>
-                                </div> <!--검색, 소팅 (토글X)-->
-                                <div class="row justify-content-around">
-                                    <div class="col-3" style="padding: 0 1.2rem;">
-                                        <div class="absdiv">
-                                            <a href="javascript:window.history.back();" class="btn btn-primary"
-                                               style="background-color: #03C75A;">뒤로가기</a>
-
-                                        </div>
-                                    </div>
-                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                    <div class="col-3" style="padding: 0 1.2rem;">
-                                        <div class="row justify-content-end absdiv">
-                                            <div class="col-3">
-                                                <div class="toggle-switch">
-                                                    <!-- 정렬 또는 토글1 -->
-                                                    <input type="checkbox" name="isToggled" id="isToggledCheckbox"
-                                                           value="Y" th:checked="${isToggled == 'Y'}"
-                                                           onchange="updateCheckboxValueAndSubmit()">
-                                                    <label for="isToggledCheckbox" class="label">
-                                                        <div class="ball"></div>
-                                                    </label>
-                                                </div>
-                                            </div>
-                                            <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">
-                                                마감된 작업
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div> <!--토글-->
-                            </form>
+    <div class="container" style="padding:0;">
+        <div class="row">
+            <aside class="col-md-3 px-4">
+                <div class="row">
+                    <div class="col-1"></div>
+                    <div class="col-8">
+                        <div class="panel">
+                            <ul class="list-group">
+                                <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
+                                <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color: #03C75A;">나의
+                                    채용</a>
+                                </li>
+                                <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                                <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                                <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+                            </ul>
                         </div>
                     </div>
+                </div>
+            </aside>
+            <!--    <script>-->
+            <!--        function toggleCheckboxValue() {-->
+            <!--            const checkbox = document.getElementById('isToggledCheckbox');-->
+            <!--            if(!checkbox.checked) checkbox.value = 'N';-->
+            <!--            else checkbox.value = 'Y';-->
+            <!--            document.getElementById('filter-form').submit();-->
+            <!--        }-->
+            <!--    </script>-->
+            <script> // toggle + sorting
+            function updateCheckboxValueAndSubmit() {
+                const checkbox = document.getElementById('isToggledCheckbox');
+                const form = document.getElementById('filter-and-sort-form');
+                // 체크박스가 체크된 상태를 확인
+                checkbox.value = checkbox.checked ? 'Y' : 'N';
+                // 폼 제출
+                form.submit();
+            }
 
-                    <div class="row justify-content-around">
-                        <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
-                            <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
-                                <div class="col-11"
-                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;">
-                                    <div class="row justify-content-center mx-3">
-                                        <div class="col-1 p-0 d-flex align-items-center justify-content-center"
-                                             style="aspect-ratio: 1; border-radius: 5px;">
-                                            <div class="date-container px-2 py-1">
-                                                <div class="month"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(board.createdDate)}"></div>
-                                                <div class="year"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(board.createdDate)}"></div>
-                                            </div>
-                                        </div>
-                                        <div class="col-5" style="color: white; " th:text="${board.boardNo}">닉네임</div>
-                                        <div class="col-6"
-                                             style="padding:0; font-size: 1rem; text-align: right; color: #BDBDBD;"
-                                             th:text="${board.formattedCreatedDate}">1주일 전
-                                        </div>
-                                    </div>
-                                    <div class="row justify-content-center mx-3">
-                                        <div class="col-12" style="color: white;">사진</div>
-                                    </div>
-                                    <div class="row justify-content-center mx-3">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
-                                             th:text="${board.title}">이름
-                                        </div>
-                                        <div class="col-3 clickable-row" style="padding: 0; text-align: right;"
-                                             th:attr="data-href=@{/recruit/free/view(no=${boardNo})}">→
-                                        </div>
-                                    </div>
-                                    <div class="row justify-content-center mx-3">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
-                                             th:text="${board.content}">내용
-                                        </div>
-                                        <div class="col-3 clickable-row" style="padding: 0; text-align: right;"
-                                             th:attr="data-href=@{/recruit/free/view(no=${boardNo})}">게시글 확인
-                                        </div>
-                                    </div>
-                                    <div class="row justify-content-center mx-3 my-5">
-                                        <div class="col-12 m-0 p-0" style="color: #333333;">
-                                            <table>
-                                                <thead>
-                                                <tr>
-                                                    <th>주문 번호</th>
-                                                    <th>구매자</th>
-                                                    <th>구매상품</th>
-                                                    <th>구매 갯수</th>
-                                                    <th>결제 금액</th>
-                                                    <th>구매 일자</th>
-                                                    <th>작업 상태</th>
-                                                </tr>
-                                                </thead>
-                                                <tbody>
-                                                <tr th:each="myRctFreeOrder : ${myRctFreeOrders}" class="clickable-row"
-                                                    th:attr="data-href=@{/recruit/free/view(no=${myRctFreeOrder.boardNo})}">
-                                                    <td th:text="${myRctFreeOrder.orderNo}">주문 번호</td>
-                                                    <td th:text="${myRctFreeOrder.memberNo}">구매자</td>
-                                                    <td th:text="${myRctFreeOrder.boardNo}">구매상품</td>
-                                                    <td th:text="${myRctFreeOrder.quantity}">구매 갯수</td>
-                                                    <td th:text="${myRctFreeOrder.price}">결제 금액</td>
-                                                    <td th:text="${myRctFreeOrder.orderedDate}">구매 일자</td>
-                                                    <td th:text="${myRctFreeOrder.status}">작업 상태</td>
-                                                </tr>
-                                                </tbody>
-                                            </table>
-                                        </div>
-                                    </div>
-                                    <div class="row justify-content-center mx-3">
-                                        <div class="col-12" style="color: white;">
-                                            <!-- 페이징 -->
-                                            <th:block th:if="${pages != null}">
-                                                <div class="d-flex justify-content-center">
-                                                    <div class="btn-group">
-                                                        <button type="button" class="btn btn-sm previous"
-                                                                th:onclick="|location.href='@{/user/my/rct/free/order(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
-                                                                th:disabled="${currentPage == 1}">
-                                                            <svg xmlns="http://www.w3.org/2000/svg" width="16"
-                                                                 height="16" fill="currentColor"
-                                                                 class="bi bi-chevron-left" viewBox="0 0 16 16">
-                                                                <path fill-rule="evenodd"
-                                                                      d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                                                            </svg>
-                                                        </button>
-                                                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">
-                                                            <button type="button" class="btn btn-sm me-2 pages"
-                                                                    th:text="${p}"
-                                                                    th:onclick="|location.href='@{/user/my/rct/free/order(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
-                                                        </th:block>
-                                                        <button type="button" class="btn btn-sm  next"
-                                                                th:onclick="|location.href='@{/user/my/rct/free/order(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
-                                                                th:disabled="${currentPage == pages}">
-                                                            <svg xmlns="http://www.w3.org/2000/svg" width="16"
-                                                                 height="16" fill="currentColor"
-                                                                 class="bi bi-chevron-right" viewBox="0 0 16 16">
-                                                                <path fill-rule="evenodd"
-                                                                      d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
-                                                            </svg>
+            function submitForm() {
+                document.getElementById('filter-and-sort-form').submit();
+            }
+            </script>
+            <style>
+                .form-select {
+                background-color : #FCFCFC;
+                border : none;
+                width : 100%;
+                height : 50px;
+                }
+                select {
+                color : #828282;
+                }
+                .form-control {
+                background-color : #FCFCFC;
+                border : none;
+                width : 100%;
+                height : 50px;
+                }
+
+
+                .form-control::placeholder {
+                color : #BBBBBB;
+                }
+
+                .date-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            background-color: #8E4B6E;
+            color: white;
+            border-radius: 10px;
+            text-align:center;
+            font-family: "Work Sans", sans-serif;
+        }
+
+        .month {
+            font-size: 1.1rem; /* M의 크기를 설정 */
+            font-weight: 550;
+            line-height: 1;
+        }
+
+        .year {
+            font-size: 0.65rem; /* yyyy의 크기를 설정 */
+            font-weight: 400;
+        }
+        :root {
+            --background-color-light: #FFFFFF;
+            --text-color-light: #000000;
+            --toggle-background-light: #CCCCCC;
+            --toggle-ball-light: #FFFFFF;
+
+            --background-color-dark: #333333;
+            --text-color-dark: #FFFFFF;
+            --toggle-background-dark: #03C75A;
+            --toggle-ball-dark: #FFFFFF;
+
+            --font-size-base: 32px; /* 기본 텍스트 크기 */
+            --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+        }
+
+
+
+        .toggle-switch {
+            position: relative;
+            display: inline-block;
+            width: 62px; /* 너비 조정 */
+            height: 38px; /* 높이 조정 */
+        }
+
+        .toggle-switch .checkbox {
+            opacity: 0;
+            width: 0;
+            height: 0;
+        }
+        #isToggledCheckbox {
+             opacity: 0;
+                width: 0;
+                height: 0;
+        }
+
+        .toggle-switch .label {
+            position: absolute;
+            cursor: pointer;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: var(--toggle-background-light);
+            transition: background-color 0.4s;
+            border-radius: 38px; /* 둥근 모서리 반경 조정 */
+        }
+
+        .toggle-switch .label:before {
+            position: absolute;
+            content: "";
+            height: 30px; /* 내부 원 높이 조정 */
+            width: 30px; /* 내부 원 너비 조정 */
+            left: 2px;
+            bottom: 0px;
+            background-color: var(--toggle-ball-light);
+            transition: transform 0.4s;
+            border-radius: 50%;
+        }
+
+        .toggle-switch input:checked + .label {
+            background-color: var(--toggle-background-dark);
+        }
+
+        .toggle-switch input:checked + .label:before {
+            transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+        }
+
+                 .absdiv {
+                    position: relative;
+                    top: 60px; /* Move down by 20px from its current position */
+                    z-index : 1000;
+                }
+
+                #searchbutton {
+                    background-color: #828282;
+                }
+            </style>
+            <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+                  rel="stylesheet">
+            <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+                  rel="stylesheet">
+            <!--수정후-->
+            <div class="col-md-9">
+                <div class="row" style="color: #828282;">
+                    <div class="col-11">
+                        <div class="row">
+                            <div class="col-12 p-0">
+                                <style>
+                                    .col-4 select {
+                                        border-radius: 50px;
+                                        text-align: center;
+                                    }
+                                    /* 검색창 스타일 */
+                                    .search-container {
+                                        width: 300px;
+                                    }
+
+                                    .search-container select {
+                                        position: absolute;
+                                        left: 0%;
+                                        width: 30%;
+                                        height: 50px;
+                                        color: #828282;
+                                        font-size: 1rem;
+                                        border-radius: 50px 0 0 50px;
+                                        outline: none;
+                                    }
+                                    .search-container input[type="text"] {
+                                        position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
+                                        left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
+                                        width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
+                                        height: 50px;
+                                        padding: 10px 40px 10px 15px;
+                                        font-size: 1rem;
+                                        outline: none;
+                                        border-radius: 0 50px 50px 0;
+                                        transition: border-color 0.3s, background-color 0.3s;
+                                        color: #828282; /* 입력 텍스트 색상 변경 */
+                                    }
+
+                                    .search-container input[type="text"]::placeholder {
+                                        color: #BBBBBB; /* placeholder 색상 변경 */
+                                    }
+
+
+                                    .search-container button {
+                                        position: absolute;
+                                        right: 1rem;
+                                        top: 25px;
+                                        background: none;
+                                        transform: translateY(-50%);
+                                        border: none;
+                                        cursor: pointer;
+                                    }
+
+                                    .search-container button i {
+                                        color: #A6AAB5;
+                                    }
+
+                                    .search-container button:hover i {
+                                        color: #03C75A;
+                                    }
+                                </style>
+                                <form id="filter-and-sort-form"
+                                      th:action="@{/user/my/rct/free/order(boardNo=${boardNo})}" method="get">
+                                    <div class="row m-0">
+                                        <div class="col-7 p-0">
+                                            <div class="row justify-content-start m-0">
+                                                <div class="col-12 p-0">
+                                                    <div class="search-container">
+                                                        <select class="form-select px-3" name="searchBy">
+                                                            <option value="boardNo"
+                                                                    th:selected="${searchBy == 'boardNo'}">
+                                                                구매상품번호
+                                                            </option>
+                                                        </select>
+                                                        <input class="form-control px-3" type="text" name="searchTerm"
+                                                               placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
+                                                        <!-- 검색 버튼 -->
+                                                        <input type="hidden" name="boardNo" th:value="${boardNo}"/>
+                                                        <button type="submit">
+                                                            <i class="fas fa-search"></i>
                                                         </button>
                                                     </div>
                                                 </div>
-                                            </th:block>
+                                            </div>
+                                        </div>
+                                        <div class="col-1" style=""></div>
+                                        <div class="col-4">
+                                            <div class="row justify-content-end">
+                                                <!-- 정렬 또는 토글2 -->
+                                                <label>
+                                                    <select class="form-select px-3" name="orderBy"
+                                                            onchange="submitForm()">
+                                                        <option value="recent" th:selected="${orderBy == 'recent'}">
+                                                            최근주문순
+                                                        </option>
+                                                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순
+                                                        </option>
+                                                        <option value="expensive"
+                                                                th:selected="${orderBy == 'expensive'}">
+                                                            결제금액높은순
+                                                        </option>
+                                                        <option value="cheap" th:selected="${orderBy == 'cheap'}">
+                                                            결제금액낮은순
+                                                        </option>
+                                                    </select>
+                                                </label>
+                                            </div>
+                                        </div>
+                                    </div> <!--검색, 소팅 (토글X)-->
+                                    <div class="row justify-content-around">
+                                        <div class="col-3" style="padding: 0 1.2rem;">
+                                            <div class="absdiv">
+                                                <a href="javascript:window.history.back();" class="btn btn-primary"
+                                                   style="background-color: #03C75A;">뒤로가기</a>
+
+                                            </div>
+                                        </div>
+                                        <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                        <div class="col-3" style="padding: 0 1.2rem;">
+                                            <div class="row justify-content-end absdiv">
+                                                <div class="col-3">
+                                                    <div class="toggle-switch">
+                                                        <!-- 정렬 또는 토글1 -->
+                                                        <input type="checkbox" name="isToggled" id="isToggledCheckbox"
+                                                               value="Y" th:checked="${isToggled == 'Y'}"
+                                                               onchange="updateCheckboxValueAndSubmit()">
+                                                        <label for="isToggledCheckbox" class="label">
+                                                            <div class="ball"></div>
+                                                        </label>
+                                                    </div>
+                                                </div>
+                                                <div class="col-8"
+                                                     style="text-align: right; padding: 0px; margin : 0px;">
+                                                    마감된 작업
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div> <!--토글-->
+                                </form>
+                            </div>
+                        </div>
+
+                        <div class="row justify-content-around">
+                            <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
+                                <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
+                                    <div class="col-11"
+                                         style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;">
+                                        <div class="row justify-content-center mx-3">
+                                            <div class="col-1 p-0 d-flex align-items-center justify-content-center"
+                                                 style="aspect-ratio: 1; border-radius: 5px;">
+                                                <div class="date-container px-2 py-1">
+                                                    <div class="month"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(board.createdDate)}"></div>
+                                                    <div class="year"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(board.createdDate)}"></div>
+                                                </div>
+                                            </div>
+                                            <div class="col-5" style="color: white; " th:text="${board.boardNo}">닉네임
+                                            </div>
+                                            <div class="col-6"
+                                                 style="padding:0; font-size: 1rem; text-align: right; color: #BDBDBD;"
+                                                 th:text="${board.formattedCreatedDate}">1주일 전
+                                            </div>
+                                        </div>
+                                        <div class="row justify-content-center mx-3">
+                                            <div class="col-12" style="color: white;">사진</div>
+                                        </div>
+                                        <div class="row justify-content-center mx-3">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                                 th:text="${board.title}">이름
+                                            </div>
+                                            <div class="col-3 clickable-row" style="padding: 0; text-align: right;"
+                                                 th:attr="data-href=@{/recruit/free/view(no=${boardNo})}">→
+                                            </div>
+                                        </div>
+                                        <div class="row justify-content-center mx-3">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                                 th:text="${board.content}">내용
+                                            </div>
+                                            <div class="col-3 clickable-row" style="padding: 0; text-align: right;"
+                                                 th:attr="data-href=@{/recruit/free/view(no=${boardNo})}">게시글 확인
+                                            </div>
+                                        </div>
+                                        <div class="row justify-content-center mx-3 my-5">
+                                            <div class="col-12 m-0 p-0" style="color: #333333;">
+                                                <table>
+                                                    <thead>
+                                                    <tr>
+                                                        <th>주문 번호</th>
+                                                        <th>구매자</th>
+                                                        <th>구매상품</th>
+                                                        <th>구매 갯수</th>
+                                                        <th>결제 금액</th>
+                                                        <th>구매 일자</th>
+                                                        <th>작업 상태</th>
+                                                    </tr>
+                                                    </thead>
+                                                    <tbody>
+                                                    <tr th:each="myRctFreeOrder : ${myRctFreeOrders}"
+                                                        class="clickable-row"
+                                                        th:attr="data-href=@{/recruit/free/view(no=${myRctFreeOrder.boardNo})}">
+                                                        <td th:text="${myRctFreeOrder.orderNo}">주문 번호</td>
+                                                        <td th:text="${myRctFreeOrder.memberNo}">구매자</td>
+                                                        <td th:text="${myRctFreeOrder.boardNo}">구매상품</td>
+                                                        <td th:text="${myRctFreeOrder.quantity}">구매 갯수</td>
+                                                        <td th:text="${myRctFreeOrder.price}">결제 금액</td>
+                                                        <td th:text="${myRctFreeOrder.orderedDate}">구매 일자</td>
+                                                        <td th:text="${myRctFreeOrder.status}">작업 상태</td>
+                                                    </tr>
+                                                    </tbody>
+                                                </table>
+                                            </div>
+                                        </div>
+                                        <div class="row justify-content-center mx-3">
+                                            <div class="col-12" style="color: white;">
+                                                <!-- 페이징 -->
+                                                <th:block th:if="${pages != null}">
+                                                    <div class="d-flex justify-content-center">
+                                                        <div class="btn-group">
+                                                            <button type="button" class="btn btn-sm previous"
+                                                                    th:onclick="|location.href='@{/user/my/rct/free/order(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
+                                                                    th:disabled="${currentPage == 1}">
+                                                                <svg xmlns="http://www.w3.org/2000/svg" width="16"
+                                                                     height="16" fill="currentColor"
+                                                                     class="bi bi-chevron-left" viewBox="0 0 16 16">
+                                                                    <path fill-rule="evenodd"
+                                                                          d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                                                                </svg>
+                                                            </button>
+                                                            <th:block th:each="p : ${#numbers.sequence(1, pages)}">
+                                                                <button type="button" class="btn btn-sm me-2 pages"
+                                                                        th:text="${p}"
+                                                                        th:onclick="|location.href='@{/user/my/rct/free/order(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
+                                                            </th:block>
+                                                            <button type="button" class="btn btn-sm  next"
+                                                                    th:onclick="|location.href='@{/user/my/rct/free/order(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
+                                                                    th:disabled="${currentPage == pages}">
+                                                                <svg xmlns="http://www.w3.org/2000/svg" width="16"
+                                                                     height="16" fill="currentColor"
+                                                                     class="bi bi-chevron-right" viewBox="0 0 16 16">
+                                                                    <path fill-rule="evenodd"
+                                                                          d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                                                                </svg>
+                                                            </button>
+                                                        </div>
+                                                    </div>
+                                                </th:block>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>
@@ -545,98 +576,98 @@
                     </div>
                 </div>
             </div>
+
+
+            <!--수정전오더리스트-->
+            <!--    <div class="col-md-9">-->
+            <!--        <div class="review-list">-->
+            <!--            <h3><a th:href="@{/user/my/rct/free}">뒤로가기(페이지번호미반영)</a></h3>-->
+            <!--            <h2>프리랜서 게시글 관리-주문목록</h2>-->
+            <!--            <h3><a th:href="@{/recruit/free/view(no=${boardNo})}">공고 확인</a></h3>-->
+            <!--            <form id="filter-and-sort-form" th:action="@{/user/my/rct/free/order(boardNo=${boardNo})}" method="get">-->
+            <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
+            <!--                <label>-->
+            <!--                    <select name="searchBy">-->
+            <!--                        <option value="boardNo" th:selected="${searchBy == 'boardNo'}">구매상품번호(추후 구매상품명)</option>-->
+            <!--                    </select>-->
+            <!--                </label>-->
+            <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
+
+            <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
+            <!--                <button type="submit">검색</button>-->
+
+            <!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
+            <!--                <label>-->
+            <!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">마감된 작업-->
+            <!--                </label>-->
+            <!--                &lt;!&ndash; Hidden field for boardNo &ndash;&gt;-->
+            <!--                <input type="hidden" name="boardNo" th:value="${boardNo}" />-->
+
+            <!--                <label>-->
+            <!--                    <select name="orderBy" onchange="submitForm()">-->
+            <!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최근주문순</option>-->
+            <!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
+            <!--                        <option value="expensive" th:selected="${orderBy == 'expensive'}">결제금액높은순</option>-->
+            <!--                        <option value="cheap" th:selected="${orderBy == 'cheap'}">결제금액낮은순</option>-->
+            <!--                    </select>-->
+            <!--                </label>-->
+            <!--            </form>-->
+            <!--&lt;!&ndash;            <form id="filter-form" th:action="@{/user/my/rct/job/apply(boardNo=${boardNo})}" method="get">&ndash;&gt;-->
+            <!--&lt;!&ndash;                <label>&ndash;&gt;-->
+            <!--&lt;!&ndash;                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="toggleCheckboxValue()">미열람&ndash;&gt;-->
+            <!--&lt;!&ndash;                </label>&ndash;&gt;-->
+            <!--&lt;!&ndash;                &lt;!&ndash; Hidden field for boardNo &ndash;&gt;&ndash;&gt;-->
+            <!--&lt;!&ndash;                <input type="hidden" name="boardNo" th:value="${boardNo}" />&ndash;&gt;-->
+            <!--&lt;!&ndash;            </form>&ndash;&gt;-->
+
+            <!--            <table>-->
+            <!--                <thead>-->
+            <!--                <tr>-->
+            <!--                    <th>주문 번호</th>-->
+            <!--                    <th>구매자</th>-->
+            <!--                    <th>구매상품</th>-->
+            <!--                    <th>구매 갯수</th>-->
+            <!--                    <th>결제 금액</th>-->
+            <!--                    <th>구매 일자</th>-->
+            <!--                    <th>작업 상태</th>-->
+            <!--                </tr>-->
+            <!--                </thead>-->
+            <!--                <tbody>-->
+            <!--                <tr th:each="myRctFreeOrder : ${myRctFreeOrders}" class="clickable-row" th:attr="data-href=@{/recruit/free/view(no=${myRctFreeOrder.boardNo})}">-->
+            <!--                    <td th:text="${myRctFreeOrder.orderNo}">주문 번호</td>-->
+            <!--                    <td th:text="${myRctFreeOrder.memberNo}">구매자</td>-->
+            <!--                    <td th:text="${myRctFreeOrder.boardNo}">구매상품</td>-->
+            <!--                    <td th:text="${myRctFreeOrder.quantity}">구매 갯수</td>-->
+            <!--                    <td th:text="${myRctFreeOrder.price}">결제 금액</td>-->
+            <!--                    <td th:text="${myRctFreeOrder.orderedDate}">구매 일자</td>-->
+            <!--                    <td th:text="${myRctFreeOrder.status}">작업 상태</td>-->
+            <!--                </tr>-->
+            <!--                </tbody>-->
+            <!--            </table>-->
+            <!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
+            <!--            <th:block th:if="${pages != null}">-->
+            <!--                <div class="d-flex justify-content-center">-->
+            <!--                    <div class="btn-group">-->
+            <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/rct/free/order(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
+            <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
+            <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
+            <!--                            </svg>-->
+            <!--                        </button>-->
+            <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
+            <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
+            <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/rct/free/order(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
+            <!--                        </th:block>-->
+            <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/rct/free/order(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
+            <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
+            <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
+            <!--                            </svg>-->
+            <!--                        </button>-->
+            <!--                    </div>-->
+            <!--                </div>-->
+            <!--            </th:block>-->
+            <!--        </div>-->
+            <!--    </div>-->
         </div>
-
-
-        <!--수정전오더리스트-->
-        <!--    <div class="col-md-9">-->
-        <!--        <div class="review-list">-->
-        <!--            <h3><a th:href="@{/user/my/rct/free}">뒤로가기(페이지번호미반영)</a></h3>-->
-        <!--            <h2>프리랜서 게시글 관리-주문목록</h2>-->
-        <!--            <h3><a th:href="@{/recruit/free/view(no=${boardNo})}">공고 확인</a></h3>-->
-        <!--            <form id="filter-and-sort-form" th:action="@{/user/my/rct/free/order(boardNo=${boardNo})}" method="get">-->
-        <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
-        <!--                <label>-->
-        <!--                    <select name="searchBy">-->
-        <!--                        <option value="boardNo" th:selected="${searchBy == 'boardNo'}">구매상품번호(추후 구매상품명)</option>-->
-        <!--                    </select>-->
-        <!--                </label>-->
-        <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
-
-        <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
-        <!--                <button type="submit">검색</button>-->
-
-        <!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
-        <!--                <label>-->
-        <!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">마감된 작업-->
-        <!--                </label>-->
-        <!--                &lt;!&ndash; Hidden field for boardNo &ndash;&gt;-->
-        <!--                <input type="hidden" name="boardNo" th:value="${boardNo}" />-->
-
-        <!--                <label>-->
-        <!--                    <select name="orderBy" onchange="submitForm()">-->
-        <!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최근주문순</option>-->
-        <!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
-        <!--                        <option value="expensive" th:selected="${orderBy == 'expensive'}">결제금액높은순</option>-->
-        <!--                        <option value="cheap" th:selected="${orderBy == 'cheap'}">결제금액낮은순</option>-->
-        <!--                    </select>-->
-        <!--                </label>-->
-        <!--            </form>-->
-        <!--&lt;!&ndash;            <form id="filter-form" th:action="@{/user/my/rct/job/apply(boardNo=${boardNo})}" method="get">&ndash;&gt;-->
-        <!--&lt;!&ndash;                <label>&ndash;&gt;-->
-        <!--&lt;!&ndash;                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="toggleCheckboxValue()">미열람&ndash;&gt;-->
-        <!--&lt;!&ndash;                </label>&ndash;&gt;-->
-        <!--&lt;!&ndash;                &lt;!&ndash; Hidden field for boardNo &ndash;&gt;&ndash;&gt;-->
-        <!--&lt;!&ndash;                <input type="hidden" name="boardNo" th:value="${boardNo}" />&ndash;&gt;-->
-        <!--&lt;!&ndash;            </form>&ndash;&gt;-->
-
-        <!--            <table>-->
-        <!--                <thead>-->
-        <!--                <tr>-->
-        <!--                    <th>주문 번호</th>-->
-        <!--                    <th>구매자</th>-->
-        <!--                    <th>구매상품</th>-->
-        <!--                    <th>구매 갯수</th>-->
-        <!--                    <th>결제 금액</th>-->
-        <!--                    <th>구매 일자</th>-->
-        <!--                    <th>작업 상태</th>-->
-        <!--                </tr>-->
-        <!--                </thead>-->
-        <!--                <tbody>-->
-        <!--                <tr th:each="myRctFreeOrder : ${myRctFreeOrders}" class="clickable-row" th:attr="data-href=@{/recruit/free/view(no=${myRctFreeOrder.boardNo})}">-->
-        <!--                    <td th:text="${myRctFreeOrder.orderNo}">주문 번호</td>-->
-        <!--                    <td th:text="${myRctFreeOrder.memberNo}">구매자</td>-->
-        <!--                    <td th:text="${myRctFreeOrder.boardNo}">구매상품</td>-->
-        <!--                    <td th:text="${myRctFreeOrder.quantity}">구매 갯수</td>-->
-        <!--                    <td th:text="${myRctFreeOrder.price}">결제 금액</td>-->
-        <!--                    <td th:text="${myRctFreeOrder.orderedDate}">구매 일자</td>-->
-        <!--                    <td th:text="${myRctFreeOrder.status}">작업 상태</td>-->
-        <!--                </tr>-->
-        <!--                </tbody>-->
-        <!--            </table>-->
-        <!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
-        <!--            <th:block th:if="${pages != null}">-->
-        <!--                <div class="d-flex justify-content-center">-->
-        <!--                    <div class="btn-group">-->
-        <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/rct/free/order(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
-        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
-        <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
-        <!--                            </svg>-->
-        <!--                        </button>-->
-        <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
-        <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
-        <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/rct/free/order(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
-        <!--                        </th:block>-->
-        <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/rct/free/order(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
-        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
-        <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
-        <!--                            </svg>-->
-        <!--                        </button>-->
-        <!--                    </div>-->
-        <!--                </div>-->
-        <!--            </th:block>-->
-        <!--        </div>-->
-        <!--    </div>-->
     </div>
 </div>
 <div th:replace="common/footer.html"></div>

--- a/src/main/resources/templates/user/mypage_rct_free_orderlist.html
+++ b/src/main/resources/templates/user/mypage_rct_free_orderlist.html
@@ -112,11 +112,11 @@
             <div class="col-md-9">
                 <nav class="navbar navbar-expand-md">
                     <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                        <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 등록 현황</a></li>
                         <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
-                        <li><a th:href="@{/user/my/rct/creator}" class="nav-link px-2">창작자 등록 현황</a></li>
-                        <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a></li>
-                        <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2" style="color:#000;">프리랜서 게시글 관리</a>
+                        <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a>
                         </li>
+                        <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2" style="color:#000;">프리랜서 게시글 관리</a></li>
                         <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
                     </ul>
                 </nav>

--- a/src/main/resources/templates/user/mypage_rct_free_orderlist.html
+++ b/src/main/resources/templates/user/mypage_rct_free_orderlist.html
@@ -124,33 +124,35 @@
         </div>
     </div>
 </div>
-<div class="row">
-    <aside class="col-md-3 px-4">
-        <div class="row">
-            <div class="col-3"></div>
-            <div class="col-6">
-                <div class="panel">
-                    <ul class="list-group">
-                        <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
-                        <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-                        <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color: #03C75A;">나의 채용</a></li>
-                        <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-                        <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                        <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-                    </ul>
+<div class="container" style="padding:0;">
+    <div class="row">
+        <aside class="col-md-3 px-4">
+            <div class="row">
+                <div class="col-3"></div>
+                <div class="col-6">
+                    <div class="panel">
+                        <ul class="list-group">
+                            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
+                            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color: #03C75A;">나의 채용</a>
+                            </li>
+                            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+                        </ul>
+                    </div>
                 </div>
             </div>
-        </div>
-    </aside>
-    <!--    <script>-->
-    <!--        function toggleCheckboxValue() {-->
-    <!--            const checkbox = document.getElementById('isToggledCheckbox');-->
-    <!--            if(!checkbox.checked) checkbox.value = 'N';-->
-    <!--            else checkbox.value = 'Y';-->
-    <!--            document.getElementById('filter-form').submit();-->
-    <!--        }-->
-    <!--    </script>-->
-    <script> // toggle + sorting
+        </aside>
+        <!--    <script>-->
+        <!--        function toggleCheckboxValue() {-->
+        <!--            const checkbox = document.getElementById('isToggledCheckbox');-->
+        <!--            if(!checkbox.checked) checkbox.value = 'N';-->
+        <!--            else checkbox.value = 'Y';-->
+        <!--            document.getElementById('filter-form').submit();-->
+        <!--        }-->
+        <!--    </script>-->
+        <script> // toggle + sorting
         function updateCheckboxValueAndSubmit() {
             const checkbox = document.getElementById('isToggledCheckbox');
             const form = document.getElementById('filter-and-sort-form');
@@ -163,276 +165,323 @@
         function submitForm() {
             document.getElementById('filter-and-sort-form').submit();
         }
-    </script>
-    <style>
-        .form-select {
-        background-color : #FCFCFC;
-        border : none;
-        width : 100%;
-        height : 50px;
-        }
-        select {
-        color : #828282;
-        }
-        .form-control {
-        background-color : #FCFCFC;
-        border : none;
-        width : 100%;
-        height : 50px;
-        }
+        </script>
+        <style>
+            .form-select {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
+            }
+            select {
+            color : #828282;
+            }
+            .form-control {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
+            }
 
 
-        .form-control::placeholder {
-        color : #BBBBBB;
-        }
+            .form-control::placeholder {
+            color : #BBBBBB;
+            }
 
-        .date-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    background-color: #8E4B6E;
-    color: white;
-    border-radius: 10px;
-    text-align:center;
-    font-family: "Work Sans", sans-serif;
-}
+            .date-container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        background-color: #8E4B6E;
+        color: white;
+        border-radius: 10px;
+        text-align:center;
+        font-family: "Work Sans", sans-serif;
+    }
 
-.month {
-    font-size: 1.1rem; /* M의 크기를 설정 */
-    font-weight: 550;
-    line-height: 1;
-}
+    .month {
+        font-size: 1.1rem; /* M의 크기를 설정 */
+        font-weight: 550;
+        line-height: 1;
+    }
 
-.year {
-    font-size: 0.65rem; /* yyyy의 크기를 설정 */
-    font-weight: 400;
-}
-:root {
-    --background-color-light: #FFFFFF;
-    --text-color-light: #000000;
-    --toggle-background-light: #CCCCCC;
-    --toggle-ball-light: #FFFFFF;
+    .year {
+        font-size: 0.65rem; /* yyyy의 크기를 설정 */
+        font-weight: 400;
+    }
+    :root {
+        --background-color-light: #FFFFFF;
+        --text-color-light: #000000;
+        --toggle-background-light: #CCCCCC;
+        --toggle-ball-light: #FFFFFF;
 
-    --background-color-dark: #333333;
-    --text-color-dark: #FFFFFF;
-    --toggle-background-dark: #03C75A;
-    --toggle-ball-dark: #FFFFFF;
+        --background-color-dark: #333333;
+        --text-color-dark: #FFFFFF;
+        --toggle-background-dark: #03C75A;
+        --toggle-ball-dark: #FFFFFF;
 
-    --font-size-base: 32px; /* 기본 텍스트 크기 */
-    --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
-}
+        --font-size-base: 32px; /* 기본 텍스트 크기 */
+        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+    }
 
 
 
-.toggle-switch {
-    position: relative;
-    display: inline-block;
-    width: 62px; /* 너비 조정 */
-    height: 38px; /* 높이 조정 */
-}
+    .toggle-switch {
+        position: relative;
+        display: inline-block;
+        width: 62px; /* 너비 조정 */
+        height: 38px; /* 높이 조정 */
+    }
 
-.toggle-switch .checkbox {
-    opacity: 0;
-    width: 0;
-    height: 0;
-}
-#isToggledCheckbox {
-     opacity: 0;
+    .toggle-switch .checkbox {
+        opacity: 0;
         width: 0;
         height: 0;
-}
+    }
+    #isToggledCheckbox {
+         opacity: 0;
+            width: 0;
+            height: 0;
+    }
 
-.toggle-switch .label {
-    position: absolute;
-    cursor: pointer;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: var(--toggle-background-light);
-    transition: background-color 0.4s;
-    border-radius: 38px; /* 둥근 모서리 반경 조정 */
-}
+    .toggle-switch .label {
+        position: absolute;
+        cursor: pointer;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: var(--toggle-background-light);
+        transition: background-color 0.4s;
+        border-radius: 38px; /* 둥근 모서리 반경 조정 */
+    }
 
-.toggle-switch .label:before {
-    position: absolute;
-    content: "";
-    height: 30px; /* 내부 원 높이 조정 */
-    width: 30px; /* 내부 원 너비 조정 */
-    left: 2px;
-    bottom: 0px;
-    background-color: var(--toggle-ball-light);
-    transition: transform 0.4s;
-    border-radius: 50%;
-}
+    .toggle-switch .label:before {
+        position: absolute;
+        content: "";
+        height: 30px; /* 내부 원 높이 조정 */
+        width: 30px; /* 내부 원 너비 조정 */
+        left: 2px;
+        bottom: 0px;
+        background-color: var(--toggle-ball-light);
+        transition: transform 0.4s;
+        border-radius: 50%;
+    }
 
-.toggle-switch input:checked + .label {
-    background-color: var(--toggle-background-dark);
-}
+    .toggle-switch input:checked + .label {
+        background-color: var(--toggle-background-dark);
+    }
 
-.toggle-switch input:checked + .label:before {
-    transform: translateX(28px); /* 내부 원 이동 거리 조정 */
-}
+    .toggle-switch input:checked + .label:before {
+        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+    }
 
-         .absdiv {
-            position: relative;
-            top: 60px; /* Move down by 20px from its current position */
-            z-index : 1000;
-        }
+             .absdiv {
+                position: relative;
+                top: 60px; /* Move down by 20px from its current position */
+                z-index : 1000;
+            }
 
-        #searchbutton {
-            background-color: #828282;
-        }
-    </style>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
-    <!--수정후-->
-    <div class="col-md-9">
-        <div class="row" style="color: #828282;">
-            <div class="col-11">
-                <div class="row">
-                    <div class="col-12">
-                        <form id="filter-and-sort-form" th:action="@{/user/my/rct/free/order(boardNo=${boardNo})}" method="get">
-                            <div class="row">
-                                <div class="col-7">
-                                    <div class="row justify-content-start m-0">
-                                        <div class="col-4">
-                                            <!-- 검색 조건 -->
+            #searchbutton {
+                background-color: #828282;
+            }
+        </style>
+        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+              rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+              rel="stylesheet">
+        <!--수정후-->
+        <div class="col-md-9">
+            <div class="row" style="color: #828282;">
+                <div class="col-11">
+                    <div class="row">
+                        <div class="col-12">
+                            <form id="filter-and-sort-form" th:action="@{/user/my/rct/free/order(boardNo=${boardNo})}"
+                                  method="get">
+                                <div class="row">
+                                    <div class="col-7">
+                                        <div class="row justify-content-start m-0">
+                                            <div class="col-4">
+                                                <!-- 검색 조건 -->
+                                                <label>
+                                                    <select class="form-select px-3" name="searchBy">
+                                                        <option value="boardNo" th:selected="${searchBy == 'boardNo'}">
+                                                            구매상품번호(추후 구매상품명)
+                                                        </option>
+                                                    </select>
+                                                </label>
+                                            </div>
+                                            <div class="col-6">
+                                                <input class="form-control px-3" type="text" name="searchTerm"
+                                                       placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
+                                            </div>
+                                            <div class="col-2">
+                                                <input type="hidden" name="boardNo" th:value="${boardNo}"/>
+                                                <!-- 검색 버튼 -->
+                                                <button id="searchbutton" type="submit" class="btn btn-primary">검색
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-1" style=""></div>
+                                    <div class="col-4">
+                                        <div class="row justify-content-end">
+                                            <!-- 정렬 또는 토글2 -->
                                             <label>
-                                                <select class="form-select px-3" name="searchBy">
-                                                    <option value="boardNo" th:selected="${searchBy == 'boardNo'}">구매상품번호(추후 구매상품명)</option>
+                                                <select class="form-select px-3" name="orderBy" onchange="submitForm()">
+                                                    <option value="recent" th:selected="${orderBy == 'recent'}">최근주문순
+                                                    </option>
+                                                    <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순
+                                                    </option>
+                                                    <option value="expensive" th:selected="${orderBy == 'expensive'}">
+                                                        결제금액높은순
+                                                    </option>
+                                                    <option value="cheap" th:selected="${orderBy == 'cheap'}">결제금액낮은순
+                                                    </option>
                                                 </select>
                                             </label>
                                         </div>
-                                        <div class="col-6">
-                                            <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
-                                        </div>
-                                        <div class="col-2">
-                                            <input type="hidden" name="boardNo" th:value="${boardNo}" />
-                                            <!-- 검색 버튼 -->
-                                            <button id="searchbutton" type="submit" class="btn btn-primary">검색</button>
-                                        </div>
                                     </div>
-                                </div>
-                                <div class="col-1" style=""></div>
-                                <div class="col-4">
-                                    <div class="row justify-content-end">
-                                        <!-- 정렬 또는 토글2 -->
-                                        <label>
-                                            <select class="form-select px-3" name="orderBy" onchange="submitForm()">
-                                                <option value="recent" th:selected="${orderBy == 'recent'}">최근주문순</option>
-                                                <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>
-                                                <option value="expensive" th:selected="${orderBy == 'expensive'}">결제금액높은순</option>
-                                                <option value="cheap" th:selected="${orderBy == 'cheap'}">결제금액낮은순</option>
-                                            </select>
-                                        </label>
-                                    </div>
-                                </div>
-                            </div> <!--검색, 소팅 (토글X)-->
-                            <div class="row justify-content-around">
-                                <div class="col-3" style="padding: 0 1.2rem;">
-                                    <div class="absdiv">
-                                        <a href="javascript:window.history.back();" class="btn btn-primary" style="background-color: #03C75A;">뒤로가기</a>
+                                </div> <!--검색, 소팅 (토글X)-->
+                                <div class="row justify-content-around">
+                                    <div class="col-3" style="padding: 0 1.2rem;">
+                                        <div class="absdiv">
+                                            <a href="javascript:window.history.back();" class="btn btn-primary"
+                                               style="background-color: #03C75A;">뒤로가기</a>
 
-                                    </div>
-                                </div>
-                                <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                <div class="col-3" style="padding: 0 1.2rem;">
-                                    <div class="row justify-content-end absdiv">
-                                        <div class="col-3">
-                                            <div class="toggle-switch">
-                                                <!-- 정렬 또는 토글1 -->
-                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">
-                                                <label for="isToggledCheckbox" class="label">
-                                                    <div class="ball"></div>
-                                                </label>
-                                            </div>
-                                        </div>
-                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">마감된 작업</div>
-                                    </div>
-                                </div>
-                            </div> <!--토글-->
-                        </form>
-                    </div>
-                </div>
-
-                <div class="row justify-content-around">
-                    <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
-                        <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
-                            <div class="col-11" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;">
-                                <div class="row justify-content-center mx-3">
-                                    <div class="col-1 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                        <div class="date-container px-2 py-1">
-                                            <div class="month" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(board.createdDate)}"></div>
-                                            <div class="year" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(board.createdDate)}"></div>
                                         </div>
                                     </div>
-                                    <div class="col-5" style="color: white; " th:text="${board.boardNo}">닉네임</div>
-                                    <div class="col-6" style="padding:0; font-size: 1rem; text-align: right; color: #BDBDBD;" th:text="${board.formattedCreatedDate}">1주일 전</div>
-                                </div>
-                                <div class="row justify-content-center mx-3">
-                                    <div class="col-12" style="color: white;" >사진</div>
-                                </div>
-                                <div class="row justify-content-center mx-3">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" th:text="${board.title}">이름</div>
-                                    <div class="col-3 clickable-row" style="padding: 0; text-align: right;" th:attr="data-href=@{/recruit/free/view(no=${boardNo})}">→</div>
-                                </div>
-                                <div class="row justify-content-center mx-3">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${board.content}">내용</div>
-                                    <div class="col-3 clickable-row" style="padding: 0; text-align: right;" th:attr="data-href=@{/recruit/free/view(no=${boardNo})}">게시글 확인</div>
-                                </div>
-                                <div class="row justify-content-center mx-3 my-5">
-                                    <div class="col-12 m-0 p-0" style="color: #333333;" >
-                                        <table>
-                                            <thead>
-                                            <tr>
-                                                <th>주문 번호</th>
-                                                <th>구매자</th>
-                                                <th>구매상품</th>
-                                                <th>구매 갯수</th>
-                                                <th>결제 금액</th>
-                                                <th>구매 일자</th>
-                                                <th>작업 상태</th>
-                                            </tr>
-                                            </thead>
-                                            <tbody>
-                                            <tr th:each="myRctFreeOrder : ${myRctFreeOrders}" class="clickable-row" th:attr="data-href=@{/recruit/free/view(no=${myRctFreeOrder.boardNo})}">
-                                                <td th:text="${myRctFreeOrder.orderNo}">주문 번호</td>
-                                                <td th:text="${myRctFreeOrder.memberNo}">구매자</td>
-                                                <td th:text="${myRctFreeOrder.boardNo}">구매상품</td>
-                                                <td th:text="${myRctFreeOrder.quantity}">구매 갯수</td>
-                                                <td th:text="${myRctFreeOrder.price}">결제 금액</td>
-                                                <td th:text="${myRctFreeOrder.orderedDate}">구매 일자</td>
-                                                <td th:text="${myRctFreeOrder.status}">작업 상태</td>
-                                            </tr>
-                                            </tbody>
-                                        </table>
-                                    </div>
-                                </div>
-                                <div class="row justify-content-center mx-3">
-                                    <div class="col-12" style="color: white;" >
-                                        <!-- 페이징 -->
-                                        <th:block th:if="${pages != null}">
-                                            <div class="d-flex justify-content-center">
-                                                <div class="btn-group">
-                                                    <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/rct/free/order(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">
-                                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-                                                            <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                                                        </svg>
-                                                    </button>
-                                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">
-                                                        <button type="button" class="btn btn-sm me-2 pages"
-                                                                th:text="${p}" th:onclick="|location.href='@{/user/my/rct/free/order(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
-                                                    </th:block>
-                                                    <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/rct/free/order(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">
-                                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-                                                            <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
-                                                        </svg>
-                                                    </button>
+                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                    <div class="col-3" style="padding: 0 1.2rem;">
+                                        <div class="row justify-content-end absdiv">
+                                            <div class="col-3">
+                                                <div class="toggle-switch">
+                                                    <!-- 정렬 또는 토글1 -->
+                                                    <input type="checkbox" name="isToggled" id="isToggledCheckbox"
+                                                           value="Y" th:checked="${isToggled == 'Y'}"
+                                                           onchange="updateCheckboxValueAndSubmit()">
+                                                    <label for="isToggledCheckbox" class="label">
+                                                        <div class="ball"></div>
+                                                    </label>
                                                 </div>
                                             </div>
-                                        </th:block>
+                                            <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">
+                                                마감된 작업
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div> <!--토글-->
+                            </form>
+                        </div>
+                    </div>
+
+                    <div class="row justify-content-around">
+                        <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
+                            <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
+                                <div class="col-11"
+                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;">
+                                    <div class="row justify-content-center mx-3">
+                                        <div class="col-1 p-0 d-flex align-items-center justify-content-center"
+                                             style="aspect-ratio: 1; border-radius: 5px;">
+                                            <div class="date-container px-2 py-1">
+                                                <div class="month"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(board.createdDate)}"></div>
+                                                <div class="year"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(board.createdDate)}"></div>
+                                            </div>
+                                        </div>
+                                        <div class="col-5" style="color: white; " th:text="${board.boardNo}">닉네임</div>
+                                        <div class="col-6"
+                                             style="padding:0; font-size: 1rem; text-align: right; color: #BDBDBD;"
+                                             th:text="${board.formattedCreatedDate}">1주일 전
+                                        </div>
+                                    </div>
+                                    <div class="row justify-content-center mx-3">
+                                        <div class="col-12" style="color: white;">사진</div>
+                                    </div>
+                                    <div class="row justify-content-center mx-3">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                             th:text="${board.title}">이름
+                                        </div>
+                                        <div class="col-3 clickable-row" style="padding: 0; text-align: right;"
+                                             th:attr="data-href=@{/recruit/free/view(no=${boardNo})}">→
+                                        </div>
+                                    </div>
+                                    <div class="row justify-content-center mx-3">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                             th:text="${board.content}">내용
+                                        </div>
+                                        <div class="col-3 clickable-row" style="padding: 0; text-align: right;"
+                                             th:attr="data-href=@{/recruit/free/view(no=${boardNo})}">게시글 확인
+                                        </div>
+                                    </div>
+                                    <div class="row justify-content-center mx-3 my-5">
+                                        <div class="col-12 m-0 p-0" style="color: #333333;">
+                                            <table>
+                                                <thead>
+                                                <tr>
+                                                    <th>주문 번호</th>
+                                                    <th>구매자</th>
+                                                    <th>구매상품</th>
+                                                    <th>구매 갯수</th>
+                                                    <th>결제 금액</th>
+                                                    <th>구매 일자</th>
+                                                    <th>작업 상태</th>
+                                                </tr>
+                                                </thead>
+                                                <tbody>
+                                                <tr th:each="myRctFreeOrder : ${myRctFreeOrders}" class="clickable-row"
+                                                    th:attr="data-href=@{/recruit/free/view(no=${myRctFreeOrder.boardNo})}">
+                                                    <td th:text="${myRctFreeOrder.orderNo}">주문 번호</td>
+                                                    <td th:text="${myRctFreeOrder.memberNo}">구매자</td>
+                                                    <td th:text="${myRctFreeOrder.boardNo}">구매상품</td>
+                                                    <td th:text="${myRctFreeOrder.quantity}">구매 갯수</td>
+                                                    <td th:text="${myRctFreeOrder.price}">결제 금액</td>
+                                                    <td th:text="${myRctFreeOrder.orderedDate}">구매 일자</td>
+                                                    <td th:text="${myRctFreeOrder.status}">작업 상태</td>
+                                                </tr>
+                                                </tbody>
+                                            </table>
+                                        </div>
+                                    </div>
+                                    <div class="row justify-content-center mx-3">
+                                        <div class="col-12" style="color: white;">
+                                            <!-- 페이징 -->
+                                            <th:block th:if="${pages != null}">
+                                                <div class="d-flex justify-content-center">
+                                                    <div class="btn-group">
+                                                        <button type="button" class="btn btn-sm previous"
+                                                                th:onclick="|location.href='@{/user/my/rct/free/order(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
+                                                                th:disabled="${currentPage == 1}">
+                                                            <svg xmlns="http://www.w3.org/2000/svg" width="16"
+                                                                 height="16" fill="currentColor"
+                                                                 class="bi bi-chevron-left" viewBox="0 0 16 16">
+                                                                <path fill-rule="evenodd"
+                                                                      d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                                                            </svg>
+                                                        </button>
+                                                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">
+                                                            <button type="button" class="btn btn-sm me-2 pages"
+                                                                    th:text="${p}"
+                                                                    th:onclick="|location.href='@{/user/my/rct/free/order(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
+                                                        </th:block>
+                                                        <button type="button" class="btn btn-sm  next"
+                                                                th:onclick="|location.href='@{/user/my/rct/free/order(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
+                                                                th:disabled="${currentPage == pages}">
+                                                            <svg xmlns="http://www.w3.org/2000/svg" width="16"
+                                                                 height="16" fill="currentColor"
+                                                                 class="bi bi-chevron-right" viewBox="0 0 16 16">
+                                                                <path fill-rule="evenodd"
+                                                                      d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                                                            </svg>
+                                                        </button>
+                                                    </div>
+                                                </div>
+                                            </th:block>
+                                        </div>
                                     </div>
                                 </div>
                             </div>
@@ -441,100 +490,98 @@
                 </div>
             </div>
         </div>
+
+
+        <!--수정전오더리스트-->
+        <!--    <div class="col-md-9">-->
+        <!--        <div class="review-list">-->
+        <!--            <h3><a th:href="@{/user/my/rct/free}">뒤로가기(페이지번호미반영)</a></h3>-->
+        <!--            <h2>프리랜서 게시글 관리-주문목록</h2>-->
+        <!--            <h3><a th:href="@{/recruit/free/view(no=${boardNo})}">공고 확인</a></h3>-->
+        <!--            <form id="filter-and-sort-form" th:action="@{/user/my/rct/free/order(boardNo=${boardNo})}" method="get">-->
+        <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
+        <!--                <label>-->
+        <!--                    <select name="searchBy">-->
+        <!--                        <option value="boardNo" th:selected="${searchBy == 'boardNo'}">구매상품번호(추후 구매상품명)</option>-->
+        <!--                    </select>-->
+        <!--                </label>-->
+        <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
+
+        <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
+        <!--                <button type="submit">검색</button>-->
+
+        <!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
+        <!--                <label>-->
+        <!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">마감된 작업-->
+        <!--                </label>-->
+        <!--                &lt;!&ndash; Hidden field for boardNo &ndash;&gt;-->
+        <!--                <input type="hidden" name="boardNo" th:value="${boardNo}" />-->
+
+        <!--                <label>-->
+        <!--                    <select name="orderBy" onchange="submitForm()">-->
+        <!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최근주문순</option>-->
+        <!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
+        <!--                        <option value="expensive" th:selected="${orderBy == 'expensive'}">결제금액높은순</option>-->
+        <!--                        <option value="cheap" th:selected="${orderBy == 'cheap'}">결제금액낮은순</option>-->
+        <!--                    </select>-->
+        <!--                </label>-->
+        <!--            </form>-->
+        <!--&lt;!&ndash;            <form id="filter-form" th:action="@{/user/my/rct/job/apply(boardNo=${boardNo})}" method="get">&ndash;&gt;-->
+        <!--&lt;!&ndash;                <label>&ndash;&gt;-->
+        <!--&lt;!&ndash;                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="toggleCheckboxValue()">미열람&ndash;&gt;-->
+        <!--&lt;!&ndash;                </label>&ndash;&gt;-->
+        <!--&lt;!&ndash;                &lt;!&ndash; Hidden field for boardNo &ndash;&gt;&ndash;&gt;-->
+        <!--&lt;!&ndash;                <input type="hidden" name="boardNo" th:value="${boardNo}" />&ndash;&gt;-->
+        <!--&lt;!&ndash;            </form>&ndash;&gt;-->
+
+        <!--            <table>-->
+        <!--                <thead>-->
+        <!--                <tr>-->
+        <!--                    <th>주문 번호</th>-->
+        <!--                    <th>구매자</th>-->
+        <!--                    <th>구매상품</th>-->
+        <!--                    <th>구매 갯수</th>-->
+        <!--                    <th>결제 금액</th>-->
+        <!--                    <th>구매 일자</th>-->
+        <!--                    <th>작업 상태</th>-->
+        <!--                </tr>-->
+        <!--                </thead>-->
+        <!--                <tbody>-->
+        <!--                <tr th:each="myRctFreeOrder : ${myRctFreeOrders}" class="clickable-row" th:attr="data-href=@{/recruit/free/view(no=${myRctFreeOrder.boardNo})}">-->
+        <!--                    <td th:text="${myRctFreeOrder.orderNo}">주문 번호</td>-->
+        <!--                    <td th:text="${myRctFreeOrder.memberNo}">구매자</td>-->
+        <!--                    <td th:text="${myRctFreeOrder.boardNo}">구매상품</td>-->
+        <!--                    <td th:text="${myRctFreeOrder.quantity}">구매 갯수</td>-->
+        <!--                    <td th:text="${myRctFreeOrder.price}">결제 금액</td>-->
+        <!--                    <td th:text="${myRctFreeOrder.orderedDate}">구매 일자</td>-->
+        <!--                    <td th:text="${myRctFreeOrder.status}">작업 상태</td>-->
+        <!--                </tr>-->
+        <!--                </tbody>-->
+        <!--            </table>-->
+        <!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
+        <!--            <th:block th:if="${pages != null}">-->
+        <!--                <div class="d-flex justify-content-center">-->
+        <!--                    <div class="btn-group">-->
+        <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/rct/free/order(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
+        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
+        <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
+        <!--                            </svg>-->
+        <!--                        </button>-->
+        <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
+        <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
+        <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/rct/free/order(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
+        <!--                        </th:block>-->
+        <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/rct/free/order(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
+        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
+        <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
+        <!--                            </svg>-->
+        <!--                        </button>-->
+        <!--                    </div>-->
+        <!--                </div>-->
+        <!--            </th:block>-->
+        <!--        </div>-->
+        <!--    </div>-->
     </div>
-
-
-
-
-    <!--수정전오더리스트-->
-<!--    <div class="col-md-9">-->
-<!--        <div class="review-list">-->
-<!--            <h3><a th:href="@{/user/my/rct/free}">뒤로가기(페이지번호미반영)</a></h3>-->
-<!--            <h2>프리랜서 게시글 관리-주문목록</h2>-->
-<!--            <h3><a th:href="@{/recruit/free/view(no=${boardNo})}">공고 확인</a></h3>-->
-<!--            <form id="filter-and-sort-form" th:action="@{/user/my/rct/free/order(boardNo=${boardNo})}" method="get">-->
-<!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
-<!--                <label>-->
-<!--                    <select name="searchBy">-->
-<!--                        <option value="boardNo" th:selected="${searchBy == 'boardNo'}">구매상품번호(추후 구매상품명)</option>-->
-<!--                    </select>-->
-<!--                </label>-->
-<!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
-
-<!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
-<!--                <button type="submit">검색</button>-->
-
-<!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
-<!--                <label>-->
-<!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">마감된 작업-->
-<!--                </label>-->
-<!--                &lt;!&ndash; Hidden field for boardNo &ndash;&gt;-->
-<!--                <input type="hidden" name="boardNo" th:value="${boardNo}" />-->
-
-<!--                <label>-->
-<!--                    <select name="orderBy" onchange="submitForm()">-->
-<!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최근주문순</option>-->
-<!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
-<!--                        <option value="expensive" th:selected="${orderBy == 'expensive'}">결제금액높은순</option>-->
-<!--                        <option value="cheap" th:selected="${orderBy == 'cheap'}">결제금액낮은순</option>-->
-<!--                    </select>-->
-<!--                </label>-->
-<!--            </form>-->
-<!--&lt;!&ndash;            <form id="filter-form" th:action="@{/user/my/rct/job/apply(boardNo=${boardNo})}" method="get">&ndash;&gt;-->
-<!--&lt;!&ndash;                <label>&ndash;&gt;-->
-<!--&lt;!&ndash;                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="toggleCheckboxValue()">미열람&ndash;&gt;-->
-<!--&lt;!&ndash;                </label>&ndash;&gt;-->
-<!--&lt;!&ndash;                &lt;!&ndash; Hidden field for boardNo &ndash;&gt;&ndash;&gt;-->
-<!--&lt;!&ndash;                <input type="hidden" name="boardNo" th:value="${boardNo}" />&ndash;&gt;-->
-<!--&lt;!&ndash;            </form>&ndash;&gt;-->
-
-<!--            <table>-->
-<!--                <thead>-->
-<!--                <tr>-->
-<!--                    <th>주문 번호</th>-->
-<!--                    <th>구매자</th>-->
-<!--                    <th>구매상품</th>-->
-<!--                    <th>구매 갯수</th>-->
-<!--                    <th>결제 금액</th>-->
-<!--                    <th>구매 일자</th>-->
-<!--                    <th>작업 상태</th>-->
-<!--                </tr>-->
-<!--                </thead>-->
-<!--                <tbody>-->
-<!--                <tr th:each="myRctFreeOrder : ${myRctFreeOrders}" class="clickable-row" th:attr="data-href=@{/recruit/free/view(no=${myRctFreeOrder.boardNo})}">-->
-<!--                    <td th:text="${myRctFreeOrder.orderNo}">주문 번호</td>-->
-<!--                    <td th:text="${myRctFreeOrder.memberNo}">구매자</td>-->
-<!--                    <td th:text="${myRctFreeOrder.boardNo}">구매상품</td>-->
-<!--                    <td th:text="${myRctFreeOrder.quantity}">구매 갯수</td>-->
-<!--                    <td th:text="${myRctFreeOrder.price}">결제 금액</td>-->
-<!--                    <td th:text="${myRctFreeOrder.orderedDate}">구매 일자</td>-->
-<!--                    <td th:text="${myRctFreeOrder.status}">작업 상태</td>-->
-<!--                </tr>-->
-<!--                </tbody>-->
-<!--            </table>-->
-<!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
-<!--            <th:block th:if="${pages != null}">-->
-<!--                <div class="d-flex justify-content-center">-->
-<!--                    <div class="btn-group">-->
-<!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/rct/free/order(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
-<!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
-<!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
-<!--                            </svg>-->
-<!--                        </button>-->
-<!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
-<!--                            <button type="button" class="btn btn-sm me-2 pages"-->
-<!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/rct/free/order(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
-<!--                        </th:block>-->
-<!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/rct/free/order(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
-<!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
-<!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
-<!--                            </svg>-->
-<!--                        </button>-->
-<!--                    </div>-->
-<!--                </div>-->
-<!--            </th:block>-->
-<!--        </div>-->
-<!--    </div>-->
 </div>
 <div th:replace="common/footer.html"></div>
 </body>

--- a/src/main/resources/templates/user/mypage_rct_free_orderlist.html
+++ b/src/main/resources/templates/user/mypage_rct_free_orderlist.html
@@ -302,31 +302,81 @@
             <div class="row" style="color: #828282;">
                 <div class="col-11">
                     <div class="row">
-                        <div class="col-12">
-                            <form id="filter-and-sort-form" th:action="@{/user/my/rct/free/order(boardNo=${boardNo})}"
-                                  method="get">
-                                <div class="row">
-                                    <div class="col-7">
+                        <div class="col-12 p-0">
+                            <style>
+                                .col-4 select {
+                                    border-radius: 50px;
+                                    text-align: center;
+                                }
+                                /* 검색창 스타일 */
+                                .search-container {
+                                    width: 300px;
+                                }
+
+                                .search-container select {
+                                    position: absolute;
+                                    left: 0%;
+                                    width: 30%;
+                                    height: 50px;
+                                    color: #828282;
+                                    font-size: 1rem;
+                                    border-radius: 50px 0 0 50px;
+                                    outline: none;
+                                }
+                                .search-container input[type="text"] {
+                                    position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
+                                    left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
+                                    width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
+                                    height: 50px;
+                                    padding: 10px 40px 10px 15px;
+                                    font-size: 1rem;
+                                    outline: none;
+                                    border-radius: 0 50px 50px 0;
+                                    transition: border-color 0.3s, background-color 0.3s;
+                                    color: #828282; /* 입력 텍스트 색상 변경 */
+                                }
+
+                                .search-container input[type="text"]::placeholder {
+                                    color: #BBBBBB; /* placeholder 색상 변경 */
+                                }
+
+
+                                .search-container button {
+                                    position: absolute;
+                                    right: 1rem;
+                                    top: 25px;
+                                    background: none;
+                                    transform: translateY(-50%);
+                                    border: none;
+                                    cursor: pointer;
+                                }
+
+                                .search-container button i {
+                                    color: #666;
+                                }
+
+                                .search-container button:hover i {
+                                    color: #03C75A;
+                                }
+                            </style>
+                            <form id="filter-and-sort-form" th:action="@{/user/my/rct/free/order(boardNo=${boardNo})}" method="get">
+                                <div class="row m-0">
+                                    <div class="col-7 p-0">
                                         <div class="row justify-content-start m-0">
-                                            <div class="col-4">
-                                                <!-- 검색 조건 -->
-                                                <label>
+                                            <div class="col-12 p-0">
+                                                <div class="search-container">
                                                     <select class="form-select px-3" name="searchBy">
                                                         <option value="boardNo" th:selected="${searchBy == 'boardNo'}">
-                                                            구매상품번호(추후 구매상품명)
+                                                            구매상품번호
                                                         </option>
                                                     </select>
-                                                </label>
-                                            </div>
-                                            <div class="col-6">
-                                                <input class="form-control px-3" type="text" name="searchTerm"
-                                                       placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
-                                            </div>
-                                            <div class="col-2">
-                                                <input type="hidden" name="boardNo" th:value="${boardNo}"/>
-                                                <!-- 검색 버튼 -->
-                                                <button id="searchbutton" type="submit" class="btn btn-primary">검색
-                                                </button>
+                                                    <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
+                                                    <!-- 검색 버튼 -->
+                                                    <input type="hidden" name="boardNo" th:value="${boardNo}"/>
+                                                    <button type="submit">
+                                                        <i class="fas fa-search"></i>
+                                                    </button>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>

--- a/src/main/resources/templates/user/mypage_rct_free_orderlist.html
+++ b/src/main/resources/templates/user/mypage_rct_free_orderlist.html
@@ -112,12 +112,12 @@
             <div class="col-md-9">
                 <nav class="navbar navbar-expand-md">
                     <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                        <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 등록 현황</a></li>
                         <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
                         <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a>
                         </li>
                         <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2" style="color:#000;">프리랜서 게시글 관리</a></li>
                         <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
+                        <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보 수정</a></li>
                     </ul>
                 </nav>
             </div>

--- a/src/main/resources/templates/user/mypage_rct_job.html
+++ b/src/main/resources/templates/user/mypage_rct_job.html
@@ -108,6 +108,7 @@
 <div class="jumbotron">
     <div class="container">
         <div class="row">
+            <!--<editor-fold desc="Description">-->
             <div class="col-md-3 px-4">
                 <h3>나의 채용</h3>
             </div>
@@ -123,6 +124,7 @@
                     </ul>
                 </nav>
             </div>
+            <!--</editor-fold>-->
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/user/mypage_rct_job.html
+++ b/src/main/resources/templates/user/mypage_rct_job.html
@@ -108,23 +108,27 @@
 <div class="jumbotron">
     <div class="container">
         <div class="row">
-            <!--<editor-fold desc="Description">-->
-            <div class="col-md-3 px-4">
-                <h3>나의 채용</h3>
+            <div class="col-9">
+                <div class="row">
+                    <div class="col-md-3 px-4">
+                        <h3>나의 채용</h3>
+                    </div>
+                    <div class="col-md-9">
+                        <nav class="navbar navbar-expand-md">
+                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color:#000;">내가 올린
+                                    공고</a></li>
+                                <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a>
+                                </li>
+                                <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
+                                <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
+                                <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보
+                                    수정</a></li>
+                            </ul>
+                        </nav>
+                    </div>
+                </div>
             </div>
-            <div class="col-md-9">
-                <nav class="navbar navbar-expand-md">
-                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                        <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color:#000;">내가 올린 공고</a></li>
-                        <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a>
-                        </li>
-                        <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
-                        <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
-                        <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보 수정</a></li>
-                    </ul>
-                </nav>
-            </div>
-            <!--</editor-fold>-->
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/user/mypage_rct_job.html
+++ b/src/main/resources/templates/user/mypage_rct_job.html
@@ -106,20 +106,22 @@
 </style>
 
 <div class="jumbotron">
-    <div class="row">
-        <div class="col-md-3 px-4">
-            <h3>나의 채용</h3>
-        </div>
-        <div class="col-md-9">
-            <nav class="navbar navbar-expand-md">
-                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                    <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color:#000;">내가 올린 공고</a></li>
-                    <li><a th:href="@{/user/my/rct/creator}" class="nav-link px-2">창작자 등록 현황</a></li>
-                    <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a></li>
-                    <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
-                    <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
-                </ul>
-            </nav>
+    <div class="container">
+        <div class="row">
+            <div class="col-md-3 px-4">
+                <h3>나의 채용</h3>
+            </div>
+            <div class="col-md-9">
+                <nav class="navbar navbar-expand-md">
+                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                        <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color:#000;">내가 올린 공고</a></li>
+                        <li><a th:href="@{/user/my/rct/creator}" class="nav-link px-2">창작자 등록 현황</a></li>
+                        <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a></li>
+                        <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
+                        <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
+                    </ul>
+                </nav>
+            </div>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/user/mypage_rct_job.html
+++ b/src/main/resources/templates/user/mypage_rct_job.html
@@ -133,7 +133,7 @@
         <aside class="col-md-3 px-4">
             <div class="row">
                 <div class="col-1"></div>
-                <div class="col-6">
+                <div class="col-8">
                     <div class="panel">
                         <ul class="list-group">
                             <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>

--- a/src/main/resources/templates/user/mypage_rct_job.html
+++ b/src/main/resources/templates/user/mypage_rct_job.html
@@ -303,14 +303,69 @@
             <div class="row" style="color: #828282;">
                 <div class="col-11">
                     <div class="row">
-                        <div class="col-12">
+                        <div class="col-12 p-0">
+                            <style>
+                                .col-4 select {
+                                    border-radius: 50px;
+                                    text-align: center;
+                                }
+                                /* 검색창 스타일 */
+                                .search-container {
+                                    width: 300px;
+                                }
+
+                                .search-container select {
+                                    position: absolute;
+                                    left: 0%;
+                                    width: 30%;
+                                    height: 50px;
+                                    color: #828282;
+                                    font-size: 1rem;
+                                    border-radius: 50px 0 0 50px;
+                                    outline: none;
+                                }
+                                .search-container input[type="text"] {
+                                    position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
+                                    left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
+                                    width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
+                                    height: 50px;
+                                    padding: 10px 40px 10px 15px;
+                                    font-size: 1rem;
+                                    outline: none;
+                                    border-radius: 0 50px 50px 0;
+                                    transition: border-color 0.3s, background-color 0.3s;
+                                    color: #828282; /* 입력 텍스트 색상 변경 */
+                                }
+
+                                .search-container input[type="text"]::placeholder {
+                                    color: #BBBBBB; /* placeholder 색상 변경 */
+                                }
+
+
+                                .search-container button {
+                                    position: absolute;
+                                    right: 1rem;
+                                    top: 25px;
+                                    background: none;
+                                    transform: translateY(-50%);
+                                    border: none;
+                                    cursor: pointer;
+                                }
+
+                                .search-container button i {
+                                    color: #666;
+                                }
+
+                                .search-container button:hover i {
+                                    color: #03C75A;
+                                }
+                            </style>
                             <form id="filter-and-sort-form" th:action="@{/user/my/rct/job}" method="get">
-                                <div class="row">
-                                    <div class="col-7">
+                                <div class="row m-0">
+                                    <div class="col-7 p-0">
                                         <div class="row justify-content-start m-0">
-                                            <div class="col-4">
-                                                <!-- 검색 조건 -->
-                                                <label>
+                                            <div class="col-12 p-0">
+                                                <div class="search-container">
                                                     <select class="form-select px-3" name="searchBy">
                                                         <option value="title" th:selected="${searchBy == 'title'}">제목
                                                         </option>
@@ -321,16 +376,12 @@
                                                                 th:selected="${searchBy == 'location'}">근무지
                                                         </option>
                                                     </select>
-                                                </label>
-                                            </div>
-                                            <div class="col-6">
-                                                <input class="form-control px-3" type="text" name="searchTerm"
-                                                       placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
-                                            </div>
-                                            <div class="col-2">
-                                                <!-- 검색 버튼 -->
-                                                <button id="searchbutton" type="submit" class="btn btn-primary">검색
-                                                </button>
+                                                    <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
+                                                    <!-- 검색 버튼 -->
+                                                    <button type="submit">
+                                                        <i class="fas fa-search"></i>
+                                                    </button>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>

--- a/src/main/resources/templates/user/mypage_rct_job.html
+++ b/src/main/resources/templates/user/mypage_rct_job.html
@@ -132,7 +132,7 @@
     <div class="row">
         <aside class="col-md-3 px-4">
             <div class="row">
-                <div class="col-3"></div>
+                <div class="col-1"></div>
                 <div class="col-6">
                     <div class="panel">
                         <ul class="list-group">

--- a/src/main/resources/templates/user/mypage_rct_job.html
+++ b/src/main/resources/templates/user/mypage_rct_job.html
@@ -125,33 +125,35 @@
         </div>
     </div>
 </div>
-<div class="row">
-    <aside class="col-md-3 px-4">
-        <div class="row">
-            <div class="col-3"></div>
-            <div class="col-6">
-                <div class="panel">
-                    <ul class="list-group">
-                        <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
-                        <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-                        <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color: #03C75A;">나의 채용</a></li>
-                        <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-                        <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                        <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-                    </ul>
+<div class="container" style="padding:0;">
+    <div class="row">
+        <aside class="col-md-3 px-4">
+            <div class="row">
+                <div class="col-3"></div>
+                <div class="col-6">
+                    <div class="panel">
+                        <ul class="list-group">
+                            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
+                            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color: #03C75A;">나의 채용</a>
+                            </li>
+                            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+                        </ul>
+                    </div>
                 </div>
             </div>
-        </div>
-    </aside>
-<!--    <script>-->
-<!--        function toggleCheckboxValue() {-->
-<!--            const checkbox = document.getElementById('isToggledCheckbox');-->
-<!--            if(!checkbox.checked) checkbox.value = 'N';-->
-<!--            else checkbox.value = 'Y';-->
-<!--            document.getElementById('filter-form').submit();-->
-<!--        }-->
-<!--    </script>-->
-    <script> // toggle + sorting
+        </aside>
+        <!--    <script>-->
+        <!--        function toggleCheckboxValue() {-->
+        <!--            const checkbox = document.getElementById('isToggledCheckbox');-->
+        <!--            if(!checkbox.checked) checkbox.value = 'N';-->
+        <!--            else checkbox.value = 'Y';-->
+        <!--            document.getElementById('filter-form').submit();-->
+        <!--        }-->
+        <!--    </script>-->
+        <script> // toggle + sorting
         function updateCheckboxValueAndSubmit() {
             const checkbox = document.getElementById('isToggledCheckbox');
             const form = document.getElementById('filter-and-sort-form');
@@ -164,322 +166,385 @@
         function submitForm() {
             document.getElementById('filter-and-sort-form').submit();
         }
-    </script>
-    <style>
-        .form-select {
-        background-color : #FCFCFC;
-        border : none;
-        width : 100%;
-        height : 50px;
-        }
-        select {
-        color : #828282;
-        }
-        .form-control {
-        background-color : #FCFCFC;
-        border : none;
-        width : 100%;
-        height : 50px;
-        }
+        </script>
+        <style>
+            .form-select {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
+            }
+            select {
+            color : #828282;
+            }
+            .form-control {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
+            }
 
 
-        .form-control::placeholder {
-        color : #BBBBBB;
-        }
+            .form-control::placeholder {
+            color : #BBBBBB;
+            }
 
-        .date-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    background-color: #8E4B6E;
-    color: white;
-    border-radius: 10px;
-    text-align:center;
-    font-family: "Work Sans", sans-serif;
-}
+            .date-container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        background-color: #8E4B6E;
+        color: white;
+        border-radius: 10px;
+        text-align:center;
+        font-family: "Work Sans", sans-serif;
+    }
 
-.month {
-    font-size: 1.1rem; /* M의 크기를 설정 */
-    font-weight: 550;
-    line-height: 1;
-}
+    .month {
+        font-size: 1.1rem; /* M의 크기를 설정 */
+        font-weight: 550;
+        line-height: 1;
+    }
 
-.year {
-    font-size: 0.65rem; /* yyyy의 크기를 설정 */
-    font-weight: 400;
-}
-:root {
-    --background-color-light: #FFFFFF;
-    --text-color-light: #000000;
-    --toggle-background-light: #CCCCCC;
-    --toggle-ball-light: #FFFFFF;
+    .year {
+        font-size: 0.65rem; /* yyyy의 크기를 설정 */
+        font-weight: 400;
+    }
+    :root {
+        --background-color-light: #FFFFFF;
+        --text-color-light: #000000;
+        --toggle-background-light: #CCCCCC;
+        --toggle-ball-light: #FFFFFF;
 
-    --background-color-dark: #333333;
-    --text-color-dark: #FFFFFF;
-    --toggle-background-dark: #03C75A;
-    --toggle-ball-dark: #FFFFFF;
+        --background-color-dark: #333333;
+        --text-color-dark: #FFFFFF;
+        --toggle-background-dark: #03C75A;
+        --toggle-ball-dark: #FFFFFF;
 
-    --font-size-base: 32px; /* 기본 텍스트 크기 */
-    --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
-}
+        --font-size-base: 32px; /* 기본 텍스트 크기 */
+        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+    }
 
 
 
-.toggle-switch {
-    position: relative;
-    display: inline-block;
-    width: 62px; /* 너비 조정 */
-    height: 38px; /* 높이 조정 */
-}
+    .toggle-switch {
+        position: relative;
+        display: inline-block;
+        width: 62px; /* 너비 조정 */
+        height: 38px; /* 높이 조정 */
+    }
 
-.toggle-switch .checkbox {
-    opacity: 0;
-    width: 0;
-    height: 0;
-}
-#isToggledCheckbox {
-     opacity: 0;
+    .toggle-switch .checkbox {
+        opacity: 0;
         width: 0;
         height: 0;
-}
+    }
+    #isToggledCheckbox {
+         opacity: 0;
+            width: 0;
+            height: 0;
+    }
 
-.toggle-switch .label {
-    position: absolute;
-    cursor: pointer;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: var(--toggle-background-light);
-    transition: background-color 0.4s;
-    border-radius: 38px; /* 둥근 모서리 반경 조정 */
-}
+    .toggle-switch .label {
+        position: absolute;
+        cursor: pointer;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: var(--toggle-background-light);
+        transition: background-color 0.4s;
+        border-radius: 38px; /* 둥근 모서리 반경 조정 */
+    }
 
-.toggle-switch .label:before {
-    position: absolute;
-    content: "";
-    height: 30px; /* 내부 원 높이 조정 */
-    width: 30px; /* 내부 원 너비 조정 */
-    left: 2px;
-    bottom: 0px;
-    background-color: var(--toggle-ball-light);
-    transition: transform 0.4s;
-    border-radius: 50%;
-}
+    .toggle-switch .label:before {
+        position: absolute;
+        content: "";
+        height: 30px; /* 내부 원 높이 조정 */
+        width: 30px; /* 내부 원 너비 조정 */
+        left: 2px;
+        bottom: 0px;
+        background-color: var(--toggle-ball-light);
+        transition: transform 0.4s;
+        border-radius: 50%;
+    }
 
-.toggle-switch input:checked + .label {
-    background-color: var(--toggle-background-dark);
-}
+    .toggle-switch input:checked + .label {
+        background-color: var(--toggle-background-dark);
+    }
 
-.toggle-switch input:checked + .label:before {
-    transform: translateX(28px); /* 내부 원 이동 거리 조정 */
-}
+    .toggle-switch input:checked + .label:before {
+        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+    }
 
-         #absdiv {
-            position: relative;
-            top: 60px; /* Move down by 20px from its current position */
-            z-index : 1000;
-        }
+             #absdiv {
+                position: relative;
+                top: 60px; /* Move down by 20px from its current position */
+                z-index : 1000;
+            }
 
-        #searchbutton {
-            background-color: #828282;
-        }
-    </style>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
-    <div class="col-md-9">
-        <div class="row" style="color: #828282;">
-            <div class="col-11">
-                <div class="row">
-                    <div class="col-12">
-                        <form id="filter-and-sort-form" th:action="@{/user/my/rct/job}" method="get">
-                            <div class="row">
-                                <div class="col-7">
-                                    <div class="row justify-content-start m-0">
-                                        <div class="col-4">
-                                            <!-- 검색 조건 -->
+            #searchbutton {
+                background-color: #828282;
+            }
+        </style>
+        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+              rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+              rel="stylesheet">
+        <div class="col-md-9">
+            <div class="row" style="color: #828282;">
+                <div class="col-11">
+                    <div class="row">
+                        <div class="col-12">
+                            <form id="filter-and-sort-form" th:action="@{/user/my/rct/job}" method="get">
+                                <div class="row">
+                                    <div class="col-7">
+                                        <div class="row justify-content-start m-0">
+                                            <div class="col-4">
+                                                <!-- 검색 조건 -->
+                                                <label>
+                                                    <select class="form-select px-3" name="searchBy">
+                                                        <option value="title" th:selected="${searchBy == 'title'}">제목
+                                                        </option>
+                                                        <option value="content" th:selected="${searchBy == 'content'}">
+                                                            내용
+                                                        </option>
+                                                        <option value="location"
+                                                                th:selected="${searchBy == 'location'}">근무지
+                                                        </option>
+                                                    </select>
+                                                </label>
+                                            </div>
+                                            <div class="col-6">
+                                                <input class="form-control px-3" type="text" name="searchTerm"
+                                                       placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
+                                            </div>
+                                            <div class="col-2">
+                                                <!-- 검색 버튼 -->
+                                                <button id="searchbutton" type="submit" class="btn btn-primary">검색
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-1" style=""></div>
+                                    <div class="col-4">
+                                        <div class="row justify-content-end">
+                                            <!-- 정렬 또는 토글2 -->
                                             <label>
-                                                <select class="form-select px-3" name="searchBy">
-                                                    <option value="title" th:selected="${searchBy == 'title'}">제목</option>
-                                                    <option value="content" th:selected="${searchBy == 'content'}">내용</option>
-                                                    <option value="location" th:selected="${searchBy == 'location'}">근무지</option>
+                                                <select class="form-select px-3" name="orderBy" onchange="submitForm()">
+                                                    <option value="recentedited"
+                                                            th:selected="${orderBy == 'recentedited'}">최근수정순
+                                                    </option>
+                                                    <option value="recent" th:selected="${orderBy == 'recent'}">최근작성순
+                                                    </option>
+                                                    <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순
+                                                    </option>
+                                                    <option value="dueSoon" th:selected="${orderBy == 'dueSoon'}">
+                                                        마감임박순
+                                                    </option>
+                                                    <option value="title" th:selected="${orderBy == 'title'}">제목가나다순
+                                                    </option>
                                                 </select>
                                             </label>
                                         </div>
-                                        <div class="col-6">
-                                            <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
-                                        </div>
-                                        <div class="col-2">
-                                            <!-- 검색 버튼 -->
-                                            <button id="searchbutton" type="submit" class="btn btn-primary">검색</button>
-                                        </div>
                                     </div>
-                                </div>
-                                <div class="col-1" style=""></div>
-                                <div class="col-4">
-                                    <div class="row justify-content-end">
-                                        <!-- 정렬 또는 토글2 -->
-                                        <label>
-                                            <select class="form-select px-3" name="orderBy" onchange="submitForm()">
-                                                <option value="recentedited" th:selected="${orderBy == 'recentedited'}">최근수정순</option>
-                                                <option value="recent" th:selected="${orderBy == 'recent'}">최근작성순</option>
-                                                <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>
-                                                <option value="dueSoon" th:selected="${orderBy == 'dueSoon'}">마감임박순</option>
-                                                <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>
-                                            </select>
-                                        </label>
-                                    </div>
-                                </div>
-                            </div> <!--검색, 소팅 (토글X)-->
-                            <div class="row justify-content-around">
-                                <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                <div class="col-3" style="padding: 0 1.2rem;">
-                                    <div id="absdiv" class="row justify-content-end">
-                                        <div class="col-3">
-                                            <div class="toggle-switch">
-                                                <!-- 정렬 또는 토글1 -->
-                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">
-                                                <label for="isToggledCheckbox" class="label">
-                                                    <div class="ball"></div>
-                                                </label>
+                                </div> <!--검색, 소팅 (토글X)-->
+                                <div class="row justify-content-around">
+                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                    <div class="col-3" style="padding: 0 1.2rem;">
+                                        <div id="absdiv" class="row justify-content-end">
+                                            <div class="col-3">
+                                                <div class="toggle-switch">
+                                                    <!-- 정렬 또는 토글1 -->
+                                                    <input type="checkbox" name="isToggled" id="isToggledCheckbox"
+                                                           value="Y" th:checked="${isToggled == 'Y'}"
+                                                           onchange="updateCheckboxValueAndSubmit()">
+                                                    <label for="isToggledCheckbox" class="label">
+                                                        <div class="ball"></div>
+                                                    </label>
+                                                </div>
+                                            </div>
+                                            <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">
+                                                마감된 공고
                                             </div>
                                         </div>
-                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">마감된 공고</div>
                                     </div>
-                                </div>
-                            </div> <!--토글-->
-                        </form>
-                    </div>
-                </div>
-                <div class="row justify-content-around">
-                    <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
-                        <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
-                            <div class="col-3 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:each="myRctJob, iterStat : ${myRctJobs}" th:attr="data-href=@{/user/my/rct/job/apply(boardNo=${myRctJob.boardNo})}" th:if="${iterStat.index < 3}">
-                                <div class="row justify-content-center">
-                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                        <div class="date-container px-2 py-1">
-                                            <div class="month" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctJob.createdDate)}"></div>
-                                            <div class="year" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctJob.createdDate)}"></div>
-                                        </div>
-                                    </div>
-                                    <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-<!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-<!--                                    </div>-->
-                                    <div class="col-4" style="color: white;" th:text="${myRctJob.boardNo}">닉네임</div>
-                                    <div class="col-4" style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD;" th:text="${myRctJob.formattedDeadLine}">시간</div>
-                                </div>
-                                <div class="row justify-content-center">
-                                    <div class="col-10" style="color: white;" th:text="${myRctJob.boardNo}">사진</div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" th:text="${myRctJob.title}">이름</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${myRctJob.content}">내용</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                </div>
-
-                            </div>
-                            <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
-                            <div class="col-3" th:if="${myRctJobs.size() == 0}"></div>
-                            <div class="col-3" th:if="${myRctJobs.size() == 0 || myRctJobs.size() == 1}"></div>
-                            <div class="col-3" th:if="${myRctJobs.size() == 0 || myRctJobs.size() == 1 || myRctJobs.size() == 2}"></div>
-                        </div>
-                        <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
-                            <div class="col-3 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:each="myRctJob, iterStat : ${myRctJobs}" th:attr="data-href=@{/user/my/rct/job/apply(boardNo=${myRctJob.boardNo})}" th:if="${iterStat.index >= 3}">
-                                <div class="row justify-content-center">
-                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                        <div class="date-container px-2 py-1">
-                                            <div class="month" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctJob.createdDate)}"></div>
-                                            <div class="year" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctJob.createdDate)}"></div>
-                                        </div>
-                                    </div>
-                                    <div class="col-4" style="color: white;" th:text="${myRctJob.boardNo}">닉네임</div>
-                                    <div class="col-4" style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD;" th:text="${myRctJob.formattedDeadLine}">시간</div>
-                                </div>
-                                <div class="row justify-content-center">
-                                    <div class="col-10" style="color: white;" th:text="${myRctJob.boardNo}">사진</div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" th:text="${myRctJob.title}">이름</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${myRctJob.content}">내용</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                </div>
-
-                            </div>
-
-                            <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
-                            <div class="col-3" th:if="${myRctJobs.size() <= 3}"></div>
-                            <div class="col-3" th:if="${myRctJobs.size() <= 3 || myRctJobs.size() == 4}"></div>
-                            <div class="col-3" th:if="${myRctJobs.size() <= 3 || myRctJobs.size() == 4 || myRctJobs.size() == 5}"></div>
+                                </div> <!--토글-->
+                            </form>
                         </div>
                     </div>
-                </div>
-                <div class="row justify-content-center">
-                    <!-- 페이징 -->
-                    <th:block th:if="${pages != null}">
-                        <div class="d-flex justify-content-center">
-                            <div class="btn-group">
-                                <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/rct/job(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-                                        <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                                    </svg>
-                                </button>
-                                <th:block th:each="p : ${#numbers.sequence(1, pages)}">
-                                    <button type="button" class="btn btn-sm me-2 pages"
-                                            th:text="${p}" th:onclick="|location.href='@{/user/my/rct/job(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
-                                </th:block>
-                                <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/rct/job(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-                                        <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
-                                    </svg>
-                                </button>
+                    <div class="row justify-content-around">
+                        <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
+                            <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
+                                <div class="col-3 clickable-row"
+                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                     th:each="myRctJob, iterStat : ${myRctJobs}"
+                                     th:attr="data-href=@{/user/my/rct/job/apply(boardNo=${myRctJob.boardNo})}"
+                                     th:if="${iterStat.index < 3}">
+                                    <div class="row justify-content-center">
+                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                             style="aspect-ratio: 1; border-radius: 5px;">
+                                            <div class="date-container px-2 py-1">
+                                                <div class="month"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctJob.createdDate)}"></div>
+                                                <div class="year"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctJob.createdDate)}"></div>
+                                            </div>
+                                        </div>
+                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                        <!--                                    </div>-->
+                                        <div class="col-4" style="color: white;" th:text="${myRctJob.boardNo}">닉네임</div>
+                                        <div class="col-4"
+                                             style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD;"
+                                             th:text="${myRctJob.formattedDeadLine}">시간
+                                        </div>
+                                    </div>
+                                    <div class="row justify-content-center">
+                                        <div class="col-10" style="color: white;" th:text="${myRctJob.boardNo}">사진</div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                             th:text="${myRctJob.title}">이름
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                             th:text="${myRctJob.content}">내용
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                    </div>
+
+                                </div>
+                                <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
+                                <div class="col-3" th:if="${myRctJobs.size() == 0}"></div>
+                                <div class="col-3" th:if="${myRctJobs.size() == 0 || myRctJobs.size() == 1}"></div>
+                                <div class="col-3"
+                                     th:if="${myRctJobs.size() == 0 || myRctJobs.size() == 1 || myRctJobs.size() == 2}"></div>
+                            </div>
+                            <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
+                                <div class="col-3 clickable-row"
+                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                     th:each="myRctJob, iterStat : ${myRctJobs}"
+                                     th:attr="data-href=@{/user/my/rct/job/apply(boardNo=${myRctJob.boardNo})}"
+                                     th:if="${iterStat.index >= 3}">
+                                    <div class="row justify-content-center">
+                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                             style="aspect-ratio: 1; border-radius: 5px;">
+                                            <div class="date-container px-2 py-1">
+                                                <div class="month"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctJob.createdDate)}"></div>
+                                                <div class="year"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctJob.createdDate)}"></div>
+                                            </div>
+                                        </div>
+                                        <div class="col-4" style="color: white;" th:text="${myRctJob.boardNo}">닉네임</div>
+                                        <div class="col-4"
+                                             style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD;"
+                                             th:text="${myRctJob.formattedDeadLine}">시간
+                                        </div>
+                                    </div>
+                                    <div class="row justify-content-center">
+                                        <div class="col-10" style="color: white;" th:text="${myRctJob.boardNo}">사진</div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                             th:text="${myRctJob.title}">이름
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                             th:text="${myRctJob.content}">내용
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                    </div>
+
+                                </div>
+
+                                <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
+                                <div class="col-3" th:if="${myRctJobs.size() <= 3}"></div>
+                                <div class="col-3" th:if="${myRctJobs.size() <= 3 || myRctJobs.size() == 4}"></div>
+                                <div class="col-3"
+                                     th:if="${myRctJobs.size() <= 3 || myRctJobs.size() == 4 || myRctJobs.size() == 5}"></div>
                             </div>
                         </div>
-                    </th:block>
-                </div>
-<!--                <div class="row">-->
-<!--                    <div class="review-list">-->
-<!--                        <table>-->
-<!--                            <thead>-->
-<!--                            <tr>-->
-<!--                                <th>게시글 번호</th>-->
-<!--                                <th>작성자</th>-->
-<!--                                <th>제목</th>-->
-<!--                                <th>내용</th>-->
-<!--                                <th>근무지</th>-->
-<!--                                <th>이미지</th>-->
-<!--                                <th>작성 일자</th>-->
-<!--                                <th>수정 일자</th>-->
-<!--                                <th>마감 일자</th>-->
-<!--                            </tr>-->
-<!--                            </thead>-->
-<!--                            <tbody>-->
-<!--                            <tr th:each="myRctJob : ${myRctJobs}" class="clickable-row" th:attr="data-href=@{/user/my/rct/job/apply(boardNo=${myRctJob.boardNo})}">-->
-<!--                                <td th:text="${myRctJob.boardNo}">게시글 번호</td>-->
-<!--                                <td th:text="${myRctJob.writer}">작성자</td>-->
-<!--                                <td th:text="${myRctJob.title}">제목</td>-->
-<!--                                <td th:text="${myRctJob.content}">내용</td>-->
-<!--                                <td th:text="${myRctJob.location}">근무지</td>-->
-<!--                                <td th:text="${myRctJob.img}">이미지</td>-->
-<!--                                <td th:text="${myRctJob.createdDate}">작성 일자</td>-->
-<!--                                <td th:text="${myRctJob.modifiedDate}">수정 일자</td>-->
-<!--                                <td th:text="${myRctJob.deadLine}">마감 일자</td>-->
-<!--                            </tr>-->
-<!--                            </tbody>-->
-<!--                        </table>-->
-<!--                    </div>-->
-<!--                </div> &lt;!&ndash;테이블&ndash;&gt;-->
-            </div><!--테이블 및 페이징 포함-->
+                    </div>
+                    <div class="row justify-content-center">
+                        <!-- 페이징 -->
+                        <th:block th:if="${pages != null}">
+                            <div class="d-flex justify-content-center">
+                                <div class="btn-group">
+                                    <button type="button" class="btn btn-sm previous"
+                                            th:onclick="|location.href='@{/user/my/rct/job(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
+                                            th:disabled="${currentPage == 1}">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                             fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+                                            <path fill-rule="evenodd"
+                                                  d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                                        </svg>
+                                    </button>
+                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">
+                                        <button type="button" class="btn btn-sm me-2 pages"
+                                                th:text="${p}"
+                                                th:onclick="|location.href='@{/user/my/rct/job(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
+                                    </th:block>
+                                    <button type="button" class="btn btn-sm  next"
+                                            th:onclick="|location.href='@{/user/my/rct/job(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
+                                            th:disabled="${currentPage == pages}">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                             fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+                                            <path fill-rule="evenodd"
+                                                  d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                                        </svg>
+                                    </button>
+                                </div>
+                            </div>
+                        </th:block>
+                    </div>
+                    <!--                <div class="row">-->
+                    <!--                    <div class="review-list">-->
+                    <!--                        <table>-->
+                    <!--                            <thead>-->
+                    <!--                            <tr>-->
+                    <!--                                <th>게시글 번호</th>-->
+                    <!--                                <th>작성자</th>-->
+                    <!--                                <th>제목</th>-->
+                    <!--                                <th>내용</th>-->
+                    <!--                                <th>근무지</th>-->
+                    <!--                                <th>이미지</th>-->
+                    <!--                                <th>작성 일자</th>-->
+                    <!--                                <th>수정 일자</th>-->
+                    <!--                                <th>마감 일자</th>-->
+                    <!--                            </tr>-->
+                    <!--                            </thead>-->
+                    <!--                            <tbody>-->
+                    <!--                            <tr th:each="myRctJob : ${myRctJobs}" class="clickable-row" th:attr="data-href=@{/user/my/rct/job/apply(boardNo=${myRctJob.boardNo})}">-->
+                    <!--                                <td th:text="${myRctJob.boardNo}">게시글 번호</td>-->
+                    <!--                                <td th:text="${myRctJob.writer}">작성자</td>-->
+                    <!--                                <td th:text="${myRctJob.title}">제목</td>-->
+                    <!--                                <td th:text="${myRctJob.content}">내용</td>-->
+                    <!--                                <td th:text="${myRctJob.location}">근무지</td>-->
+                    <!--                                <td th:text="${myRctJob.img}">이미지</td>-->
+                    <!--                                <td th:text="${myRctJob.createdDate}">작성 일자</td>-->
+                    <!--                                <td th:text="${myRctJob.modifiedDate}">수정 일자</td>-->
+                    <!--                                <td th:text="${myRctJob.deadLine}">마감 일자</td>-->
+                    <!--                            </tr>-->
+                    <!--                            </tbody>-->
+                    <!--                        </table>-->
+                    <!--                    </div>-->
+                    <!--                </div> &lt;!&ndash;테이블&ndash;&gt;-->
+                </div><!--테이블 및 페이징 포함-->
+            </div> <!--본화면-->
         </div> <!--본화면-->
-    </div> <!--본화면-->
-</div> <!--aside와 본화면-->
+    </div> <!--aside와 본화면--></div>
 <div th:replace="common/footer.html"></div>
 </body>
 </html>

--- a/src/main/resources/templates/user/mypage_rct_job.html
+++ b/src/main/resources/templates/user/mypage_rct_job.html
@@ -114,9 +114,10 @@
             <div class="col-md-9">
                 <nav class="navbar navbar-expand-md">
                     <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                        <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 등록 현황</a></li>
                         <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color:#000;">내가 올린 공고</a></li>
-                        <li><a th:href="@{/user/my/rct/creator}" class="nav-link px-2">창작자 등록 현황</a></li>
-                        <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a></li>
+                        <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a>
+                        </li>
                         <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
                         <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
                     </ul>

--- a/src/main/resources/templates/user/mypage_rct_job.html
+++ b/src/main/resources/templates/user/mypage_rct_job.html
@@ -114,12 +114,12 @@
             <div class="col-md-9">
                 <nav class="navbar navbar-expand-md">
                     <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                        <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 등록 현황</a></li>
                         <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color:#000;">내가 올린 공고</a></li>
                         <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a>
                         </li>
                         <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
                         <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
+                        <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보 수정</a></li>
                     </ul>
                 </nav>
             </div>

--- a/src/main/resources/templates/user/mypage_rct_job.html
+++ b/src/main/resources/templates/user/mypage_rct_job.html
@@ -353,7 +353,7 @@
                                 }
 
                                 .search-container button i {
-                                    color: #666;
+                                    color: #A6AAB5;
                                 }
 
                                 .search-container button:hover i {

--- a/src/main/resources/templates/user/mypage_rct_job.html
+++ b/src/main/resources/templates/user/mypage_rct_job.html
@@ -87,522 +87,552 @@
 
 <div th:replace="~{common/menubar}"></div>
 <style>
-    .jumbotron {
-    position : relative;
-    background-color : #EEEEEE;
+    html, body {
+        height: 100%;
+        margin: 0;
     }
-    .jumbotron .row {
-    position : absolute;
-    width : 100%;
-    bottom: 0%;
+    body {
+        display: flex;
+        flex-direction: column;
     }
-    .nav-link {
-            color: #828282;
+    .content-wrapper {
+        flex: 1 0 auto;
     }
-    ul {
-  list-style: none;
-  padding-left : 0px;
-  }
-</style>
+    footer {
+        flex-shrink: 0;
+    }
 
-<div class="jumbotron">
-    <div class="container">
-        <div class="row">
-            <div class="col-9">
-                <div class="row">
-                    <div class="col-md-3 px-4">
-                        <h3>나의 채용</h3>
-                    </div>
-                    <div class="col-md-9">
-                        <nav class="navbar navbar-expand-md">
-                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color:#000;">내가 올린
-                                    공고</a></li>
-                                <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a>
-                                </li>
-                                <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
-                                <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
-                                <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보
-                                    수정</a></li>
-                            </ul>
-                        </nav>
+</style>
+<div class="content-wrapper">
+    <style>
+        .jumbotron {
+        position : relative;
+        background-color : #EEEEEE;
+        }
+        .jumbotron .row {
+        position : absolute;
+        width : 100%;
+        bottom: 0%;
+        }
+        .nav-link {
+                color: #828282;
+        }
+        ul {
+      list-style: none;
+      padding-left : 0px;
+      }
+    </style>
+
+    <div class="jumbotron">
+        <div class="container">
+            <div class="row">
+                <div class="col-9">
+                    <div class="row">
+                        <div class="col-md-3 px-4">
+                            <h3>나의 채용</h3>
+                        </div>
+                        <div class="col-md-9">
+                            <nav class="navbar navbar-expand-md">
+                                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                    <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color:#000;">내가 올린
+                                        공고</a></li>
+                                    <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a>
+                                    </li>
+                                    <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
+                                    <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
+                                    <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보
+                                        수정</a></li>
+                                </ul>
+                            </nav>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
-<div class="container" style="padding:0;">
-    <div class="row">
-        <aside class="col-md-3 px-4">
-            <div class="row">
-                <div class="col-1"></div>
-                <div class="col-8">
-                    <div class="panel">
-                        <ul class="list-group">
-                            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
-                            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-                            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color: #03C75A;">나의 채용</a>
-                            </li>
-                            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-                        </ul>
+    <div class="container" style="padding:0;">
+        <div class="row">
+            <aside class="col-md-3 px-4">
+                <div class="row">
+                    <div class="col-1"></div>
+                    <div class="col-8">
+                        <div class="panel">
+                            <ul class="list-group">
+                                <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
+                                <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color: #03C75A;">나의
+                                    채용</a>
+                                </li>
+                                <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                                <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                                <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </aside>
-        <!--    <script>-->
-        <!--        function toggleCheckboxValue() {-->
-        <!--            const checkbox = document.getElementById('isToggledCheckbox');-->
-        <!--            if(!checkbox.checked) checkbox.value = 'N';-->
-        <!--            else checkbox.value = 'Y';-->
-        <!--            document.getElementById('filter-form').submit();-->
-        <!--        }-->
-        <!--    </script>-->
-        <script> // toggle + sorting
-        function updateCheckboxValueAndSubmit() {
-            const checkbox = document.getElementById('isToggledCheckbox');
-            const form = document.getElementById('filter-and-sort-form');
-            // 체크박스가 체크된 상태를 확인
-            checkbox.value = checkbox.checked ? 'Y' : 'N';
-            // 폼 제출
-            form.submit();
+            </aside>
+            <!--    <script>-->
+            <!--        function toggleCheckboxValue() {-->
+            <!--            const checkbox = document.getElementById('isToggledCheckbox');-->
+            <!--            if(!checkbox.checked) checkbox.value = 'N';-->
+            <!--            else checkbox.value = 'Y';-->
+            <!--            document.getElementById('filter-form').submit();-->
+            <!--        }-->
+            <!--    </script>-->
+            <script> // toggle + sorting
+            function updateCheckboxValueAndSubmit() {
+                const checkbox = document.getElementById('isToggledCheckbox');
+                const form = document.getElementById('filter-and-sort-form');
+                // 체크박스가 체크된 상태를 확인
+                checkbox.value = checkbox.checked ? 'Y' : 'N';
+                // 폼 제출
+                form.submit();
+            }
+
+            function submitForm() {
+                document.getElementById('filter-and-sort-form').submit();
+            }
+            </script>
+            <style>
+                .form-select {
+                background-color : #FCFCFC;
+                border : none;
+                width : 100%;
+                height : 50px;
+                }
+                select {
+                color : #828282;
+                }
+                .form-control {
+                background-color : #FCFCFC;
+                border : none;
+                width : 100%;
+                height : 50px;
+                }
+
+
+                .form-control::placeholder {
+                color : #BBBBBB;
+                }
+
+                .date-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            background-color: #8E4B6E;
+            color: white;
+            border-radius: 10px;
+            text-align:center;
+            font-family: "Work Sans", sans-serif;
         }
 
-        function submitForm() {
-            document.getElementById('filter-and-sort-form').submit();
+        .month {
+            font-size: 1.1rem; /* M의 크기를 설정 */
+            font-weight: 550;
+            line-height: 1;
         }
-        </script>
-        <style>
-            .form-select {
-            background-color : #FCFCFC;
-            border : none;
-            width : 100%;
-            height : 50px;
-            }
-            select {
-            color : #828282;
-            }
-            .form-control {
-            background-color : #FCFCFC;
-            border : none;
-            width : 100%;
-            height : 50px;
-            }
 
+        .year {
+            font-size: 0.65rem; /* yyyy의 크기를 설정 */
+            font-weight: 400;
+        }
+        :root {
+            --background-color-light: #FFFFFF;
+            --text-color-light: #000000;
+            --toggle-background-light: #CCCCCC;
+            --toggle-ball-light: #FFFFFF;
 
-            .form-control::placeholder {
-            color : #BBBBBB;
-            }
+            --background-color-dark: #333333;
+            --text-color-dark: #FFFFFF;
+            --toggle-background-dark: #03C75A;
+            --toggle-ball-dark: #FFFFFF;
 
-            .date-container {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        background-color: #8E4B6E;
-        color: white;
-        border-radius: 10px;
-        text-align:center;
-        font-family: "Work Sans", sans-serif;
-    }
-
-    .month {
-        font-size: 1.1rem; /* M의 크기를 설정 */
-        font-weight: 550;
-        line-height: 1;
-    }
-
-    .year {
-        font-size: 0.65rem; /* yyyy의 크기를 설정 */
-        font-weight: 400;
-    }
-    :root {
-        --background-color-light: #FFFFFF;
-        --text-color-light: #000000;
-        --toggle-background-light: #CCCCCC;
-        --toggle-ball-light: #FFFFFF;
-
-        --background-color-dark: #333333;
-        --text-color-dark: #FFFFFF;
-        --toggle-background-dark: #03C75A;
-        --toggle-ball-dark: #FFFFFF;
-
-        --font-size-base: 32px; /* 기본 텍스트 크기 */
-        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
-    }
+            --font-size-base: 32px; /* 기본 텍스트 크기 */
+            --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+        }
 
 
 
-    .toggle-switch {
-        position: relative;
-        display: inline-block;
-        width: 62px; /* 너비 조정 */
-        height: 38px; /* 높이 조정 */
-    }
+        .toggle-switch {
+            position: relative;
+            display: inline-block;
+            width: 62px; /* 너비 조정 */
+            height: 38px; /* 높이 조정 */
+        }
 
-    .toggle-switch .checkbox {
-        opacity: 0;
-        width: 0;
-        height: 0;
-    }
-    #isToggledCheckbox {
-         opacity: 0;
+        .toggle-switch .checkbox {
+            opacity: 0;
             width: 0;
             height: 0;
-    }
+        }
+        #isToggledCheckbox {
+             opacity: 0;
+                width: 0;
+                height: 0;
+        }
 
-    .toggle-switch .label {
-        position: absolute;
-        cursor: pointer;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background-color: var(--toggle-background-light);
-        transition: background-color 0.4s;
-        border-radius: 38px; /* 둥근 모서리 반경 조정 */
-    }
+        .toggle-switch .label {
+            position: absolute;
+            cursor: pointer;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: var(--toggle-background-light);
+            transition: background-color 0.4s;
+            border-radius: 38px; /* 둥근 모서리 반경 조정 */
+        }
 
-    .toggle-switch .label:before {
-        position: absolute;
-        content: "";
-        height: 30px; /* 내부 원 높이 조정 */
-        width: 30px; /* 내부 원 너비 조정 */
-        left: 2px;
-        bottom: 0px;
-        background-color: var(--toggle-ball-light);
-        transition: transform 0.4s;
-        border-radius: 50%;
-    }
+        .toggle-switch .label:before {
+            position: absolute;
+            content: "";
+            height: 30px; /* 내부 원 높이 조정 */
+            width: 30px; /* 내부 원 너비 조정 */
+            left: 2px;
+            bottom: 0px;
+            background-color: var(--toggle-ball-light);
+            transition: transform 0.4s;
+            border-radius: 50%;
+        }
 
-    .toggle-switch input:checked + .label {
-        background-color: var(--toggle-background-dark);
-    }
+        .toggle-switch input:checked + .label {
+            background-color: var(--toggle-background-dark);
+        }
 
-    .toggle-switch input:checked + .label:before {
-        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
-    }
+        .toggle-switch input:checked + .label:before {
+            transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+        }
 
-             #absdiv {
-                position: relative;
-                top: 60px; /* Move down by 20px from its current position */
-                z-index : 1000;
-            }
+                 #absdiv {
+                    position: relative;
+                    top: 60px; /* Move down by 20px from its current position */
+                    z-index : 1000;
+                }
 
-            #searchbutton {
-                background-color: #828282;
-            }
-        </style>
-        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
-              rel="stylesheet">
-        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
-              rel="stylesheet">
-        <div class="col-md-9">
-            <div class="row" style="color: #828282;">
-                <div class="col-11">
-                    <div class="row">
-                        <div class="col-12 p-0">
-                            <style>
-                                .col-4 select {
-                                    border-radius: 50px;
-                                    text-align: center;
-                                }
-                                /* 검색창 스타일 */
-                                .search-container {
-                                    width: 300px;
-                                }
+                #searchbutton {
+                    background-color: #828282;
+                }
+            </style>
+            <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+                  rel="stylesheet">
+            <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+                  rel="stylesheet">
+            <div class="col-md-9">
+                <div class="row" style="color: #828282;">
+                    <div class="col-11">
+                        <div class="row">
+                            <div class="col-12 p-0">
+                                <style>
+                                    .col-4 select {
+                                        border-radius: 50px;
+                                        text-align: center;
+                                    }
+                                    /* 검색창 스타일 */
+                                    .search-container {
+                                        width: 300px;
+                                    }
 
-                                .search-container select {
-                                    position: absolute;
-                                    left: 0%;
-                                    width: 30%;
-                                    height: 50px;
-                                    color: #828282;
-                                    font-size: 1rem;
-                                    border-radius: 50px 0 0 50px;
-                                    outline: none;
-                                }
-                                .search-container input[type="text"] {
-                                    position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
-                                    left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
-                                    width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
-                                    height: 50px;
-                                    padding: 10px 40px 10px 15px;
-                                    font-size: 1rem;
-                                    outline: none;
-                                    border-radius: 0 50px 50px 0;
-                                    transition: border-color 0.3s, background-color 0.3s;
-                                    color: #828282; /* 입력 텍스트 색상 변경 */
-                                }
+                                    .search-container select {
+                                        position: absolute;
+                                        left: 0%;
+                                        width: 30%;
+                                        height: 50px;
+                                        color: #828282;
+                                        font-size: 1rem;
+                                        border-radius: 50px 0 0 50px;
+                                        outline: none;
+                                    }
+                                    .search-container input[type="text"] {
+                                        position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
+                                        left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
+                                        width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
+                                        height: 50px;
+                                        padding: 10px 40px 10px 15px;
+                                        font-size: 1rem;
+                                        outline: none;
+                                        border-radius: 0 50px 50px 0;
+                                        transition: border-color 0.3s, background-color 0.3s;
+                                        color: #828282; /* 입력 텍스트 색상 변경 */
+                                    }
 
-                                .search-container input[type="text"]::placeholder {
-                                    color: #BBBBBB; /* placeholder 색상 변경 */
-                                }
+                                    .search-container input[type="text"]::placeholder {
+                                        color: #BBBBBB; /* placeholder 색상 변경 */
+                                    }
 
 
-                                .search-container button {
-                                    position: absolute;
-                                    right: 1rem;
-                                    top: 25px;
-                                    background: none;
-                                    transform: translateY(-50%);
-                                    border: none;
-                                    cursor: pointer;
-                                }
+                                    .search-container button {
+                                        position: absolute;
+                                        right: 1rem;
+                                        top: 25px;
+                                        background: none;
+                                        transform: translateY(-50%);
+                                        border: none;
+                                        cursor: pointer;
+                                    }
 
-                                .search-container button i {
-                                    color: #A6AAB5;
-                                }
+                                    .search-container button i {
+                                        color: #A6AAB5;
+                                    }
 
-                                .search-container button:hover i {
-                                    color: #03C75A;
-                                }
-                            </style>
-                            <form id="filter-and-sort-form" th:action="@{/user/my/rct/job}" method="get">
-                                <div class="row m-0">
-                                    <div class="col-7 p-0">
-                                        <div class="row justify-content-start m-0">
-                                            <div class="col-12 p-0">
-                                                <div class="search-container">
-                                                    <select class="form-select px-3" name="searchBy">
-                                                        <option value="title" th:selected="${searchBy == 'title'}">제목
+                                    .search-container button:hover i {
+                                        color: #03C75A;
+                                    }
+                                </style>
+                                <form id="filter-and-sort-form" th:action="@{/user/my/rct/job}" method="get">
+                                    <div class="row m-0">
+                                        <div class="col-7 p-0">
+                                            <div class="row justify-content-start m-0">
+                                                <div class="col-12 p-0">
+                                                    <div class="search-container">
+                                                        <select class="form-select px-3" name="searchBy">
+                                                            <option value="title" th:selected="${searchBy == 'title'}">
+                                                                제목
+                                                            </option>
+                                                            <option value="content"
+                                                                    th:selected="${searchBy == 'content'}">
+                                                                내용
+                                                            </option>
+                                                            <option value="location"
+                                                                    th:selected="${searchBy == 'location'}">근무지
+                                                            </option>
+                                                        </select>
+                                                        <input class="form-control px-3" type="text" name="searchTerm"
+                                                               placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
+                                                        <!-- 검색 버튼 -->
+                                                        <button type="submit">
+                                                            <i class="fas fa-search"></i>
+                                                        </button>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="col-1" style=""></div>
+                                        <div class="col-4">
+                                            <div class="row justify-content-end">
+                                                <!-- 정렬 또는 토글2 -->
+                                                <label>
+                                                    <select class="form-select px-3" name="orderBy"
+                                                            onchange="submitForm()">
+                                                        <option value="recentedited"
+                                                                th:selected="${orderBy == 'recentedited'}">최근수정순
                                                         </option>
-                                                        <option value="content" th:selected="${searchBy == 'content'}">
-                                                            내용
+                                                        <option value="recent" th:selected="${orderBy == 'recent'}">
+                                                            최근작성순
                                                         </option>
-                                                        <option value="location"
-                                                                th:selected="${searchBy == 'location'}">근무지
+                                                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순
+                                                        </option>
+                                                        <option value="dueSoon" th:selected="${orderBy == 'dueSoon'}">
+                                                            마감임박순
+                                                        </option>
+                                                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순
                                                         </option>
                                                     </select>
-                                                    <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
-                                                    <!-- 검색 버튼 -->
-                                                    <button type="submit">
-                                                        <i class="fas fa-search"></i>
-                                                    </button>
+                                                </label>
+                                            </div>
+                                        </div>
+                                    </div> <!--검색, 소팅 (토글X)-->
+                                    <div class="row justify-content-around">
+                                        <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                        <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                        <div class="col-3" style="padding: 0 1.2rem;">
+                                            <div id="absdiv" class="row justify-content-end">
+                                                <div class="col-3">
+                                                    <div class="toggle-switch">
+                                                        <!-- 정렬 또는 토글1 -->
+                                                        <input type="checkbox" name="isToggled" id="isToggledCheckbox"
+                                                               value="Y" th:checked="${isToggled == 'Y'}"
+                                                               onchange="updateCheckboxValueAndSubmit()">
+                                                        <label for="isToggledCheckbox" class="label">
+                                                            <div class="ball"></div>
+                                                        </label>
+                                                    </div>
+                                                </div>
+                                                <div class="col-8"
+                                                     style="text-align: right; padding: 0px; margin : 0px;">
+                                                    마감된 공고
                                                 </div>
                                             </div>
                                         </div>
-                                    </div>
-                                    <div class="col-1" style=""></div>
-                                    <div class="col-4">
-                                        <div class="row justify-content-end">
-                                            <!-- 정렬 또는 토글2 -->
-                                            <label>
-                                                <select class="form-select px-3" name="orderBy" onchange="submitForm()">
-                                                    <option value="recentedited"
-                                                            th:selected="${orderBy == 'recentedited'}">최근수정순
-                                                    </option>
-                                                    <option value="recent" th:selected="${orderBy == 'recent'}">최근작성순
-                                                    </option>
-                                                    <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순
-                                                    </option>
-                                                    <option value="dueSoon" th:selected="${orderBy == 'dueSoon'}">
-                                                        마감임박순
-                                                    </option>
-                                                    <option value="title" th:selected="${orderBy == 'title'}">제목가나다순
-                                                    </option>
-                                                </select>
-                                            </label>
-                                        </div>
-                                    </div>
-                                </div> <!--검색, 소팅 (토글X)-->
-                                <div class="row justify-content-around">
-                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                    <div class="col-3" style="padding: 0 1.2rem;">
-                                        <div id="absdiv" class="row justify-content-end">
-                                            <div class="col-3">
-                                                <div class="toggle-switch">
-                                                    <!-- 정렬 또는 토글1 -->
-                                                    <input type="checkbox" name="isToggled" id="isToggledCheckbox"
-                                                           value="Y" th:checked="${isToggled == 'Y'}"
-                                                           onchange="updateCheckboxValueAndSubmit()">
-                                                    <label for="isToggledCheckbox" class="label">
-                                                        <div class="ball"></div>
-                                                    </label>
+                                    </div> <!--토글-->
+                                </form>
+                            </div>
+                        </div>
+                        <div class="row justify-content-around">
+                            <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
+                                <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
+                                    <div class="col-3 clickable-row"
+                                         style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                         th:each="myRctJob, iterStat : ${myRctJobs}"
+                                         th:attr="data-href=@{/user/my/rct/job/apply(boardNo=${myRctJob.boardNo})}"
+                                         th:if="${iterStat.index < 3}">
+                                        <div class="row justify-content-center">
+                                            <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                                 style="aspect-ratio: 1; border-radius: 5px;">
+                                                <div class="date-container px-2 py-1">
+                                                    <div class="month"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctJob.createdDate)}"></div>
+                                                    <div class="year"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctJob.createdDate)}"></div>
                                                 </div>
                                             </div>
-                                            <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">
-                                                마감된 공고
+                                            <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                            <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                            <!--                                    </div>-->
+                                            <div class="col-4" style="color: white;" th:text="${myRctJob.boardNo}">닉네임
+                                            </div>
+                                            <div class="col-4"
+                                                 style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD;"
+                                                 th:text="${myRctJob.formattedDeadLine}">시간
                                             </div>
                                         </div>
-                                    </div>
-                                </div> <!--토글-->
-                            </form>
-                        </div>
-                    </div>
-                    <div class="row justify-content-around">
-                        <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
-                            <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
-                                <div class="col-3 clickable-row"
-                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
-                                     th:each="myRctJob, iterStat : ${myRctJobs}"
-                                     th:attr="data-href=@{/user/my/rct/job/apply(boardNo=${myRctJob.boardNo})}"
-                                     th:if="${iterStat.index < 3}">
-                                    <div class="row justify-content-center">
-                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
-                                             style="aspect-ratio: 1; border-radius: 5px;">
-                                            <div class="date-container px-2 py-1">
-                                                <div class="month"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctJob.createdDate)}"></div>
-                                                <div class="year"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctJob.createdDate)}"></div>
+                                        <div class="row justify-content-center">
+                                            <div class="col-10" style="color: white;" th:text="${myRctJob.boardNo}">사진
                                             </div>
                                         </div>
-                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                        <!--                                    </div>-->
-                                        <div class="col-4" style="color: white;" th:text="${myRctJob.boardNo}">닉네임</div>
-                                        <div class="col-4"
-                                             style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD;"
-                                             th:text="${myRctJob.formattedDeadLine}">시간
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                                 th:text="${myRctJob.title}">이름
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;"></div>
                                         </div>
-                                    </div>
-                                    <div class="row justify-content-center">
-                                        <div class="col-10" style="color: white;" th:text="${myRctJob.boardNo}">사진</div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
-                                             th:text="${myRctJob.title}">이름
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                                 th:text="${myRctJob.content}">내용
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;">→</div>
                                         </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
-                                             th:text="${myRctJob.content}">내용
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                    </div>
 
+                                    </div>
+                                    <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
+                                    <div class="col-3" th:if="${myRctJobs.size() == 0}"></div>
+                                    <div class="col-3" th:if="${myRctJobs.size() == 0 || myRctJobs.size() == 1}"></div>
+                                    <div class="col-3"
+                                         th:if="${myRctJobs.size() == 0 || myRctJobs.size() == 1 || myRctJobs.size() == 2}"></div>
                                 </div>
-                                <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
-                                <div class="col-3" th:if="${myRctJobs.size() == 0}"></div>
-                                <div class="col-3" th:if="${myRctJobs.size() == 0 || myRctJobs.size() == 1}"></div>
-                                <div class="col-3"
-                                     th:if="${myRctJobs.size() == 0 || myRctJobs.size() == 1 || myRctJobs.size() == 2}"></div>
-                            </div>
-                            <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
-                                <div class="col-3 clickable-row"
-                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
-                                     th:each="myRctJob, iterStat : ${myRctJobs}"
-                                     th:attr="data-href=@{/user/my/rct/job/apply(boardNo=${myRctJob.boardNo})}"
-                                     th:if="${iterStat.index >= 3}">
-                                    <div class="row justify-content-center">
-                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
-                                             style="aspect-ratio: 1; border-radius: 5px;">
-                                            <div class="date-container px-2 py-1">
-                                                <div class="month"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctJob.createdDate)}"></div>
-                                                <div class="year"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctJob.createdDate)}"></div>
+                                <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
+                                    <div class="col-3 clickable-row"
+                                         style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                         th:each="myRctJob, iterStat : ${myRctJobs}"
+                                         th:attr="data-href=@{/user/my/rct/job/apply(boardNo=${myRctJob.boardNo})}"
+                                         th:if="${iterStat.index >= 3}">
+                                        <div class="row justify-content-center">
+                                            <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                                 style="aspect-ratio: 1; border-radius: 5px;">
+                                                <div class="date-container px-2 py-1">
+                                                    <div class="month"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctJob.createdDate)}"></div>
+                                                    <div class="year"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctJob.createdDate)}"></div>
+                                                </div>
+                                            </div>
+                                            <div class="col-4" style="color: white;" th:text="${myRctJob.boardNo}">닉네임
+                                            </div>
+                                            <div class="col-4"
+                                                 style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD;"
+                                                 th:text="${myRctJob.formattedDeadLine}">시간
                                             </div>
                                         </div>
-                                        <div class="col-4" style="color: white;" th:text="${myRctJob.boardNo}">닉네임</div>
-                                        <div class="col-4"
-                                             style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD;"
-                                             th:text="${myRctJob.formattedDeadLine}">시간
+                                        <div class="row justify-content-center">
+                                            <div class="col-10" style="color: white;" th:text="${myRctJob.boardNo}">사진
+                                            </div>
                                         </div>
-                                    </div>
-                                    <div class="row justify-content-center">
-                                        <div class="col-10" style="color: white;" th:text="${myRctJob.boardNo}">사진</div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
-                                             th:text="${myRctJob.title}">이름
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                                 th:text="${myRctJob.title}">이름
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;"></div>
                                         </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
-                                             th:text="${myRctJob.content}">내용
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                                 th:text="${myRctJob.content}">내용
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;">→</div>
                                         </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
+
                                     </div>
 
+                                    <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
+                                    <div class="col-3" th:if="${myRctJobs.size() <= 3}"></div>
+                                    <div class="col-3" th:if="${myRctJobs.size() <= 3 || myRctJobs.size() == 4}"></div>
+                                    <div class="col-3"
+                                         th:if="${myRctJobs.size() <= 3 || myRctJobs.size() == 4 || myRctJobs.size() == 5}"></div>
                                 </div>
-
-                                <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
-                                <div class="col-3" th:if="${myRctJobs.size() <= 3}"></div>
-                                <div class="col-3" th:if="${myRctJobs.size() <= 3 || myRctJobs.size() == 4}"></div>
-                                <div class="col-3"
-                                     th:if="${myRctJobs.size() <= 3 || myRctJobs.size() == 4 || myRctJobs.size() == 5}"></div>
                             </div>
                         </div>
-                    </div>
-                    <div class="row justify-content-center">
-                        <!-- 페이징 -->
-                        <th:block th:if="${pages != null}">
-                            <div class="d-flex justify-content-center">
-                                <div class="btn-group">
-                                    <button type="button" class="btn btn-sm previous"
-                                            th:onclick="|location.href='@{/user/my/rct/job(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
-                                            th:disabled="${currentPage == 1}">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                             fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-                                            <path fill-rule="evenodd"
-                                                  d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                                        </svg>
-                                    </button>
-                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">
-                                        <button type="button" class="btn btn-sm me-2 pages"
-                                                th:text="${p}"
-                                                th:onclick="|location.href='@{/user/my/rct/job(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
-                                    </th:block>
-                                    <button type="button" class="btn btn-sm  next"
-                                            th:onclick="|location.href='@{/user/my/rct/job(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
-                                            th:disabled="${currentPage == pages}">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                             fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-                                            <path fill-rule="evenodd"
-                                                  d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
-                                        </svg>
-                                    </button>
+                        <div class="row justify-content-center">
+                            <!-- 페이징 -->
+                            <th:block th:if="${pages != null}">
+                                <div class="d-flex justify-content-center">
+                                    <div class="btn-group">
+                                        <button type="button" class="btn btn-sm previous"
+                                                th:onclick="|location.href='@{/user/my/rct/job(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
+                                                th:disabled="${currentPage == 1}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                                 fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+                                                <path fill-rule="evenodd"
+                                                      d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                                            </svg>
+                                        </button>
+                                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">
+                                            <button type="button" class="btn btn-sm me-2 pages"
+                                                    th:text="${p}"
+                                                    th:onclick="|location.href='@{/user/my/rct/job(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
+                                        </th:block>
+                                        <button type="button" class="btn btn-sm  next"
+                                                th:onclick="|location.href='@{/user/my/rct/job(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
+                                                th:disabled="${currentPage == pages}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                                 fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+                                                <path fill-rule="evenodd"
+                                                      d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                                            </svg>
+                                        </button>
+                                    </div>
                                 </div>
-                            </div>
-                        </th:block>
-                    </div>
-                    <!--                <div class="row">-->
-                    <!--                    <div class="review-list">-->
-                    <!--                        <table>-->
-                    <!--                            <thead>-->
-                    <!--                            <tr>-->
-                    <!--                                <th>게시글 번호</th>-->
-                    <!--                                <th>작성자</th>-->
-                    <!--                                <th>제목</th>-->
-                    <!--                                <th>내용</th>-->
-                    <!--                                <th>근무지</th>-->
-                    <!--                                <th>이미지</th>-->
-                    <!--                                <th>작성 일자</th>-->
-                    <!--                                <th>수정 일자</th>-->
-                    <!--                                <th>마감 일자</th>-->
-                    <!--                            </tr>-->
-                    <!--                            </thead>-->
-                    <!--                            <tbody>-->
-                    <!--                            <tr th:each="myRctJob : ${myRctJobs}" class="clickable-row" th:attr="data-href=@{/user/my/rct/job/apply(boardNo=${myRctJob.boardNo})}">-->
-                    <!--                                <td th:text="${myRctJob.boardNo}">게시글 번호</td>-->
-                    <!--                                <td th:text="${myRctJob.writer}">작성자</td>-->
-                    <!--                                <td th:text="${myRctJob.title}">제목</td>-->
-                    <!--                                <td th:text="${myRctJob.content}">내용</td>-->
-                    <!--                                <td th:text="${myRctJob.location}">근무지</td>-->
-                    <!--                                <td th:text="${myRctJob.img}">이미지</td>-->
-                    <!--                                <td th:text="${myRctJob.createdDate}">작성 일자</td>-->
-                    <!--                                <td th:text="${myRctJob.modifiedDate}">수정 일자</td>-->
-                    <!--                                <td th:text="${myRctJob.deadLine}">마감 일자</td>-->
-                    <!--                            </tr>-->
-                    <!--                            </tbody>-->
-                    <!--                        </table>-->
-                    <!--                    </div>-->
-                    <!--                </div> &lt;!&ndash;테이블&ndash;&gt;-->
-                </div><!--테이블 및 페이징 포함-->
+                            </th:block>
+                        </div>
+                        <!--                <div class="row">-->
+                        <!--                    <div class="review-list">-->
+                        <!--                        <table>-->
+                        <!--                            <thead>-->
+                        <!--                            <tr>-->
+                        <!--                                <th>게시글 번호</th>-->
+                        <!--                                <th>작성자</th>-->
+                        <!--                                <th>제목</th>-->
+                        <!--                                <th>내용</th>-->
+                        <!--                                <th>근무지</th>-->
+                        <!--                                <th>이미지</th>-->
+                        <!--                                <th>작성 일자</th>-->
+                        <!--                                <th>수정 일자</th>-->
+                        <!--                                <th>마감 일자</th>-->
+                        <!--                            </tr>-->
+                        <!--                            </thead>-->
+                        <!--                            <tbody>-->
+                        <!--                            <tr th:each="myRctJob : ${myRctJobs}" class="clickable-row" th:attr="data-href=@{/user/my/rct/job/apply(boardNo=${myRctJob.boardNo})}">-->
+                        <!--                                <td th:text="${myRctJob.boardNo}">게시글 번호</td>-->
+                        <!--                                <td th:text="${myRctJob.writer}">작성자</td>-->
+                        <!--                                <td th:text="${myRctJob.title}">제목</td>-->
+                        <!--                                <td th:text="${myRctJob.content}">내용</td>-->
+                        <!--                                <td th:text="${myRctJob.location}">근무지</td>-->
+                        <!--                                <td th:text="${myRctJob.img}">이미지</td>-->
+                        <!--                                <td th:text="${myRctJob.createdDate}">작성 일자</td>-->
+                        <!--                                <td th:text="${myRctJob.modifiedDate}">수정 일자</td>-->
+                        <!--                                <td th:text="${myRctJob.deadLine}">마감 일자</td>-->
+                        <!--                            </tr>-->
+                        <!--                            </tbody>-->
+                        <!--                        </table>-->
+                        <!--                    </div>-->
+                        <!--                </div> &lt;!&ndash;테이블&ndash;&gt;-->
+                    </div><!--테이블 및 페이징 포함-->
+                </div> <!--본화면-->
             </div> <!--본화면-->
-        </div> <!--본화면-->
-    </div> <!--aside와 본화면--></div>
+        </div> <!--aside와 본화면--></div>
+</div>
 <div th:replace="common/footer.html"></div>
 </body>
 </html>

--- a/src/main/resources/templates/user/mypage_rct_job_applicationlist.html
+++ b/src/main/resources/templates/user/mypage_rct_job_applicationlist.html
@@ -302,15 +302,69 @@
             <div class="row" style="color: #828282;">
                 <div class="col-11">
                     <div class="row">
-                        <div class="col-12">
-                            <form id="filter-and-sort-form" th:action="@{/user/my/rct/job/apply(boardNo=${boardNo})}"
-                                  method="get">
-                                <div class="row">
-                                    <div class="col-7">
+                        <div class="col-12 p-0">
+                            <style>
+                                .col-4 select {
+                                    border-radius: 50px;
+                                    text-align: center;
+                                }
+                                /* 검색창 스타일 */
+                                .search-container {
+                                    width: 300px;
+                                }
+
+                                .search-container select {
+                                    position: absolute;
+                                    left: 0%;
+                                    width: 30%;
+                                    height: 50px;
+                                    color: #828282;
+                                    font-size: 1rem;
+                                    border-radius: 50px 0 0 50px;
+                                    outline: none;
+                                }
+                                .search-container input[type="text"] {
+                                    position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
+                                    left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
+                                    width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
+                                    height: 50px;
+                                    padding: 10px 40px 10px 15px;
+                                    font-size: 1rem;
+                                    outline: none;
+                                    border-radius: 0 50px 50px 0;
+                                    transition: border-color 0.3s, background-color 0.3s;
+                                    color: #828282; /* 입력 텍스트 색상 변경 */
+                                }
+
+                                .search-container input[type="text"]::placeholder {
+                                    color: #BBBBBB; /* placeholder 색상 변경 */
+                                }
+
+
+                                .search-container button {
+                                    position: absolute;
+                                    right: 1rem;
+                                    top: 25px;
+                                    background: none;
+                                    transform: translateY(-50%);
+                                    border: none;
+                                    cursor: pointer;
+                                }
+
+                                .search-container button i {
+                                    color: #666;
+                                }
+
+                                .search-container button:hover i {
+                                    color: #03C75A;
+                                }
+                            </style>
+                            <form id="filter-and-sort-form" th:action="@{/user/my/rct/job/apply(boardNo=${boardNo})}" method="get">
+                                <div class="row m-0">
+                                    <div class="col-7 p-0">
                                         <div class="row justify-content-start m-0">
-                                            <div class="col-4">
-                                                <!-- 검색 조건 -->
-                                                <label>
+                                            <div class="col-12 p-0">
+                                                <div class="search-container">
                                                     <select class="form-select px-3" name="searchBy">
                                                         <option value="title" th:selected="${searchBy == 'title'}">
                                                             지원서제목
@@ -320,17 +374,13 @@
                                                         </option>
                                                         <!--                        <option value="realname" th:selected="${searchBy == 'realname'}">지원자성명</option>-->
                                                     </select>
-                                                </label>
-                                            </div>
-                                            <div class="col-6">
-                                                <input class="form-control px-3" type="text" name="searchTerm"
-                                                       placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
-                                            </div>
-                                            <div class="col-2">
-                                                <input type="hidden" name="boardNo" th:value="${boardNo}"/>
-                                                <!-- 검색 버튼 -->
-                                                <button id="searchbutton" type="submit" class="btn btn-primary">검색
-                                                </button>
+                                                    <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
+                                                    <!-- 검색 버튼 -->
+                                                    <input type="hidden" name="boardNo" th:value="${boardNo}"/>
+                                                    <button type="submit">
+                                                        <i class="fas fa-search"></i>
+                                                    </button>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>

--- a/src/main/resources/templates/user/mypage_rct_job_applicationlist.html
+++ b/src/main/resources/templates/user/mypage_rct_job_applicationlist.html
@@ -134,7 +134,7 @@
     <div class="row">
         <aside class="col-md-3 px-4">
             <div class="row">
-                <div class="col-3"></div>
+                <div class="col-1"></div>
                 <div class="col-6">
                     <div class="panel">
                         <ul class="list-group">

--- a/src/main/resources/templates/user/mypage_rct_job_applicationlist.html
+++ b/src/main/resources/templates/user/mypage_rct_job_applicationlist.html
@@ -352,7 +352,7 @@
                                 }
 
                                 .search-container button i {
-                                    color: #666;
+                                    color: #A6AAB5;
                                 }
 
                                 .search-container button:hover i {

--- a/src/main/resources/templates/user/mypage_rct_job_applicationlist.html
+++ b/src/main/resources/templates/user/mypage_rct_job_applicationlist.html
@@ -86,568 +86,595 @@
 
 <div th:replace="~{common/menubar}"></div>
 <style>
-    .jumbotron {
-    position : relative;
-    background-color : #EEEEEE;
+    html, body {
+        height: 100%;
+        margin: 0;
     }
-    .jumbotron .row {
-    position : absolute;
-    width : 100%;
-    bottom: 0%;
+    body {
+        display: flex;
+        flex-direction: column;
     }
-    .nav-link {
-            color: #828282;
+    .content-wrapper {
+        flex: 1 0 auto;
     }
-    ul {
-  list-style: none;
-  padding-left : 0px;
-  }
+    footer {
+        flex-shrink: 0;
+    }
+
 </style>
-<div class="jumbotron">
-    <div class="container">
-        <div class="row">
-            <div class="col-9">
-                <div class="row">
-                    <div class="col-md-3 px-4">
-                        <h3>나의 채용</h3>
-                    </div>
-                    <div class="col-md-9">
-                        <nav class="navbar navbar-expand-md">
-                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color:#000;">내가 올린
-                                    공고</a></li>
-                                <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a>
-                                </li>
-                                <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
-                                <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
-                                <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보
-                                    수정</a></li>
-                            </ul>
-                        </nav>
+<div class="content-wrapper">
+    <style>
+        .jumbotron {
+        position : relative;
+        background-color : #EEEEEE;
+        }
+        .jumbotron .row {
+        position : absolute;
+        width : 100%;
+        bottom: 0%;
+        }
+        .nav-link {
+                color: #828282;
+        }
+        ul {
+      list-style: none;
+      padding-left : 0px;
+      }
+    </style>
+    <div class="jumbotron">
+        <div class="container">
+            <div class="row">
+                <div class="col-9">
+                    <div class="row">
+                        <div class="col-md-3 px-4">
+                            <h3>나의 채용</h3>
+                        </div>
+                        <div class="col-md-9">
+                            <nav class="navbar navbar-expand-md">
+                                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                    <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color:#000;">내가 올린
+                                        공고</a></li>
+                                    <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a>
+                                    </li>
+                                    <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
+                                    <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
+                                    <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보
+                                        수정</a></li>
+                                </ul>
+                            </nav>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
-<div class="container" style="padding:0;">
-    <div class="row">
-        <aside class="col-md-3 px-4">
-            <div class="row">
-                <div class="col-1"></div>
-                <div class="col-8">
-                    <div class="panel">
-                        <ul class="list-group">
-                            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
-                            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-                            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color: #03C75A;">나의 채용</a>
-                            </li>
-                            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-        </aside>
-        <!--    <script>-->
-        <!--        function toggleCheckboxValue() {-->
-        <!--            const checkbox = document.getElementById('isToggledCheckbox');-->
-        <!--            if(!checkbox.checked) checkbox.value = 'N';-->
-        <!--            else checkbox.value = 'Y';-->
-        <!--            document.getElementById('filter-form').submit();-->
-        <!--        }-->
-        <!--    </script>-->
-        <script> // toggle + sorting
-        function updateCheckboxValueAndSubmit() {
-            const checkbox = document.getElementById('isToggledCheckbox');
-            const form = document.getElementById('filter-and-sort-form');
-            // 체크박스가 체크된 상태를 확인
-            checkbox.value = checkbox.checked ? 'Y' : 'N';
-            // 폼 제출
-            form.submit();
-        }
-
-        function submitForm() {
-            document.getElementById('filter-and-sort-form').submit();
-        }
-        </script>
-        <style>
-            .form-select {
-            background-color : #FCFCFC;
-            border : none;
-            width : 100%;
-            height : 50px;
-            }
-            select {
-            color : #828282;
-            }
-            .form-control {
-            background-color : #FCFCFC;
-            border : none;
-            width : 100%;
-            height : 50px;
-            }
-
-
-            .form-control::placeholder {
-            color : #BBBBBB;
-            }
-
-            .date-container {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        background-color: #8E4B6E;
-        color: white;
-        border-radius: 10px;
-        text-align:center;
-        font-family: "Work Sans", sans-serif;
-    }
-
-    .month {
-        font-size: 1.1rem; /* M의 크기를 설정 */
-        font-weight: 550;
-        line-height: 1;
-    }
-
-    .year {
-        font-size: 0.65rem; /* yyyy의 크기를 설정 */
-        font-weight: 400;
-    }
-    :root {
-        --background-color-light: #FFFFFF;
-        --text-color-light: #000000;
-        --toggle-background-light: #CCCCCC;
-        --toggle-ball-light: #FFFFFF;
-
-        --background-color-dark: #333333;
-        --text-color-dark: #FFFFFF;
-        --toggle-background-dark: #03C75A;
-        --toggle-ball-dark: #FFFFFF;
-
-        --font-size-base: 32px; /* 기본 텍스트 크기 */
-        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
-    }
-
-
-
-    .toggle-switch {
-        position: relative;
-        display: inline-block;
-        width: 62px; /* 너비 조정 */
-        height: 38px; /* 높이 조정 */
-    }
-
-    .toggle-switch .checkbox {
-        opacity: 0;
-        width: 0;
-        height: 0;
-    }
-    #isToggledCheckbox {
-         opacity: 0;
-            width: 0;
-            height: 0;
-    }
-
-    .toggle-switch .label {
-        position: absolute;
-        cursor: pointer;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background-color: var(--toggle-background-light);
-        transition: background-color 0.4s;
-        border-radius: 38px; /* 둥근 모서리 반경 조정 */
-    }
-
-    .toggle-switch .label:before {
-        position: absolute;
-        content: "";
-        height: 30px; /* 내부 원 높이 조정 */
-        width: 30px; /* 내부 원 너비 조정 */
-        left: 2px;
-        bottom: 0px;
-        background-color: var(--toggle-ball-light);
-        transition: transform 0.4s;
-        border-radius: 50%;
-    }
-
-    .toggle-switch input:checked + .label {
-        background-color: var(--toggle-background-dark);
-    }
-
-    .toggle-switch input:checked + .label:before {
-        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
-    }
-
-             .absdiv {
-                position: relative;
-                top: 60px; /* Move down by 20px from its current position */
-                z-index : 1000;
-            }
-
-            #searchbutton {
-                background-color: #828282;
-            }
-        </style>
-        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
-              rel="stylesheet">
-        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
-              rel="stylesheet">
-
-        <div class="col-md-9">
-            <div class="row" style="color: #828282;">
-                <div class="col-11">
-                    <div class="row">
-                        <div class="col-12 p-0">
-                            <style>
-                                .col-4 select {
-                                    border-radius: 50px;
-                                    text-align: center;
-                                }
-                                /* 검색창 스타일 */
-                                .search-container {
-                                    width: 300px;
-                                }
-
-                                .search-container select {
-                                    position: absolute;
-                                    left: 0%;
-                                    width: 30%;
-                                    height: 50px;
-                                    color: #828282;
-                                    font-size: 1rem;
-                                    border-radius: 50px 0 0 50px;
-                                    outline: none;
-                                }
-                                .search-container input[type="text"] {
-                                    position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
-                                    left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
-                                    width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
-                                    height: 50px;
-                                    padding: 10px 40px 10px 15px;
-                                    font-size: 1rem;
-                                    outline: none;
-                                    border-radius: 0 50px 50px 0;
-                                    transition: border-color 0.3s, background-color 0.3s;
-                                    color: #828282; /* 입력 텍스트 색상 변경 */
-                                }
-
-                                .search-container input[type="text"]::placeholder {
-                                    color: #BBBBBB; /* placeholder 색상 변경 */
-                                }
-
-
-                                .search-container button {
-                                    position: absolute;
-                                    right: 1rem;
-                                    top: 25px;
-                                    background: none;
-                                    transform: translateY(-50%);
-                                    border: none;
-                                    cursor: pointer;
-                                }
-
-                                .search-container button i {
-                                    color: #A6AAB5;
-                                }
-
-                                .search-container button:hover i {
-                                    color: #03C75A;
-                                }
-                            </style>
-                            <form id="filter-and-sort-form" th:action="@{/user/my/rct/job/apply(boardNo=${boardNo})}" method="get">
-                                <div class="row m-0">
-                                    <div class="col-7 p-0">
-                                        <div class="row justify-content-start m-0">
-                                            <div class="col-12 p-0">
-                                                <div class="search-container">
-                                                    <select class="form-select px-3" name="searchBy">
-                                                        <option value="title" th:selected="${searchBy == 'title'}">
-                                                            지원서제목
-                                                        </option>
-                                                        <option value="content" th:selected="${searchBy == 'content'}">
-                                                            지원서내용
-                                                        </option>
-                                                        <!--                        <option value="realname" th:selected="${searchBy == 'realname'}">지원자성명</option>-->
-                                                    </select>
-                                                    <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
-                                                    <!-- 검색 버튼 -->
-                                                    <input type="hidden" name="boardNo" th:value="${boardNo}"/>
-                                                    <button type="submit">
-                                                        <i class="fas fa-search"></i>
-                                                    </button>
-                                                </div>
-                                            </div>
-                                        </div>
-                                    </div>
-                                    <div class="col-1" style=""></div>
-                                    <div class="col-4">
-                                        <div class="row justify-content-end">
-                                            <!-- 정렬 또는 토글2 -->
-                                            <label>
-                                                <select class="form-select px-3" name="orderBy" onchange="submitForm()">
-                                                    <option value="recent" th:selected="${orderBy == 'recent'}">최근작성순
-                                                    </option>
-                                                    <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순
-                                                    </option>
-                                                </select>
-                                            </label>
-                                        </div>
-                                    </div>
-                                </div> <!--검색, 소팅 (토글X)-->
-                                <div class="row justify-content-around">
-                                    <div class="col-3" style="padding: 0 1.2rem;">
-                                        <div class="absdiv">
-                                            <a href="javascript:window.history.back();" class="btn btn-primary"
-                                               style="background-color: #03C75A;">뒤로가기</a>
-
-                                        </div>
-                                    </div>
-                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                    <div class="col-3" style="padding: 0 1.2rem;">
-                                        <div class="row justify-content-end absdiv">
-                                            <div class="col-3">
-                                                <div class="toggle-switch">
-                                                    <!-- 정렬 또는 토글1 -->
-                                                    <input type="checkbox" name="isToggled" id="isToggledCheckbox"
-                                                           value="Y" th:checked="${isToggled == 'Y'}"
-                                                           onchange="updateCheckboxValueAndSubmit()">
-                                                    <label for="isToggledCheckbox" class="label">
-                                                        <div class="ball"></div>
-                                                    </label>
-                                                </div>
-                                            </div>
-                                            <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">
-                                                미열람 지원서
-                                            </div>
-                                        </div>
-                                    </div>
-                                </div> <!--토글-->
-                            </form>
+    <div class="container" style="padding:0;">
+        <div class="row">
+            <aside class="col-md-3 px-4">
+                <div class="row">
+                    <div class="col-1"></div>
+                    <div class="col-8">
+                        <div class="panel">
+                            <ul class="list-group">
+                                <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
+                                <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color: #03C75A;">나의
+                                    채용</a>
+                                </li>
+                                <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                                <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                                <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+                            </ul>
                         </div>
                     </div>
+                </div>
+            </aside>
+            <!--    <script>-->
+            <!--        function toggleCheckboxValue() {-->
+            <!--            const checkbox = document.getElementById('isToggledCheckbox');-->
+            <!--            if(!checkbox.checked) checkbox.value = 'N';-->
+            <!--            else checkbox.value = 'Y';-->
+            <!--            document.getElementById('filter-form').submit();-->
+            <!--        }-->
+            <!--    </script>-->
+            <script> // toggle + sorting
+            function updateCheckboxValueAndSubmit() {
+                const checkbox = document.getElementById('isToggledCheckbox');
+                const form = document.getElementById('filter-and-sort-form');
+                // 체크박스가 체크된 상태를 확인
+                checkbox.value = checkbox.checked ? 'Y' : 'N';
+                // 폼 제출
+                form.submit();
+            }
 
-                    <div class="row justify-content-around">
-                        <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
-                            <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
-                                <div class="col-11"
-                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;">
-                                    <div class="row justify-content-center mx-3">
-                                        <div class="col-1 p-0 d-flex align-items-center justify-content-center"
-                                             style="aspect-ratio: 1; border-radius: 5px;">
-                                            <div class="date-container px-2 py-1">
-                                                <div class="month"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(board.createdDate)}"></div>
-                                                <div class="year"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(board.createdDate)}"></div>
-                                            </div>
-                                        </div>
-                                        <div class="col-5" style="color: white; " th:text="${board.boardNo}">닉네임</div>
-                                        <div class="col-6"
-                                             style="padding:0; font-size: 1rem; text-align: right; color: #BDBDBD;"
-                                             th:text="${board.formattedDeadLine}">1주일 전
-                                        </div>
-                                    </div>
-                                    <div class="row justify-content-center mx-3">
-                                        <div class="col-12" style="color: white;">사진</div>
-                                    </div>
-                                    <div class="row justify-content-center mx-3">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
-                                             th:text="${board.title}">이름
-                                        </div>
-                                        <div class="col-3 clickable-row" style="padding: 0; text-align: right;"
-                                             th:attr="data-href=@{/recruit/job/view(no=${boardNo})}">→
-                                        </div>
-                                    </div>
-                                    <div class="row justify-content-center mx-3">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
-                                             th:text="${board.content}">내용
-                                        </div>
-                                        <div class="col-3 clickable-row" style="padding: 0; text-align: right;"
-                                             th:attr="data-href=@{/recruit/job/view(no=${boardNo})}">공고 확인
-                                        </div>
-                                    </div>
-                                    <div class="row justify-content-center mx-3 my-5">
-                                        <div class="col-12 m-0 p-0" style="color: #333333;">
-                                            <table>
-                                                <thead>
-                                                <tr>
-                                                    <th>지원글 번호</th>
-                                                    <th>지원자</th>
-                                                    <th>제목</th>
-                                                    <th>작성 일자</th>
-                                                    <th>조회 여부</th>
-                                                </tr>
-                                                </thead>
-                                                <tbody>
-                                                <tr th:each="myRctJobApplication : ${myRctJobApplications}"
-                                                    class="clickable-row"
-                                                    th:attr="data-href=@{/recruit/job/applyView(no=${myRctJobApplication.applyNo})}">
-                                                    <td th:text="${myRctJobApplication.applyNo}">지원글 번호</td>
-                                                    <td th:text="${myRctJobApplication.writer}">지원자</td>
-                                                    <td th:text="${myRctJobApplication.applyTitle}">제목</td>
-                                                    <td th:text="${myRctJobApplication.applyCreatedDate}">작성 일자</td>
-                                                    <td th:text="${myRctJobApplication.applyCheckStatus}">조회 여부</td>
-                                                </tr>
-                                                </tbody>
-                                            </table>
-                                        </div>
-                                    </div>
-                                    <div class="row justify-content-center mx-3">
-                                        <div class="col-12" style="color: white;">
-                                            <!-- 페이징 -->
-                                            <th:block th:if="${pages != null}">
-                                                <div class="d-flex justify-content-center">
-                                                    <div class="btn-group">
-                                                        <button type="button" class="btn btn-sm previous"
-                                                                th:onclick="|location.href='@{/user/my/rct/job/apply(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
-                                                                th:disabled="${currentPage == 1}">
-                                                            <svg xmlns="http://www.w3.org/2000/svg" width="16"
-                                                                 height="16" fill="currentColor"
-                                                                 class="bi bi-chevron-left" viewBox="0 0 16 16">
-                                                                <path fill-rule="evenodd"
-                                                                      d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                                                            </svg>
-                                                        </button>
-                                                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">
-                                                            <button type="button" class="btn btn-sm me-2 pages"
-                                                                    th:text="${p}"
-                                                                    th:onclick="|location.href='@{/user/my/rct/job/apply(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
-                                                        </th:block>
-                                                        <button type="button" class="btn btn-sm  next"
-                                                                th:onclick="|location.href='@{/user/my/rct/job/apply(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
-                                                                th:disabled="${currentPage == pages}">
-                                                            <svg xmlns="http://www.w3.org/2000/svg" width="16"
-                                                                 height="16" fill="currentColor"
-                                                                 class="bi bi-chevron-right" viewBox="0 0 16 16">
-                                                                <path fill-rule="evenodd"
-                                                                      d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
-                                                            </svg>
+            function submitForm() {
+                document.getElementById('filter-and-sort-form').submit();
+            }
+            </script>
+            <style>
+                .form-select {
+                background-color : #FCFCFC;
+                border : none;
+                width : 100%;
+                height : 50px;
+                }
+                select {
+                color : #828282;
+                }
+                .form-control {
+                background-color : #FCFCFC;
+                border : none;
+                width : 100%;
+                height : 50px;
+                }
+
+
+                .form-control::placeholder {
+                color : #BBBBBB;
+                }
+
+                .date-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            background-color: #8E4B6E;
+            color: white;
+            border-radius: 10px;
+            text-align:center;
+            font-family: "Work Sans", sans-serif;
+        }
+
+        .month {
+            font-size: 1.1rem; /* M의 크기를 설정 */
+            font-weight: 550;
+            line-height: 1;
+        }
+
+        .year {
+            font-size: 0.65rem; /* yyyy의 크기를 설정 */
+            font-weight: 400;
+        }
+        :root {
+            --background-color-light: #FFFFFF;
+            --text-color-light: #000000;
+            --toggle-background-light: #CCCCCC;
+            --toggle-ball-light: #FFFFFF;
+
+            --background-color-dark: #333333;
+            --text-color-dark: #FFFFFF;
+            --toggle-background-dark: #03C75A;
+            --toggle-ball-dark: #FFFFFF;
+
+            --font-size-base: 32px; /* 기본 텍스트 크기 */
+            --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+        }
+
+
+
+        .toggle-switch {
+            position: relative;
+            display: inline-block;
+            width: 62px; /* 너비 조정 */
+            height: 38px; /* 높이 조정 */
+        }
+
+        .toggle-switch .checkbox {
+            opacity: 0;
+            width: 0;
+            height: 0;
+        }
+        #isToggledCheckbox {
+             opacity: 0;
+                width: 0;
+                height: 0;
+        }
+
+        .toggle-switch .label {
+            position: absolute;
+            cursor: pointer;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: var(--toggle-background-light);
+            transition: background-color 0.4s;
+            border-radius: 38px; /* 둥근 모서리 반경 조정 */
+        }
+
+        .toggle-switch .label:before {
+            position: absolute;
+            content: "";
+            height: 30px; /* 내부 원 높이 조정 */
+            width: 30px; /* 내부 원 너비 조정 */
+            left: 2px;
+            bottom: 0px;
+            background-color: var(--toggle-ball-light);
+            transition: transform 0.4s;
+            border-radius: 50%;
+        }
+
+        .toggle-switch input:checked + .label {
+            background-color: var(--toggle-background-dark);
+        }
+
+        .toggle-switch input:checked + .label:before {
+            transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+        }
+
+                 .absdiv {
+                    position: relative;
+                    top: 60px; /* Move down by 20px from its current position */
+                    z-index : 1000;
+                }
+
+                #searchbutton {
+                    background-color: #828282;
+                }
+            </style>
+            <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+                  rel="stylesheet">
+            <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+                  rel="stylesheet">
+
+            <div class="col-md-9">
+                <div class="row" style="color: #828282;">
+                    <div class="col-11">
+                        <div class="row">
+                            <div class="col-12 p-0">
+                                <style>
+                                    .col-4 select {
+                                        border-radius: 50px;
+                                        text-align: center;
+                                    }
+                                    /* 검색창 스타일 */
+                                    .search-container {
+                                        width: 300px;
+                                    }
+
+                                    .search-container select {
+                                        position: absolute;
+                                        left: 0%;
+                                        width: 30%;
+                                        height: 50px;
+                                        color: #828282;
+                                        font-size: 1rem;
+                                        border-radius: 50px 0 0 50px;
+                                        outline: none;
+                                    }
+                                    .search-container input[type="text"] {
+                                        position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
+                                        left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
+                                        width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
+                                        height: 50px;
+                                        padding: 10px 40px 10px 15px;
+                                        font-size: 1rem;
+                                        outline: none;
+                                        border-radius: 0 50px 50px 0;
+                                        transition: border-color 0.3s, background-color 0.3s;
+                                        color: #828282; /* 입력 텍스트 색상 변경 */
+                                    }
+
+                                    .search-container input[type="text"]::placeholder {
+                                        color: #BBBBBB; /* placeholder 색상 변경 */
+                                    }
+
+
+                                    .search-container button {
+                                        position: absolute;
+                                        right: 1rem;
+                                        top: 25px;
+                                        background: none;
+                                        transform: translateY(-50%);
+                                        border: none;
+                                        cursor: pointer;
+                                    }
+
+                                    .search-container button i {
+                                        color: #A6AAB5;
+                                    }
+
+                                    .search-container button:hover i {
+                                        color: #03C75A;
+                                    }
+                                </style>
+                                <form id="filter-and-sort-form"
+                                      th:action="@{/user/my/rct/job/apply(boardNo=${boardNo})}" method="get">
+                                    <div class="row m-0">
+                                        <div class="col-7 p-0">
+                                            <div class="row justify-content-start m-0">
+                                                <div class="col-12 p-0">
+                                                    <div class="search-container">
+                                                        <select class="form-select px-3" name="searchBy">
+                                                            <option value="title" th:selected="${searchBy == 'title'}">
+                                                                지원서제목
+                                                            </option>
+                                                            <option value="content"
+                                                                    th:selected="${searchBy == 'content'}">
+                                                                지원서내용
+                                                            </option>
+                                                            <!--                        <option value="realname" th:selected="${searchBy == 'realname'}">지원자성명</option>-->
+                                                        </select>
+                                                        <input class="form-control px-3" type="text" name="searchTerm"
+                                                               placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
+                                                        <!-- 검색 버튼 -->
+                                                        <input type="hidden" name="boardNo" th:value="${boardNo}"/>
+                                                        <button type="submit">
+                                                            <i class="fas fa-search"></i>
                                                         </button>
                                                     </div>
                                                 </div>
-                                            </th:block>
+                                            </div>
                                         </div>
-                                    </div>
+                                        <div class="col-1" style=""></div>
+                                        <div class="col-4">
+                                            <div class="row justify-content-end">
+                                                <!-- 정렬 또는 토글2 -->
+                                                <label>
+                                                    <select class="form-select px-3" name="orderBy"
+                                                            onchange="submitForm()">
+                                                        <option value="recent" th:selected="${orderBy == 'recent'}">
+                                                            최근작성순
+                                                        </option>
+                                                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순
+                                                        </option>
+                                                    </select>
+                                                </label>
+                                            </div>
+                                        </div>
+                                    </div> <!--검색, 소팅 (토글X)-->
+                                    <div class="row justify-content-around">
+                                        <div class="col-3" style="padding: 0 1.2rem;">
+                                            <div class="absdiv">
+                                                <a href="javascript:window.history.back();" class="btn btn-primary"
+                                                   style="background-color: #03C75A;">뒤로가기</a>
 
+                                            </div>
+                                        </div>
+                                        <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                        <div class="col-3" style="padding: 0 1.2rem;">
+                                            <div class="row justify-content-end absdiv">
+                                                <div class="col-3">
+                                                    <div class="toggle-switch">
+                                                        <!-- 정렬 또는 토글1 -->
+                                                        <input type="checkbox" name="isToggled" id="isToggledCheckbox"
+                                                               value="Y" th:checked="${isToggled == 'Y'}"
+                                                               onchange="updateCheckboxValueAndSubmit()">
+                                                        <label for="isToggledCheckbox" class="label">
+                                                            <div class="ball"></div>
+                                                        </label>
+                                                    </div>
+                                                </div>
+                                                <div class="col-8"
+                                                     style="text-align: right; padding: 0px; margin : 0px;">
+                                                    미열람 지원서
+                                                </div>
+                                            </div>
+                                        </div>
+                                    </div> <!--토글-->
+                                </form>
+                            </div>
+                        </div>
+
+                        <div class="row justify-content-around">
+                            <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
+                                <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
+                                    <div class="col-11"
+                                         style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;">
+                                        <div class="row justify-content-center mx-3">
+                                            <div class="col-1 p-0 d-flex align-items-center justify-content-center"
+                                                 style="aspect-ratio: 1; border-radius: 5px;">
+                                                <div class="date-container px-2 py-1">
+                                                    <div class="month"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(board.createdDate)}"></div>
+                                                    <div class="year"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(board.createdDate)}"></div>
+                                                </div>
+                                            </div>
+                                            <div class="col-5" style="color: white; " th:text="${board.boardNo}">닉네임
+                                            </div>
+                                            <div class="col-6"
+                                                 style="padding:0; font-size: 1rem; text-align: right; color: #BDBDBD;"
+                                                 th:text="${board.formattedDeadLine}">1주일 전
+                                            </div>
+                                        </div>
+                                        <div class="row justify-content-center mx-3">
+                                            <div class="col-12" style="color: white;">사진</div>
+                                        </div>
+                                        <div class="row justify-content-center mx-3">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                                 th:text="${board.title}">이름
+                                            </div>
+                                            <div class="col-3 clickable-row" style="padding: 0; text-align: right;"
+                                                 th:attr="data-href=@{/recruit/job/view(no=${boardNo})}">→
+                                            </div>
+                                        </div>
+                                        <div class="row justify-content-center mx-3">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                                 th:text="${board.content}">내용
+                                            </div>
+                                            <div class="col-3 clickable-row" style="padding: 0; text-align: right;"
+                                                 th:attr="data-href=@{/recruit/job/view(no=${boardNo})}">공고 확인
+                                            </div>
+                                        </div>
+                                        <div class="row justify-content-center mx-3 my-5">
+                                            <div class="col-12 m-0 p-0" style="color: #333333;">
+                                                <table>
+                                                    <thead>
+                                                    <tr>
+                                                        <th>지원글 번호</th>
+                                                        <th>지원자</th>
+                                                        <th>제목</th>
+                                                        <th>작성 일자</th>
+                                                        <th>조회 여부</th>
+                                                    </tr>
+                                                    </thead>
+                                                    <tbody>
+                                                    <tr th:each="myRctJobApplication : ${myRctJobApplications}"
+                                                        class="clickable-row"
+                                                        th:attr="data-href=@{/recruit/job/applyView(no=${myRctJobApplication.applyNo})}">
+                                                        <td th:text="${myRctJobApplication.applyNo}">지원글 번호</td>
+                                                        <td th:text="${myRctJobApplication.writer}">지원자</td>
+                                                        <td th:text="${myRctJobApplication.applyTitle}">제목</td>
+                                                        <td th:text="${myRctJobApplication.applyCreatedDate}">작성 일자</td>
+                                                        <td th:text="${myRctJobApplication.applyCheckStatus}">조회 여부</td>
+                                                    </tr>
+                                                    </tbody>
+                                                </table>
+                                            </div>
+                                        </div>
+                                        <div class="row justify-content-center mx-3">
+                                            <div class="col-12" style="color: white;">
+                                                <!-- 페이징 -->
+                                                <th:block th:if="${pages != null}">
+                                                    <div class="d-flex justify-content-center">
+                                                        <div class="btn-group">
+                                                            <button type="button" class="btn btn-sm previous"
+                                                                    th:onclick="|location.href='@{/user/my/rct/job/apply(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
+                                                                    th:disabled="${currentPage == 1}">
+                                                                <svg xmlns="http://www.w3.org/2000/svg" width="16"
+                                                                     height="16" fill="currentColor"
+                                                                     class="bi bi-chevron-left" viewBox="0 0 16 16">
+                                                                    <path fill-rule="evenodd"
+                                                                          d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                                                                </svg>
+                                                            </button>
+                                                            <th:block th:each="p : ${#numbers.sequence(1, pages)}">
+                                                                <button type="button" class="btn btn-sm me-2 pages"
+                                                                        th:text="${p}"
+                                                                        th:onclick="|location.href='@{/user/my/rct/job/apply(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
+                                                            </th:block>
+                                                            <button type="button" class="btn btn-sm  next"
+                                                                    th:onclick="|location.href='@{/user/my/rct/job/apply(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
+                                                                    th:disabled="${currentPage == pages}">
+                                                                <svg xmlns="http://www.w3.org/2000/svg" width="16"
+                                                                     height="16" fill="currentColor"
+                                                                     class="bi bi-chevron-right" viewBox="0 0 16 16">
+                                                                    <path fill-rule="evenodd"
+                                                                          d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                                                                </svg>
+                                                            </button>
+                                                        </div>
+                                                    </div>
+                                                </th:block>
+                                            </div>
+                                        </div>
+
+                                    </div>
                                 </div>
                             </div>
                         </div>
+
+                        <!--수정전-->
+
+                        <!--    <div class="col-md-9">-->
+                        <!--        <div class="review-list">-->
+                        <!--            <h3><a th:href="@{/user/my/rct/job}">뒤로가기(페이지번호미반영)</a></h3>-->
+                        <!--            <h2>내가 올린 공고-지원서목록</h2>-->
+                        <!--            <h3><a th:href="@{/recruit/job/view(no=${boardNo})}">공고 확인</a></h3>-->
+                        <!--            <form id="filter-and-sort-form" th:action="@{/user/my/rct/job/apply(boardNo=${boardNo})}" method="get">-->
+                        <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
+                        <!--                <label>-->
+                        <!--                    <select name="searchBy">-->
+                        <!--                        <option value="title" th:selected="${searchBy == 'title'}">지원서제목</option>-->
+                        <!--                        <option value="content" th:selected="${searchBy == 'content'}">지원서내용</option>-->
+                        <!--&lt;!&ndash;                        <option value="realname" th:selected="${searchBy == 'realname'}">지원자성명</option>&ndash;&gt;-->
+                        <!--                    </select>-->
+                        <!--                </label>-->
+                        <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
+
+                        <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
+                        <!--                <button type="submit">검색</button>-->
+
+                        <!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
+                        <!--                <label>-->
+                        <!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">미열람-->
+                        <!--                </label>-->
+                        <!--                &lt;!&ndash; Hidden field for boardNo &ndash;&gt;-->
+                        <!--                <input type="hidden" name="boardNo" th:value="${boardNo}" />-->
+
+                        <!--                <label>-->
+                        <!--                    <select name="orderBy" onchange="submitForm()">-->
+                        <!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최근작성순</option>-->
+                        <!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
+                        <!--                    </select>-->
+                        <!--                </label>-->
+                        <!--            </form>-->
+                        <!--            <form id="filter-form" th:action="@{/user/my/rct/job/apply(boardNo=${boardNo})}" method="get">-->
+                        <!--                <label>-->
+                        <!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="toggleCheckboxValue()">미열람-->
+                        <!--                </label>-->
+                        <!--                &lt;!&ndash; Hidden field for boardNo &ndash;&gt;-->
+                        <!--                <input type="hidden" name="boardNo" th:value="${boardNo}" />-->
+                        <!--            </form>-->
+                        <!--            <table>-->
+                        <!--                <thead>-->
+                        <!--                <tr>-->
+                        <!--                    <th>지원글 번호</th>-->
+                        <!--                    <th>게시글 번호</th>-->
+                        <!--                    <th>지원자</th>-->
+                        <!--                    <th>제목</th>-->
+                        <!--                    <th>내용</th>-->
+                        <!--                    <th>이미지</th>-->
+                        <!--                    <th>작성 일자</th>-->
+                        <!--                    <th>조회 여부</th>-->
+
+                        <!--                    <th>작성자</th>-->
+                        <!--                    <th>제목</th>-->
+                        <!--                    <th>내용</th>-->
+                        <!--                    <th>근무지</th>-->
+                        <!--                    <th>이미지</th>-->
+                        <!--                    <th>작성 일자</th>-->
+                        <!--                    <th>수정 일자</th>-->
+                        <!--                    <th>마감 일자</th>-->
+                        <!--                </tr>-->
+                        <!--                </thead>-->
+                        <!--                <tbody>-->
+                        <!--                <tr th:each="myRctJobApplication : ${myRctJobApplications}" class="clickable-row" th:attr="data-href=@{/recruit/job/applyView(no=${myRctJobApplication.applyNo})}">-->
+                        <!--                    <td th:text="${myRctJobApplication.applyNo}">지원글 번호</td>-->
+                        <!--                    <td th:text="${myRctJobApplication.boardNo}">게시글 번호</td>-->
+                        <!--                    <td th:text="${myRctJobApplication.writer}">지원자</td>-->
+                        <!--                    <td th:text="${myRctJobApplication.applyTitle}">제목</td>-->
+                        <!--                    <td th:text="${myRctJobApplication.applyContent}">내용</td>-->
+                        <!--                    <td th:text="${myRctJobApplication.applyImg}">이미지</td>-->
+                        <!--                    <td th:text="${myRctJobApplication.applyCreatedDate}">작성 일자</td>-->
+                        <!--                    <td th:text="${myRctJobApplication.applyCheckStatus}">조회 여부</td>-->
+
+                        <!--                    <td th:text="${myRctJobApplication.jobWriter}">작성자</td>-->
+                        <!--                    <td th:text="${myRctJobApplication.jobTitle}">제목</td>-->
+                        <!--                    <td th:text="${myRctJobApplication.jobContent}">내용</td>-->
+                        <!--                    <td th:text="${myRctJobApplication.jobLocation}">근무지</td>-->
+                        <!--                    <td th:text="${myRctJobApplication.jobImg}">이미지</td>-->
+                        <!--                    <td th:text="${myRctJobApplication.jobCreatedDate}">작성 일자</td>-->
+                        <!--                    <td th:text="${myRctJobApplication.jobModifiedDate}">수정 일자</td>-->
+                        <!--                    <td th:text="${myRctJobApplication.jobDeadLine}">마감 일자</td>-->
+                        <!--                </tr>-->
+                        <!--                </tbody>-->
+                        <!--            </table>-->
+                        <!-- 페이징 -->
+                        <!--            <th:block th:if="${pages != null}">-->
+                        <!--                <div class="d-flex justify-content-center">-->
+                        <!--                    <div class="btn-group">-->
+                        <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/rct/job/apply(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
+                        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
+                        <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
+                        <!--                            </svg>-->
+                        <!--                        </button>-->
+                        <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
+                        <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
+                        <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/rct/job/apply(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
+                        <!--                        </th:block>-->
+                        <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/rct/job/apply(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
+                        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
+                        <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
+                        <!--                            </svg>-->
+                        <!--                        </button>-->
+                        <!--                    </div>-->
+                        <!--                </div>-->
+                        <!--            </th:block>-->
                     </div>
-
-                    <!--수정전-->
-
-                    <!--    <div class="col-md-9">-->
-                    <!--        <div class="review-list">-->
-                    <!--            <h3><a th:href="@{/user/my/rct/job}">뒤로가기(페이지번호미반영)</a></h3>-->
-                    <!--            <h2>내가 올린 공고-지원서목록</h2>-->
-                    <!--            <h3><a th:href="@{/recruit/job/view(no=${boardNo})}">공고 확인</a></h3>-->
-                    <!--            <form id="filter-and-sort-form" th:action="@{/user/my/rct/job/apply(boardNo=${boardNo})}" method="get">-->
-                    <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
-                    <!--                <label>-->
-                    <!--                    <select name="searchBy">-->
-                    <!--                        <option value="title" th:selected="${searchBy == 'title'}">지원서제목</option>-->
-                    <!--                        <option value="content" th:selected="${searchBy == 'content'}">지원서내용</option>-->
-                    <!--&lt;!&ndash;                        <option value="realname" th:selected="${searchBy == 'realname'}">지원자성명</option>&ndash;&gt;-->
-                    <!--                    </select>-->
-                    <!--                </label>-->
-                    <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
-
-                    <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
-                    <!--                <button type="submit">검색</button>-->
-
-                    <!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
-                    <!--                <label>-->
-                    <!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">미열람-->
-                    <!--                </label>-->
-                    <!--                &lt;!&ndash; Hidden field for boardNo &ndash;&gt;-->
-                    <!--                <input type="hidden" name="boardNo" th:value="${boardNo}" />-->
-
-                    <!--                <label>-->
-                    <!--                    <select name="orderBy" onchange="submitForm()">-->
-                    <!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최근작성순</option>-->
-                    <!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
-                    <!--                    </select>-->
-                    <!--                </label>-->
-                    <!--            </form>-->
-                    <!--            <form id="filter-form" th:action="@{/user/my/rct/job/apply(boardNo=${boardNo})}" method="get">-->
-                    <!--                <label>-->
-                    <!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="toggleCheckboxValue()">미열람-->
-                    <!--                </label>-->
-                    <!--                &lt;!&ndash; Hidden field for boardNo &ndash;&gt;-->
-                    <!--                <input type="hidden" name="boardNo" th:value="${boardNo}" />-->
-                    <!--            </form>-->
-                    <!--            <table>-->
-                    <!--                <thead>-->
-                    <!--                <tr>-->
-                    <!--                    <th>지원글 번호</th>-->
-                    <!--                    <th>게시글 번호</th>-->
-                    <!--                    <th>지원자</th>-->
-                    <!--                    <th>제목</th>-->
-                    <!--                    <th>내용</th>-->
-                    <!--                    <th>이미지</th>-->
-                    <!--                    <th>작성 일자</th>-->
-                    <!--                    <th>조회 여부</th>-->
-
-                    <!--                    <th>작성자</th>-->
-                    <!--                    <th>제목</th>-->
-                    <!--                    <th>내용</th>-->
-                    <!--                    <th>근무지</th>-->
-                    <!--                    <th>이미지</th>-->
-                    <!--                    <th>작성 일자</th>-->
-                    <!--                    <th>수정 일자</th>-->
-                    <!--                    <th>마감 일자</th>-->
-                    <!--                </tr>-->
-                    <!--                </thead>-->
-                    <!--                <tbody>-->
-                    <!--                <tr th:each="myRctJobApplication : ${myRctJobApplications}" class="clickable-row" th:attr="data-href=@{/recruit/job/applyView(no=${myRctJobApplication.applyNo})}">-->
-                    <!--                    <td th:text="${myRctJobApplication.applyNo}">지원글 번호</td>-->
-                    <!--                    <td th:text="${myRctJobApplication.boardNo}">게시글 번호</td>-->
-                    <!--                    <td th:text="${myRctJobApplication.writer}">지원자</td>-->
-                    <!--                    <td th:text="${myRctJobApplication.applyTitle}">제목</td>-->
-                    <!--                    <td th:text="${myRctJobApplication.applyContent}">내용</td>-->
-                    <!--                    <td th:text="${myRctJobApplication.applyImg}">이미지</td>-->
-                    <!--                    <td th:text="${myRctJobApplication.applyCreatedDate}">작성 일자</td>-->
-                    <!--                    <td th:text="${myRctJobApplication.applyCheckStatus}">조회 여부</td>-->
-
-                    <!--                    <td th:text="${myRctJobApplication.jobWriter}">작성자</td>-->
-                    <!--                    <td th:text="${myRctJobApplication.jobTitle}">제목</td>-->
-                    <!--                    <td th:text="${myRctJobApplication.jobContent}">내용</td>-->
-                    <!--                    <td th:text="${myRctJobApplication.jobLocation}">근무지</td>-->
-                    <!--                    <td th:text="${myRctJobApplication.jobImg}">이미지</td>-->
-                    <!--                    <td th:text="${myRctJobApplication.jobCreatedDate}">작성 일자</td>-->
-                    <!--                    <td th:text="${myRctJobApplication.jobModifiedDate}">수정 일자</td>-->
-                    <!--                    <td th:text="${myRctJobApplication.jobDeadLine}">마감 일자</td>-->
-                    <!--                </tr>-->
-                    <!--                </tbody>-->
-                    <!--            </table>-->
-                    <!-- 페이징 -->
-                    <!--            <th:block th:if="${pages != null}">-->
-                    <!--                <div class="d-flex justify-content-center">-->
-                    <!--                    <div class="btn-group">-->
-                    <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/rct/job/apply(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
-                    <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
-                    <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
-                    <!--                            </svg>-->
-                    <!--                        </button>-->
-                    <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
-                    <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
-                    <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/rct/job/apply(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
-                    <!--                        </th:block>-->
-                    <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/rct/job/apply(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
-                    <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
-                    <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
-                    <!--                            </svg>-->
-                    <!--                        </button>-->
-                    <!--                    </div>-->
-                    <!--                </div>-->
-                    <!--            </th:block>-->
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/user/mypage_rct_job_applicationlist.html
+++ b/src/main/resources/templates/user/mypage_rct_job_applicationlist.html
@@ -106,20 +106,26 @@
 <div class="jumbotron">
     <div class="container">
         <div class="row">
-            <div class="col-md-3 px-4">
-                <h3>나의 채용</h3>
-            </div>
-            <div class="col-md-9">
-                <nav class="navbar navbar-expand-md">
-                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                        <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color:#000;">내가 올린 공고</a></li>
-                        <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a>
-                        </li>
-                        <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
-                        <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
-                        <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보 수정</a></li>
-                    </ul>
-                </nav>
+            <div class="col-9">
+                <div class="row">
+                    <div class="col-md-3 px-4">
+                        <h3>나의 채용</h3>
+                    </div>
+                    <div class="col-md-9">
+                        <nav class="navbar navbar-expand-md">
+                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color:#000;">내가 올린
+                                    공고</a></li>
+                                <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a>
+                                </li>
+                                <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
+                                <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
+                                <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보
+                                    수정</a></li>
+                            </ul>
+                        </nav>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/user/mypage_rct_job_applicationlist.html
+++ b/src/main/resources/templates/user/mypage_rct_job_applicationlist.html
@@ -104,20 +104,22 @@
   }
 </style>
 <div class="jumbotron">
-    <div class="row">
-        <div class="col-md-3 px-4">
-            <h3>나의 채용</h3>
-        </div>
-        <div class="col-md-9">
-            <nav class="navbar navbar-expand-md">
-                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                    <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color:#000;">내가 올린 공고</a></li>
-                    <li><a th:href="@{/user/my/rct/creator}" class="nav-link px-2">창작자 등록 현황</a></li>
-                    <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a></li>
-                    <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
-                    <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
-                </ul>
-            </nav>
+    <div class="container">
+        <div class="row">
+            <div class="col-md-3 px-4">
+                <h3>나의 채용</h3>
+            </div>
+            <div class="col-md-9">
+                <nav class="navbar navbar-expand-md">
+                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                        <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color:#000;">내가 올린 공고</a></li>
+                        <li><a th:href="@{/user/my/rct/creator}" class="nav-link px-2">창작자 등록 현황</a></li>
+                        <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a></li>
+                        <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
+                        <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
+                    </ul>
+                </nav>
+            </div>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/user/mypage_rct_job_applicationlist.html
+++ b/src/main/resources/templates/user/mypage_rct_job_applicationlist.html
@@ -123,33 +123,35 @@
         </div>
     </div>
 </div>
-<div class="row">
-    <aside class="col-md-3 px-4">
-        <div class="row">
-            <div class="col-3"></div>
-            <div class="col-6">
-                <div class="panel">
-                    <ul class="list-group">
-                        <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
-                        <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-                        <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color: #03C75A;">나의 채용</a></li>
-                        <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-                        <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                        <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-                    </ul>
+<div class="container" style="padding:0;">
+    <div class="row">
+        <aside class="col-md-3 px-4">
+            <div class="row">
+                <div class="col-3"></div>
+                <div class="col-6">
+                    <div class="panel">
+                        <ul class="list-group">
+                            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
+                            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color: #03C75A;">나의 채용</a>
+                            </li>
+                            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+                        </ul>
+                    </div>
                 </div>
             </div>
-        </div>
-    </aside>
-<!--    <script>-->
-<!--        function toggleCheckboxValue() {-->
-<!--            const checkbox = document.getElementById('isToggledCheckbox');-->
-<!--            if(!checkbox.checked) checkbox.value = 'N';-->
-<!--            else checkbox.value = 'Y';-->
-<!--            document.getElementById('filter-form').submit();-->
-<!--        }-->
-<!--    </script>-->
-    <script> // toggle + sorting
+        </aside>
+        <!--    <script>-->
+        <!--        function toggleCheckboxValue() {-->
+        <!--            const checkbox = document.getElementById('isToggledCheckbox');-->
+        <!--            if(!checkbox.checked) checkbox.value = 'N';-->
+        <!--            else checkbox.value = 'Y';-->
+        <!--            document.getElementById('filter-form').submit();-->
+        <!--        }-->
+        <!--    </script>-->
+        <script> // toggle + sorting
         function updateCheckboxValueAndSubmit() {
             const checkbox = document.getElementById('isToggledCheckbox');
             const form = document.getElementById('filter-and-sort-form');
@@ -162,387 +164,434 @@
         function submitForm() {
             document.getElementById('filter-and-sort-form').submit();
         }
-    </script>
-    <style>
-        .form-select {
-        background-color : #FCFCFC;
-        border : none;
-        width : 100%;
-        height : 50px;
-        }
-        select {
-        color : #828282;
-        }
-        .form-control {
-        background-color : #FCFCFC;
-        border : none;
-        width : 100%;
-        height : 50px;
-        }
+        </script>
+        <style>
+            .form-select {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
+            }
+            select {
+            color : #828282;
+            }
+            .form-control {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
+            }
 
 
-        .form-control::placeholder {
-        color : #BBBBBB;
-        }
+            .form-control::placeholder {
+            color : #BBBBBB;
+            }
 
-        .date-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    background-color: #8E4B6E;
-    color: white;
-    border-radius: 10px;
-    text-align:center;
-    font-family: "Work Sans", sans-serif;
-}
+            .date-container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        background-color: #8E4B6E;
+        color: white;
+        border-radius: 10px;
+        text-align:center;
+        font-family: "Work Sans", sans-serif;
+    }
 
-.month {
-    font-size: 1.1rem; /* M의 크기를 설정 */
-    font-weight: 550;
-    line-height: 1;
-}
+    .month {
+        font-size: 1.1rem; /* M의 크기를 설정 */
+        font-weight: 550;
+        line-height: 1;
+    }
 
-.year {
-    font-size: 0.65rem; /* yyyy의 크기를 설정 */
-    font-weight: 400;
-}
-:root {
-    --background-color-light: #FFFFFF;
-    --text-color-light: #000000;
-    --toggle-background-light: #CCCCCC;
-    --toggle-ball-light: #FFFFFF;
+    .year {
+        font-size: 0.65rem; /* yyyy의 크기를 설정 */
+        font-weight: 400;
+    }
+    :root {
+        --background-color-light: #FFFFFF;
+        --text-color-light: #000000;
+        --toggle-background-light: #CCCCCC;
+        --toggle-ball-light: #FFFFFF;
 
-    --background-color-dark: #333333;
-    --text-color-dark: #FFFFFF;
-    --toggle-background-dark: #03C75A;
-    --toggle-ball-dark: #FFFFFF;
+        --background-color-dark: #333333;
+        --text-color-dark: #FFFFFF;
+        --toggle-background-dark: #03C75A;
+        --toggle-ball-dark: #FFFFFF;
 
-    --font-size-base: 32px; /* 기본 텍스트 크기 */
-    --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
-}
+        --font-size-base: 32px; /* 기본 텍스트 크기 */
+        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+    }
 
 
 
-.toggle-switch {
-    position: relative;
-    display: inline-block;
-    width: 62px; /* 너비 조정 */
-    height: 38px; /* 높이 조정 */
-}
+    .toggle-switch {
+        position: relative;
+        display: inline-block;
+        width: 62px; /* 너비 조정 */
+        height: 38px; /* 높이 조정 */
+    }
 
-.toggle-switch .checkbox {
-    opacity: 0;
-    width: 0;
-    height: 0;
-}
-#isToggledCheckbox {
-     opacity: 0;
+    .toggle-switch .checkbox {
+        opacity: 0;
         width: 0;
         height: 0;
-}
+    }
+    #isToggledCheckbox {
+         opacity: 0;
+            width: 0;
+            height: 0;
+    }
 
-.toggle-switch .label {
-    position: absolute;
-    cursor: pointer;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: var(--toggle-background-light);
-    transition: background-color 0.4s;
-    border-radius: 38px; /* 둥근 모서리 반경 조정 */
-}
+    .toggle-switch .label {
+        position: absolute;
+        cursor: pointer;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: var(--toggle-background-light);
+        transition: background-color 0.4s;
+        border-radius: 38px; /* 둥근 모서리 반경 조정 */
+    }
 
-.toggle-switch .label:before {
-    position: absolute;
-    content: "";
-    height: 30px; /* 내부 원 높이 조정 */
-    width: 30px; /* 내부 원 너비 조정 */
-    left: 2px;
-    bottom: 0px;
-    background-color: var(--toggle-ball-light);
-    transition: transform 0.4s;
-    border-radius: 50%;
-}
+    .toggle-switch .label:before {
+        position: absolute;
+        content: "";
+        height: 30px; /* 내부 원 높이 조정 */
+        width: 30px; /* 내부 원 너비 조정 */
+        left: 2px;
+        bottom: 0px;
+        background-color: var(--toggle-ball-light);
+        transition: transform 0.4s;
+        border-radius: 50%;
+    }
 
-.toggle-switch input:checked + .label {
-    background-color: var(--toggle-background-dark);
-}
+    .toggle-switch input:checked + .label {
+        background-color: var(--toggle-background-dark);
+    }
 
-.toggle-switch input:checked + .label:before {
-    transform: translateX(28px); /* 내부 원 이동 거리 조정 */
-}
+    .toggle-switch input:checked + .label:before {
+        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+    }
 
-         .absdiv {
-            position: relative;
-            top: 60px; /* Move down by 20px from its current position */
-            z-index : 1000;
-        }
+             .absdiv {
+                position: relative;
+                top: 60px; /* Move down by 20px from its current position */
+                z-index : 1000;
+            }
 
-        #searchbutton {
-            background-color: #828282;
-        }
-    </style>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+            #searchbutton {
+                background-color: #828282;
+            }
+        </style>
+        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+              rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+              rel="stylesheet">
 
-    <div class="col-md-9">
-        <div class="row" style="color: #828282;">
-            <div class="col-11">
-                <div class="row">
-                    <div class="col-12">
-                        <form id="filter-and-sort-form" th:action="@{/user/my/rct/job/apply(boardNo=${boardNo})}" method="get">
-                            <div class="row">
-                                <div class="col-7">
-                                    <div class="row justify-content-start m-0">
-                                        <div class="col-4">
-                                            <!-- 검색 조건 -->
+        <div class="col-md-9">
+            <div class="row" style="color: #828282;">
+                <div class="col-11">
+                    <div class="row">
+                        <div class="col-12">
+                            <form id="filter-and-sort-form" th:action="@{/user/my/rct/job/apply(boardNo=${boardNo})}"
+                                  method="get">
+                                <div class="row">
+                                    <div class="col-7">
+                                        <div class="row justify-content-start m-0">
+                                            <div class="col-4">
+                                                <!-- 검색 조건 -->
+                                                <label>
+                                                    <select class="form-select px-3" name="searchBy">
+                                                        <option value="title" th:selected="${searchBy == 'title'}">
+                                                            지원서제목
+                                                        </option>
+                                                        <option value="content" th:selected="${searchBy == 'content'}">
+                                                            지원서내용
+                                                        </option>
+                                                        <!--                        <option value="realname" th:selected="${searchBy == 'realname'}">지원자성명</option>-->
+                                                    </select>
+                                                </label>
+                                            </div>
+                                            <div class="col-6">
+                                                <input class="form-control px-3" type="text" name="searchTerm"
+                                                       placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
+                                            </div>
+                                            <div class="col-2">
+                                                <input type="hidden" name="boardNo" th:value="${boardNo}"/>
+                                                <!-- 검색 버튼 -->
+                                                <button id="searchbutton" type="submit" class="btn btn-primary">검색
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-1" style=""></div>
+                                    <div class="col-4">
+                                        <div class="row justify-content-end">
+                                            <!-- 정렬 또는 토글2 -->
                                             <label>
-                                                <select class="form-select px-3" name="searchBy">
-                                                    <option value="title" th:selected="${searchBy == 'title'}">지원서제목</option>
-                                                    <option value="content" th:selected="${searchBy == 'content'}">지원서내용</option>
-                                                    <!--                        <option value="realname" th:selected="${searchBy == 'realname'}">지원자성명</option>-->
+                                                <select class="form-select px-3" name="orderBy" onchange="submitForm()">
+                                                    <option value="recent" th:selected="${orderBy == 'recent'}">최근작성순
+                                                    </option>
+                                                    <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순
+                                                    </option>
                                                 </select>
                                             </label>
                                         </div>
-                                        <div class="col-6">
-                                            <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
-                                        </div>
-                                        <div class="col-2">
-                                            <input type="hidden" name="boardNo" th:value="${boardNo}" />
-                                            <!-- 검색 버튼 -->
-                                            <button id="searchbutton" type="submit" class="btn btn-primary">검색</button>
-                                        </div>
                                     </div>
-                                </div>
-                                <div class="col-1" style=""></div>
-                                <div class="col-4">
-                                    <div class="row justify-content-end">
-                                        <!-- 정렬 또는 토글2 -->
-                                        <label>
-                                            <select class="form-select px-3" name="orderBy" onchange="submitForm()">
-                                                <option value="recent" th:selected="${orderBy == 'recent'}">최근작성순</option>
-                                                <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>
-                                            </select>
-                                        </label>
-                                    </div>
-                                </div>
-                            </div> <!--검색, 소팅 (토글X)-->
-                            <div class="row justify-content-around">
-                                <div class="col-3" style="padding: 0 1.2rem;">
-                                    <div class="absdiv">
-                                        <a href="javascript:window.history.back();" class="btn btn-primary" style="background-color: #03C75A;">뒤로가기</a>
+                                </div> <!--검색, 소팅 (토글X)-->
+                                <div class="row justify-content-around">
+                                    <div class="col-3" style="padding: 0 1.2rem;">
+                                        <div class="absdiv">
+                                            <a href="javascript:window.history.back();" class="btn btn-primary"
+                                               style="background-color: #03C75A;">뒤로가기</a>
 
-                                    </div>
-                                </div>
-                                <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                <div class="col-3" style="padding: 0 1.2rem;">
-                                    <div class="row justify-content-end absdiv">
-                                        <div class="col-3">
-                                            <div class="toggle-switch">
-                                                <!-- 정렬 또는 토글1 -->
-                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">
-                                                <label for="isToggledCheckbox" class="label">
-                                                    <div class="ball"></div>
-                                                </label>
-                                            </div>
-                                        </div>
-                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">미열람 지원서</div>
-                                    </div>
-                                </div>
-                            </div> <!--토글-->
-                        </form>
-                    </div>
-                </div>
-
-                <div class="row justify-content-around">
-                    <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
-                        <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
-                            <div class="col-11" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;">
-                                <div class="row justify-content-center mx-3">
-                                    <div class="col-1 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                        <div class="date-container px-2 py-1">
-                                            <div class="month" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(board.createdDate)}"></div>
-                                            <div class="year" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(board.createdDate)}"></div>
                                         </div>
                                     </div>
-                                    <div class="col-5" style="color: white; " th:text="${board.boardNo}">닉네임</div>
-                                    <div class="col-6" style="padding:0; font-size: 1rem; text-align: right; color: #BDBDBD;" th:text="${board.formattedDeadLine}">1주일 전</div>
-                                </div>
-                                <div class="row justify-content-center mx-3">
-                                    <div class="col-12" style="color: white;" >사진</div>
-                                </div>
-                                <div class="row justify-content-center mx-3">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" th:text="${board.title}">이름</div>
-                                    <div class="col-3 clickable-row" style="padding: 0; text-align: right;" th:attr="data-href=@{/recruit/job/view(no=${boardNo})}">→</div>
-                                </div>
-                                <div class="row justify-content-center mx-3">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${board.content}">내용</div>
-                                    <div class="col-3 clickable-row" style="padding: 0; text-align: right;" th:attr="data-href=@{/recruit/job/view(no=${boardNo})}">공고 확인</div>
-                                </div>
-                                <div class="row justify-content-center mx-3 my-5">
-                                    <div class="col-12 m-0 p-0" style="color: #333333;" >
-                                        <table>
-                                            <thead>
-                                            <tr>
-                                                <th>지원글 번호</th>
-                                                <th>지원자</th>
-                                                <th>제목</th>
-                                                <th>작성 일자</th>
-                                                <th>조회 여부</th>
-                                            </tr>
-                                            </thead>
-                                            <tbody>
-                                            <tr th:each="myRctJobApplication : ${myRctJobApplications}" class="clickable-row" th:attr="data-href=@{/recruit/job/applyView(no=${myRctJobApplication.applyNo})}">
-                                                <td th:text="${myRctJobApplication.applyNo}">지원글 번호</td>
-                                                <td th:text="${myRctJobApplication.writer}">지원자</td>
-                                                <td th:text="${myRctJobApplication.applyTitle}">제목</td>
-                                                <td th:text="${myRctJobApplication.applyCreatedDate}">작성 일자</td>
-                                                <td th:text="${myRctJobApplication.applyCheckStatus}">조회 여부</td>
-                                            </tr>
-                                            </tbody>
-                                        </table>
-                                    </div>
-                                </div>
-                                <div class="row justify-content-center mx-3">
-                                    <div class="col-12" style="color: white;" >
-                                        <!-- 페이징 -->
-                                        <th:block th:if="${pages != null}">
-                                            <div class="d-flex justify-content-center">
-                                                <div class="btn-group">
-                                                    <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/rct/job/apply(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">
-                                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-                                                            <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                                                        </svg>
-                                                    </button>
-                                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">
-                                                        <button type="button" class="btn btn-sm me-2 pages"
-                                                                th:text="${p}" th:onclick="|location.href='@{/user/my/rct/job/apply(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
-                                                    </th:block>
-                                                    <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/rct/job/apply(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">
-                                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-                                                            <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
-                                                        </svg>
-                                                    </button>
+                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                    <div class="col-3" style="padding: 0 1.2rem;">
+                                        <div class="row justify-content-end absdiv">
+                                            <div class="col-3">
+                                                <div class="toggle-switch">
+                                                    <!-- 정렬 또는 토글1 -->
+                                                    <input type="checkbox" name="isToggled" id="isToggledCheckbox"
+                                                           value="Y" th:checked="${isToggled == 'Y'}"
+                                                           onchange="updateCheckboxValueAndSubmit()">
+                                                    <label for="isToggledCheckbox" class="label">
+                                                        <div class="ball"></div>
+                                                    </label>
                                                 </div>
                                             </div>
-                                        </th:block>
+                                            <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">
+                                                미열람 지원서
+                                            </div>
+                                        </div>
                                     </div>
-                                </div>
+                                </div> <!--토글-->
+                            </form>
+                        </div>
+                    </div>
 
+                    <div class="row justify-content-around">
+                        <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
+                            <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
+                                <div class="col-11"
+                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;">
+                                    <div class="row justify-content-center mx-3">
+                                        <div class="col-1 p-0 d-flex align-items-center justify-content-center"
+                                             style="aspect-ratio: 1; border-radius: 5px;">
+                                            <div class="date-container px-2 py-1">
+                                                <div class="month"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(board.createdDate)}"></div>
+                                                <div class="year"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(board.createdDate)}"></div>
+                                            </div>
+                                        </div>
+                                        <div class="col-5" style="color: white; " th:text="${board.boardNo}">닉네임</div>
+                                        <div class="col-6"
+                                             style="padding:0; font-size: 1rem; text-align: right; color: #BDBDBD;"
+                                             th:text="${board.formattedDeadLine}">1주일 전
+                                        </div>
+                                    </div>
+                                    <div class="row justify-content-center mx-3">
+                                        <div class="col-12" style="color: white;">사진</div>
+                                    </div>
+                                    <div class="row justify-content-center mx-3">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                             th:text="${board.title}">이름
+                                        </div>
+                                        <div class="col-3 clickable-row" style="padding: 0; text-align: right;"
+                                             th:attr="data-href=@{/recruit/job/view(no=${boardNo})}">→
+                                        </div>
+                                    </div>
+                                    <div class="row justify-content-center mx-3">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                             th:text="${board.content}">내용
+                                        </div>
+                                        <div class="col-3 clickable-row" style="padding: 0; text-align: right;"
+                                             th:attr="data-href=@{/recruit/job/view(no=${boardNo})}">공고 확인
+                                        </div>
+                                    </div>
+                                    <div class="row justify-content-center mx-3 my-5">
+                                        <div class="col-12 m-0 p-0" style="color: #333333;">
+                                            <table>
+                                                <thead>
+                                                <tr>
+                                                    <th>지원글 번호</th>
+                                                    <th>지원자</th>
+                                                    <th>제목</th>
+                                                    <th>작성 일자</th>
+                                                    <th>조회 여부</th>
+                                                </tr>
+                                                </thead>
+                                                <tbody>
+                                                <tr th:each="myRctJobApplication : ${myRctJobApplications}"
+                                                    class="clickable-row"
+                                                    th:attr="data-href=@{/recruit/job/applyView(no=${myRctJobApplication.applyNo})}">
+                                                    <td th:text="${myRctJobApplication.applyNo}">지원글 번호</td>
+                                                    <td th:text="${myRctJobApplication.writer}">지원자</td>
+                                                    <td th:text="${myRctJobApplication.applyTitle}">제목</td>
+                                                    <td th:text="${myRctJobApplication.applyCreatedDate}">작성 일자</td>
+                                                    <td th:text="${myRctJobApplication.applyCheckStatus}">조회 여부</td>
+                                                </tr>
+                                                </tbody>
+                                            </table>
+                                        </div>
+                                    </div>
+                                    <div class="row justify-content-center mx-3">
+                                        <div class="col-12" style="color: white;">
+                                            <!-- 페이징 -->
+                                            <th:block th:if="${pages != null}">
+                                                <div class="d-flex justify-content-center">
+                                                    <div class="btn-group">
+                                                        <button type="button" class="btn btn-sm previous"
+                                                                th:onclick="|location.href='@{/user/my/rct/job/apply(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
+                                                                th:disabled="${currentPage == 1}">
+                                                            <svg xmlns="http://www.w3.org/2000/svg" width="16"
+                                                                 height="16" fill="currentColor"
+                                                                 class="bi bi-chevron-left" viewBox="0 0 16 16">
+                                                                <path fill-rule="evenodd"
+                                                                      d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                                                            </svg>
+                                                        </button>
+                                                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">
+                                                            <button type="button" class="btn btn-sm me-2 pages"
+                                                                    th:text="${p}"
+                                                                    th:onclick="|location.href='@{/user/my/rct/job/apply(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
+                                                        </th:block>
+                                                        <button type="button" class="btn btn-sm  next"
+                                                                th:onclick="|location.href='@{/user/my/rct/job/apply(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
+                                                                th:disabled="${currentPage == pages}">
+                                                            <svg xmlns="http://www.w3.org/2000/svg" width="16"
+                                                                 height="16" fill="currentColor"
+                                                                 class="bi bi-chevron-right" viewBox="0 0 16 16">
+                                                                <path fill-rule="evenodd"
+                                                                      d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                                                            </svg>
+                                                        </button>
+                                                    </div>
+                                                </div>
+                                            </th:block>
+                                        </div>
+                                    </div>
+
+                                </div>
                             </div>
                         </div>
                     </div>
+
+                    <!--수정전-->
+
+                    <!--    <div class="col-md-9">-->
+                    <!--        <div class="review-list">-->
+                    <!--            <h3><a th:href="@{/user/my/rct/job}">뒤로가기(페이지번호미반영)</a></h3>-->
+                    <!--            <h2>내가 올린 공고-지원서목록</h2>-->
+                    <!--            <h3><a th:href="@{/recruit/job/view(no=${boardNo})}">공고 확인</a></h3>-->
+                    <!--            <form id="filter-and-sort-form" th:action="@{/user/my/rct/job/apply(boardNo=${boardNo})}" method="get">-->
+                    <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
+                    <!--                <label>-->
+                    <!--                    <select name="searchBy">-->
+                    <!--                        <option value="title" th:selected="${searchBy == 'title'}">지원서제목</option>-->
+                    <!--                        <option value="content" th:selected="${searchBy == 'content'}">지원서내용</option>-->
+                    <!--&lt;!&ndash;                        <option value="realname" th:selected="${searchBy == 'realname'}">지원자성명</option>&ndash;&gt;-->
+                    <!--                    </select>-->
+                    <!--                </label>-->
+                    <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
+
+                    <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
+                    <!--                <button type="submit">검색</button>-->
+
+                    <!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
+                    <!--                <label>-->
+                    <!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">미열람-->
+                    <!--                </label>-->
+                    <!--                &lt;!&ndash; Hidden field for boardNo &ndash;&gt;-->
+                    <!--                <input type="hidden" name="boardNo" th:value="${boardNo}" />-->
+
+                    <!--                <label>-->
+                    <!--                    <select name="orderBy" onchange="submitForm()">-->
+                    <!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최근작성순</option>-->
+                    <!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
+                    <!--                    </select>-->
+                    <!--                </label>-->
+                    <!--            </form>-->
+                    <!--            <form id="filter-form" th:action="@{/user/my/rct/job/apply(boardNo=${boardNo})}" method="get">-->
+                    <!--                <label>-->
+                    <!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="toggleCheckboxValue()">미열람-->
+                    <!--                </label>-->
+                    <!--                &lt;!&ndash; Hidden field for boardNo &ndash;&gt;-->
+                    <!--                <input type="hidden" name="boardNo" th:value="${boardNo}" />-->
+                    <!--            </form>-->
+                    <!--            <table>-->
+                    <!--                <thead>-->
+                    <!--                <tr>-->
+                    <!--                    <th>지원글 번호</th>-->
+                    <!--                    <th>게시글 번호</th>-->
+                    <!--                    <th>지원자</th>-->
+                    <!--                    <th>제목</th>-->
+                    <!--                    <th>내용</th>-->
+                    <!--                    <th>이미지</th>-->
+                    <!--                    <th>작성 일자</th>-->
+                    <!--                    <th>조회 여부</th>-->
+
+                    <!--                    <th>작성자</th>-->
+                    <!--                    <th>제목</th>-->
+                    <!--                    <th>내용</th>-->
+                    <!--                    <th>근무지</th>-->
+                    <!--                    <th>이미지</th>-->
+                    <!--                    <th>작성 일자</th>-->
+                    <!--                    <th>수정 일자</th>-->
+                    <!--                    <th>마감 일자</th>-->
+                    <!--                </tr>-->
+                    <!--                </thead>-->
+                    <!--                <tbody>-->
+                    <!--                <tr th:each="myRctJobApplication : ${myRctJobApplications}" class="clickable-row" th:attr="data-href=@{/recruit/job/applyView(no=${myRctJobApplication.applyNo})}">-->
+                    <!--                    <td th:text="${myRctJobApplication.applyNo}">지원글 번호</td>-->
+                    <!--                    <td th:text="${myRctJobApplication.boardNo}">게시글 번호</td>-->
+                    <!--                    <td th:text="${myRctJobApplication.writer}">지원자</td>-->
+                    <!--                    <td th:text="${myRctJobApplication.applyTitle}">제목</td>-->
+                    <!--                    <td th:text="${myRctJobApplication.applyContent}">내용</td>-->
+                    <!--                    <td th:text="${myRctJobApplication.applyImg}">이미지</td>-->
+                    <!--                    <td th:text="${myRctJobApplication.applyCreatedDate}">작성 일자</td>-->
+                    <!--                    <td th:text="${myRctJobApplication.applyCheckStatus}">조회 여부</td>-->
+
+                    <!--                    <td th:text="${myRctJobApplication.jobWriter}">작성자</td>-->
+                    <!--                    <td th:text="${myRctJobApplication.jobTitle}">제목</td>-->
+                    <!--                    <td th:text="${myRctJobApplication.jobContent}">내용</td>-->
+                    <!--                    <td th:text="${myRctJobApplication.jobLocation}">근무지</td>-->
+                    <!--                    <td th:text="${myRctJobApplication.jobImg}">이미지</td>-->
+                    <!--                    <td th:text="${myRctJobApplication.jobCreatedDate}">작성 일자</td>-->
+                    <!--                    <td th:text="${myRctJobApplication.jobModifiedDate}">수정 일자</td>-->
+                    <!--                    <td th:text="${myRctJobApplication.jobDeadLine}">마감 일자</td>-->
+                    <!--                </tr>-->
+                    <!--                </tbody>-->
+                    <!--            </table>-->
+                    <!-- 페이징 -->
+                    <!--            <th:block th:if="${pages != null}">-->
+                    <!--                <div class="d-flex justify-content-center">-->
+                    <!--                    <div class="btn-group">-->
+                    <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/rct/job/apply(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
+                    <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
+                    <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
+                    <!--                            </svg>-->
+                    <!--                        </button>-->
+                    <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
+                    <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
+                    <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/rct/job/apply(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
+                    <!--                        </th:block>-->
+                    <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/rct/job/apply(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
+                    <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
+                    <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
+                    <!--                            </svg>-->
+                    <!--                        </button>-->
+                    <!--                    </div>-->
+                    <!--                </div>-->
+                    <!--            </th:block>-->
                 </div>
-
-    <!--수정전-->
-
-<!--    <div class="col-md-9">-->
-<!--        <div class="review-list">-->
-<!--            <h3><a th:href="@{/user/my/rct/job}">뒤로가기(페이지번호미반영)</a></h3>-->
-<!--            <h2>내가 올린 공고-지원서목록</h2>-->
-<!--            <h3><a th:href="@{/recruit/job/view(no=${boardNo})}">공고 확인</a></h3>-->
-<!--            <form id="filter-and-sort-form" th:action="@{/user/my/rct/job/apply(boardNo=${boardNo})}" method="get">-->
-<!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
-<!--                <label>-->
-<!--                    <select name="searchBy">-->
-<!--                        <option value="title" th:selected="${searchBy == 'title'}">지원서제목</option>-->
-<!--                        <option value="content" th:selected="${searchBy == 'content'}">지원서내용</option>-->
-<!--&lt;!&ndash;                        <option value="realname" th:selected="${searchBy == 'realname'}">지원자성명</option>&ndash;&gt;-->
-<!--                    </select>-->
-<!--                </label>-->
-<!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
-
-<!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
-<!--                <button type="submit">검색</button>-->
-
-<!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
-<!--                <label>-->
-<!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">미열람-->
-<!--                </label>-->
-<!--                &lt;!&ndash; Hidden field for boardNo &ndash;&gt;-->
-<!--                <input type="hidden" name="boardNo" th:value="${boardNo}" />-->
-
-<!--                <label>-->
-<!--                    <select name="orderBy" onchange="submitForm()">-->
-<!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최근작성순</option>-->
-<!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
-<!--                    </select>-->
-<!--                </label>-->
-<!--            </form>-->
-<!--            <form id="filter-form" th:action="@{/user/my/rct/job/apply(boardNo=${boardNo})}" method="get">-->
-<!--                <label>-->
-<!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="toggleCheckboxValue()">미열람-->
-<!--                </label>-->
-<!--                &lt;!&ndash; Hidden field for boardNo &ndash;&gt;-->
-<!--                <input type="hidden" name="boardNo" th:value="${boardNo}" />-->
-<!--            </form>-->
-<!--            <table>-->
-<!--                <thead>-->
-<!--                <tr>-->
-<!--                    <th>지원글 번호</th>-->
-<!--                    <th>게시글 번호</th>-->
-<!--                    <th>지원자</th>-->
-<!--                    <th>제목</th>-->
-<!--                    <th>내용</th>-->
-<!--                    <th>이미지</th>-->
-<!--                    <th>작성 일자</th>-->
-<!--                    <th>조회 여부</th>-->
-
-<!--                    <th>작성자</th>-->
-<!--                    <th>제목</th>-->
-<!--                    <th>내용</th>-->
-<!--                    <th>근무지</th>-->
-<!--                    <th>이미지</th>-->
-<!--                    <th>작성 일자</th>-->
-<!--                    <th>수정 일자</th>-->
-<!--                    <th>마감 일자</th>-->
-<!--                </tr>-->
-<!--                </thead>-->
-<!--                <tbody>-->
-<!--                <tr th:each="myRctJobApplication : ${myRctJobApplications}" class="clickable-row" th:attr="data-href=@{/recruit/job/applyView(no=${myRctJobApplication.applyNo})}">-->
-<!--                    <td th:text="${myRctJobApplication.applyNo}">지원글 번호</td>-->
-<!--                    <td th:text="${myRctJobApplication.boardNo}">게시글 번호</td>-->
-<!--                    <td th:text="${myRctJobApplication.writer}">지원자</td>-->
-<!--                    <td th:text="${myRctJobApplication.applyTitle}">제목</td>-->
-<!--                    <td th:text="${myRctJobApplication.applyContent}">내용</td>-->
-<!--                    <td th:text="${myRctJobApplication.applyImg}">이미지</td>-->
-<!--                    <td th:text="${myRctJobApplication.applyCreatedDate}">작성 일자</td>-->
-<!--                    <td th:text="${myRctJobApplication.applyCheckStatus}">조회 여부</td>-->
-
-<!--                    <td th:text="${myRctJobApplication.jobWriter}">작성자</td>-->
-<!--                    <td th:text="${myRctJobApplication.jobTitle}">제목</td>-->
-<!--                    <td th:text="${myRctJobApplication.jobContent}">내용</td>-->
-<!--                    <td th:text="${myRctJobApplication.jobLocation}">근무지</td>-->
-<!--                    <td th:text="${myRctJobApplication.jobImg}">이미지</td>-->
-<!--                    <td th:text="${myRctJobApplication.jobCreatedDate}">작성 일자</td>-->
-<!--                    <td th:text="${myRctJobApplication.jobModifiedDate}">수정 일자</td>-->
-<!--                    <td th:text="${myRctJobApplication.jobDeadLine}">마감 일자</td>-->
-<!--                </tr>-->
-<!--                </tbody>-->
-<!--            </table>-->
-            <!-- 페이징 -->
-<!--            <th:block th:if="${pages != null}">-->
-<!--                <div class="d-flex justify-content-center">-->
-<!--                    <div class="btn-group">-->
-<!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/rct/job/apply(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
-<!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
-<!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
-<!--                            </svg>-->
-<!--                        </button>-->
-<!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
-<!--                            <button type="button" class="btn btn-sm me-2 pages"-->
-<!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/rct/job/apply(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
-<!--                        </th:block>-->
-<!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/rct/job/apply(boardNo=${boardNo}, isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
-<!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
-<!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
-<!--                            </svg>-->
-<!--                        </button>-->
-<!--                    </div>-->
-<!--                </div>-->
-<!--            </th:block>-->
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/user/mypage_rct_job_applicationlist.html
+++ b/src/main/resources/templates/user/mypage_rct_job_applicationlist.html
@@ -135,7 +135,7 @@
         <aside class="col-md-3 px-4">
             <div class="row">
                 <div class="col-1"></div>
-                <div class="col-6">
+                <div class="col-8">
                     <div class="panel">
                         <ul class="list-group">
                             <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>

--- a/src/main/resources/templates/user/mypage_rct_job_applicationlist.html
+++ b/src/main/resources/templates/user/mypage_rct_job_applicationlist.html
@@ -112,12 +112,12 @@
             <div class="col-md-9">
                 <nav class="navbar navbar-expand-md">
                     <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                        <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 등록 현황</a></li>
                         <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color:#000;">내가 올린 공고</a></li>
                         <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a>
                         </li>
                         <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
                         <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
+                        <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보 수정</a></li>
                     </ul>
                 </nav>
             </div>

--- a/src/main/resources/templates/user/mypage_rct_job_applicationlist.html
+++ b/src/main/resources/templates/user/mypage_rct_job_applicationlist.html
@@ -112,9 +112,10 @@
             <div class="col-md-9">
                 <nav class="navbar navbar-expand-md">
                     <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                        <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 등록 현황</a></li>
                         <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color:#000;">내가 올린 공고</a></li>
-                        <li><a th:href="@{/user/my/rct/creator}" class="nav-link px-2">창작자 등록 현황</a></li>
-                        <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a></li>
+                        <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a>
+                        </li>
                         <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
                         <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2">프리랜서 구매 목록</a></li>
                     </ul>

--- a/src/main/resources/templates/user/mypage_rct_order.html
+++ b/src/main/resources/templates/user/mypage_rct_order.html
@@ -86,578 +86,609 @@
 
 <div th:replace="~{common/menubar}"></div>
 <style>
-    .jumbotron {
-    position : relative;
-    background-color : #EEEEEE;
+    html, body {
+        height: 100%;
+        margin: 0;
     }
-    .jumbotron .row {
-    position : absolute;
-    width : 100%;
-    bottom: 0%;
+    body {
+        display: flex;
+        flex-direction: column;
     }
-    .nav-link {
-            color: #828282;
+    .content-wrapper {
+        flex: 1 0 auto;
     }
-    ul {
-  list-style: none;
-  padding-left : 0px;
-  }
+    footer {
+        flex-shrink: 0;
+    }
+
 </style>
-<div class="jumbotron">
-    <div class="container">
-        <div class="row">
-            <div class="col-9">
-                <div class="row">
-                    <div class="col-md-3 px-4">
-                        <h3>나의 채용</h3>
-                    </div>
-                    <div class="col-md-9">
-                        <nav class="navbar navbar-expand-md">
-                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
-                                <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a>
-                                </li>
-                                <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
-                                <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2" style="color:#000;">프리랜서 구매
-                                    목록</a></li>
-                                <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보
-                                    수정</a></li>
-                            </ul>
-                        </nav>
+<div class="content-wrapper">
+    <style>
+        .jumbotron {
+        position : relative;
+        background-color : #EEEEEE;
+        }
+        .jumbotron .row {
+        position : absolute;
+        width : 100%;
+        bottom: 0%;
+        }
+        .nav-link {
+                color: #828282;
+        }
+        ul {
+      list-style: none;
+      padding-left : 0px;
+      }
+    </style>
+    <div class="jumbotron">
+        <div class="container">
+            <div class="row">
+                <div class="col-9">
+                    <div class="row">
+                        <div class="col-md-3 px-4">
+                            <h3>나의 채용</h3>
+                        </div>
+                        <div class="col-md-9">
+                            <nav class="navbar navbar-expand-md">
+                                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                    <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
+                                    <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a>
+                                    </li>
+                                    <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
+                                    <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2" style="color:#000;">프리랜서
+                                        구매
+                                        목록</a></li>
+                                    <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보
+                                        수정</a></li>
+                                </ul>
+                            </nav>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
-<div class="container" style="padding:0;">
-    <div class="row">
-        <aside class="col-md-3 px-4">
-            <div class="row">
-                <div class="col-1"></div>
-                <div class="col-8">
-                    <div class="panel">
-                        <ul class="list-group">
-                            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
-                            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-                            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color: #03C75A;">나의 채용</a>
-                            </li>
-                            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-                        </ul>
+    <div class="container" style="padding:0;">
+        <div class="row">
+            <aside class="col-md-3 px-4">
+                <div class="row">
+                    <div class="col-1"></div>
+                    <div class="col-8">
+                        <div class="panel">
+                            <ul class="list-group">
+                                <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
+                                <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color: #03C75A;">나의
+                                    채용</a>
+                                </li>
+                                <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                                <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                                <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </aside>
-        <!--    <script>-->
-        <!--        function toggleCheckboxValue() {-->
-        <!--            const checkbox = document.getElementById('isToggledCheckbox');-->
-        <!--            if(!checkbox.checked) checkbox.value = 'N';-->
-        <!--            else checkbox.value = 'Y';-->
-        <!--            document.getElementById('filter-form').submit();-->
-        <!--        }-->
-        <!--    </script>-->
-        <script> // toggle + sorting
-        function updateCheckboxValueAndSubmit() {
-            const checkbox = document.getElementById('isToggledCheckbox');
-            const form = document.getElementById('filter-and-sort-form');
-            // 체크박스가 체크된 상태를 확인
-            checkbox.value = checkbox.checked ? 'Y' : 'N';
-            // 폼 제출
-            form.submit();
+            </aside>
+            <!--    <script>-->
+            <!--        function toggleCheckboxValue() {-->
+            <!--            const checkbox = document.getElementById('isToggledCheckbox');-->
+            <!--            if(!checkbox.checked) checkbox.value = 'N';-->
+            <!--            else checkbox.value = 'Y';-->
+            <!--            document.getElementById('filter-form').submit();-->
+            <!--        }-->
+            <!--    </script>-->
+            <script> // toggle + sorting
+            function updateCheckboxValueAndSubmit() {
+                const checkbox = document.getElementById('isToggledCheckbox');
+                const form = document.getElementById('filter-and-sort-form');
+                // 체크박스가 체크된 상태를 확인
+                checkbox.value = checkbox.checked ? 'Y' : 'N';
+                // 폼 제출
+                form.submit();
+            }
+
+            function submitForm() {
+                document.getElementById('filter-and-sort-form').submit();
+            }
+            </script>
+            <style>
+                .form-select {
+                background-color : #FCFCFC;
+                border : none;
+                width : 100%;
+                height : 50px;
+                }
+                select {
+                color : #828282;
+                }
+                .form-control {
+                background-color : #FCFCFC;
+                border : none;
+                width : 100%;
+                height : 50px;
+                }
+
+
+                .form-control::placeholder {
+                color : #BBBBBB;
+                }
+
+                .date-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            background-color: #8E4B6E;
+            color: white;
+            border-radius: 10px;
+            text-align:center;
+            font-family: "Work Sans", sans-serif;
         }
 
-        function submitForm() {
-            document.getElementById('filter-and-sort-form').submit();
+        .month {
+            font-size: 1.1rem; /* M의 크기를 설정 */
+            font-weight: 550;
+            line-height: 1;
         }
-        </script>
-        <style>
-            .form-select {
-            background-color : #FCFCFC;
-            border : none;
-            width : 100%;
-            height : 50px;
-            }
-            select {
-            color : #828282;
-            }
-            .form-control {
-            background-color : #FCFCFC;
-            border : none;
-            width : 100%;
-            height : 50px;
-            }
 
+        .year {
+            font-size: 0.65rem; /* yyyy의 크기를 설정 */
+            font-weight: 400;
+        }
+        :root {
+            --background-color-light: #FFFFFF;
+            --text-color-light: #000000;
+            --toggle-background-light: #CCCCCC;
+            --toggle-ball-light: #FFFFFF;
 
-            .form-control::placeholder {
-            color : #BBBBBB;
-            }
+            --background-color-dark: #333333;
+            --text-color-dark: #FFFFFF;
+            --toggle-background-dark: #03C75A;
+            --toggle-ball-dark: #FFFFFF;
 
-            .date-container {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        background-color: #8E4B6E;
-        color: white;
-        border-radius: 10px;
-        text-align:center;
-        font-family: "Work Sans", sans-serif;
-    }
-
-    .month {
-        font-size: 1.1rem; /* M의 크기를 설정 */
-        font-weight: 550;
-        line-height: 1;
-    }
-
-    .year {
-        font-size: 0.65rem; /* yyyy의 크기를 설정 */
-        font-weight: 400;
-    }
-    :root {
-        --background-color-light: #FFFFFF;
-        --text-color-light: #000000;
-        --toggle-background-light: #CCCCCC;
-        --toggle-ball-light: #FFFFFF;
-
-        --background-color-dark: #333333;
-        --text-color-dark: #FFFFFF;
-        --toggle-background-dark: #03C75A;
-        --toggle-ball-dark: #FFFFFF;
-
-        --font-size-base: 32px; /* 기본 텍스트 크기 */
-        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
-    }
+            --font-size-base: 32px; /* 기본 텍스트 크기 */
+            --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+        }
 
 
 
-    .toggle-switch {
-        position: relative;
-        display: inline-block;
-        width: 62px; /* 너비 조정 */
-        height: 38px; /* 높이 조정 */
-    }
+        .toggle-switch {
+            position: relative;
+            display: inline-block;
+            width: 62px; /* 너비 조정 */
+            height: 38px; /* 높이 조정 */
+        }
 
-    .toggle-switch .checkbox {
-        opacity: 0;
-        width: 0;
-        height: 0;
-    }
-    #isToggledCheckbox {
-         opacity: 0;
+        .toggle-switch .checkbox {
+            opacity: 0;
             width: 0;
             height: 0;
-    }
+        }
+        #isToggledCheckbox {
+             opacity: 0;
+                width: 0;
+                height: 0;
+        }
 
-    .toggle-switch .label {
-        position: absolute;
-        cursor: pointer;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background-color: var(--toggle-background-light);
-        transition: background-color 0.4s;
-        border-radius: 38px; /* 둥근 모서리 반경 조정 */
-    }
+        .toggle-switch .label {
+            position: absolute;
+            cursor: pointer;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: var(--toggle-background-light);
+            transition: background-color 0.4s;
+            border-radius: 38px; /* 둥근 모서리 반경 조정 */
+        }
 
-    .toggle-switch .label:before {
-        position: absolute;
-        content: "";
-        height: 30px; /* 내부 원 높이 조정 */
-        width: 30px; /* 내부 원 너비 조정 */
-        left: 2px;
-        bottom: 0px;
-        background-color: var(--toggle-ball-light);
-        transition: transform 0.4s;
-        border-radius: 50%;
-    }
+        .toggle-switch .label:before {
+            position: absolute;
+            content: "";
+            height: 30px; /* 내부 원 높이 조정 */
+            width: 30px; /* 내부 원 너비 조정 */
+            left: 2px;
+            bottom: 0px;
+            background-color: var(--toggle-ball-light);
+            transition: transform 0.4s;
+            border-radius: 50%;
+        }
 
-    .toggle-switch input:checked + .label {
-        background-color: var(--toggle-background-dark);
-    }
+        .toggle-switch input:checked + .label {
+            background-color: var(--toggle-background-dark);
+        }
 
-    .toggle-switch input:checked + .label:before {
-        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
-    }
+        .toggle-switch input:checked + .label:before {
+            transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+        }
 
-             #absdiv {
-                position: relative;
-                top: 60px; /* Move down by 20px from its current position */
-                z-index : 1000;
-            }
+                 #absdiv {
+                    position: relative;
+                    top: 60px; /* Move down by 20px from its current position */
+                    z-index : 1000;
+                }
 
-            #searchbutton {
-                background-color: #828282;
-            }
-        </style>
-        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
-              rel="stylesheet">
-        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
-              rel="stylesheet">
-        <div class="col-md-9">
-            <div class="row" style="color: #828282;">
-                <div class="col-11">
-                    <div class="row">
-                        <div class="col-12 p-0">
-                            <style>
-                                .col-4 select {
-                                    border-radius: 50px;
-                                    text-align: center;
-                                }
-                                /* 검색창 스타일 */
-                                .search-container {
-                                    width: 300px;
-                                }
+                #searchbutton {
+                    background-color: #828282;
+                }
+            </style>
+            <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+                  rel="stylesheet">
+            <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+                  rel="stylesheet">
+            <div class="col-md-9">
+                <div class="row" style="color: #828282;">
+                    <div class="col-11">
+                        <div class="row">
+                            <div class="col-12 p-0">
+                                <style>
+                                    .col-4 select {
+                                        border-radius: 50px;
+                                        text-align: center;
+                                    }
+                                    /* 검색창 스타일 */
+                                    .search-container {
+                                        width: 300px;
+                                    }
 
-                                .search-container select {
-                                    position: absolute;
-                                    left: 0%;
-                                    width: 30%;
-                                    height: 50px;
-                                    color: #828282;
-                                    font-size: 1rem;
-                                    border-radius: 50px 0 0 50px;
-                                    outline: none;
-                                }
-                                .search-container input[type="text"] {
-                                    position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
-                                    left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
-                                    width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
-                                    height: 50px;
-                                    padding: 10px 40px 10px 15px;
-                                    font-size: 1rem;
-                                    outline: none;
-                                    border-radius: 0 50px 50px 0;
-                                    transition: border-color 0.3s, background-color 0.3s;
-                                    color: #828282; /* 입력 텍스트 색상 변경 */
-                                }
+                                    .search-container select {
+                                        position: absolute;
+                                        left: 0%;
+                                        width: 30%;
+                                        height: 50px;
+                                        color: #828282;
+                                        font-size: 1rem;
+                                        border-radius: 50px 0 0 50px;
+                                        outline: none;
+                                    }
+                                    .search-container input[type="text"] {
+                                        position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
+                                        left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
+                                        width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
+                                        height: 50px;
+                                        padding: 10px 40px 10px 15px;
+                                        font-size: 1rem;
+                                        outline: none;
+                                        border-radius: 0 50px 50px 0;
+                                        transition: border-color 0.3s, background-color 0.3s;
+                                        color: #828282; /* 입력 텍스트 색상 변경 */
+                                    }
 
-                                .search-container input[type="text"]::placeholder {
-                                    color: #BBBBBB; /* placeholder 색상 변경 */
-                                }
+                                    .search-container input[type="text"]::placeholder {
+                                        color: #BBBBBB; /* placeholder 색상 변경 */
+                                    }
 
 
-                                .search-container button {
-                                    position: absolute;
-                                    right: 1rem;
-                                    top: 25px;
-                                    background: none;
-                                    transform: translateY(-50%);
-                                    border: none;
-                                    cursor: pointer;
-                                }
+                                    .search-container button {
+                                        position: absolute;
+                                        right: 1rem;
+                                        top: 25px;
+                                        background: none;
+                                        transform: translateY(-50%);
+                                        border: none;
+                                        cursor: pointer;
+                                    }
 
-                                .search-container button i {
-                                    color: #A6AAB5;
-                                }
+                                    .search-container button i {
+                                        color: #A6AAB5;
+                                    }
 
-                                .search-container button:hover i {
-                                    color: #03C75A;
-                                }
-                            </style>
-                            <form id="filter-and-sort-form" th:action="@{/user/my/rct/order}" method="get">
-                                <div class="row m-0">
-                                    <div class="col-7 p-0">
-                                        <div class="row justify-content-start m-0">
-                                            <div class="col-12 p-0">
-                                                <div class="search-container">
-                                                    <select class="form-select px-3" name="searchBy">
-                                                        <option value="title" th:selected="${searchBy == 'title'}">
-                                                            구매상품명
+                                    .search-container button:hover i {
+                                        color: #03C75A;
+                                    }
+                                </style>
+                                <form id="filter-and-sort-form" th:action="@{/user/my/rct/order}" method="get">
+                                    <div class="row m-0">
+                                        <div class="col-7 p-0">
+                                            <div class="row justify-content-start m-0">
+                                                <div class="col-12 p-0">
+                                                    <div class="search-container">
+                                                        <select class="form-select px-3" name="searchBy">
+                                                            <option value="title" th:selected="${searchBy == 'title'}">
+                                                                구매상품명
+                                                            </option>
+                                                            <option value="nickname"
+                                                                    th:selected="${searchBy == 'nickname'}">프리랜서닉네임
+                                                            </option>
+                                                        </select>
+                                                        <input class="form-control px-3" type="text" name="searchTerm"
+                                                               placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
+                                                        <!-- 검색 버튼 -->
+                                                        <button type="submit">
+                                                            <i class="fas fa-search"></i>
+                                                        </button>
+                                                    </div>
+                                                </div>
+                                            </div>
+                                        </div>
+                                        <div class="col-1" style=""></div>
+                                        <div class="col-4">
+                                            <div class="row justify-content-end">
+                                                <!-- 정렬 또는 토글2 -->
+                                                <label>
+                                                    <select class="form-select px-3" name="orderBy"
+                                                            onchange="submitForm()">
+                                                        <option value="recent" th:selected="${orderBy == 'recent'}">
+                                                            최근주문순
                                                         </option>
-                                                        <option value="nickname"
-                                                                th:selected="${searchBy == 'nickname'}">프리랜서닉네임
+                                                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순
+                                                        </option>
+                                                        <option value="expensive"
+                                                                th:selected="${orderBy == 'expensive'}">
+                                                            결제금액높은순
+                                                        </option>
+                                                        <option value="cheap" th:selected="${orderBy == 'cheap'}">
+                                                            결제금액낮은순
                                                         </option>
                                                     </select>
-                                                    <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
-                                                    <!-- 검색 버튼 -->
-                                                    <button type="submit">
-                                                        <i class="fas fa-search"></i>
-                                                    </button>
+                                                </label>
+                                            </div>
+                                        </div>
+                                    </div> <!--검색, 소팅 (토글X)-->
+                                    <div class="row justify-content-around">
+                                        <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                        <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                        <div class="col-3" style="padding: 0 1.2rem;">
+                                            <div id="absdiv" class="row justify-content-end">
+                                                <div class="col-3">
+                                                    <div class="toggle-switch">
+                                                        <!-- 정렬 또는 토글1 -->
+                                                        <input type="checkbox" name="isToggled" id="isToggledCheckbox"
+                                                               value="Y" th:checked="${isToggled == 'Y'}"
+                                                               onchange="updateCheckboxValueAndSubmit()">
+                                                        <label for="isToggledCheckbox" class="label">
+                                                            <div class="ball"></div>
+                                                        </label>
+                                                    </div>
+                                                </div>
+                                                <div class="col-8"
+                                                     style="text-align: right; padding: 0px; margin : 0px;">
+                                                    마감된 작업
                                                 </div>
                                             </div>
                                         </div>
-                                    </div>
-                                    <div class="col-1" style=""></div>
-                                    <div class="col-4">
-                                        <div class="row justify-content-end">
-                                            <!-- 정렬 또는 토글2 -->
-                                            <label>
-                                                <select class="form-select px-3" name="orderBy" onchange="submitForm()">
-                                                    <option value="recent" th:selected="${orderBy == 'recent'}">최근주문순
-                                                    </option>
-                                                    <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순
-                                                    </option>
-                                                    <option value="expensive" th:selected="${orderBy == 'expensive'}">
-                                                        결제금액높은순
-                                                    </option>
-                                                    <option value="cheap" th:selected="${orderBy == 'cheap'}">결제금액낮은순
-                                                    </option>
-                                                </select>
-                                            </label>
-                                        </div>
-                                    </div>
-                                </div> <!--검색, 소팅 (토글X)-->
-                                <div class="row justify-content-around">
-                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                    <div class="col-3" style="padding: 0 1.2rem;">
-                                        <div id="absdiv" class="row justify-content-end">
-                                            <div class="col-3">
-                                                <div class="toggle-switch">
-                                                    <!-- 정렬 또는 토글1 -->
-                                                    <input type="checkbox" name="isToggled" id="isToggledCheckbox"
-                                                           value="Y" th:checked="${isToggled == 'Y'}"
-                                                           onchange="updateCheckboxValueAndSubmit()">
-                                                    <label for="isToggledCheckbox" class="label">
-                                                        <div class="ball"></div>
-                                                    </label>
+                                    </div> <!--토글-->
+                                </form>
+                            </div>
+                        </div>
+                        <div class="row justify-content-around">
+                            <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
+                                <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
+                                    <div class="col-3 clickable-row"
+                                         style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                         th:each="myRctOrder, iterStat : ${myRctOrders}"
+                                         th:attr="data-href=@{/recruit/free/view(no=${myRctOrder.boardNo})}"
+                                         th:if="${iterStat.index < 3}">
+                                        <div class="row justify-content-center">
+                                            <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                                 style="aspect-ratio: 1; border-radius: 5px;">
+                                                <div class="date-container px-2 py-1">
+                                                    <div class="month"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctOrder.orderedDate)}"></div>
+                                                    <div class="year"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctOrder.orderedDate)}"></div>
                                                 </div>
                                             </div>
-                                            <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">
-                                                마감된 작업
+                                            <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                            <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                            <!--                                    </div>-->
+                                            <div class="col-4"
+                                                 style="color: #333333; font-size: 0.8rem; font-weight: 530;"
+                                                 th:text="${myRctOrder.nickname}">닉네임
+                                            </div>
+                                            <div class="col-4"
+                                                 style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
+                                                 th:text="${myRctOrder.formattedOrderedDate}">시간
                                             </div>
                                         </div>
-                                    </div>
-                                </div> <!--토글-->
-                            </form>
-                        </div>
-                    </div>
-                    <div class="row justify-content-around">
-                        <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
-                            <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
-                                <div class="col-3 clickable-row"
-                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
-                                     th:each="myRctOrder, iterStat : ${myRctOrders}"
-                                     th:attr="data-href=@{/recruit/free/view(no=${myRctOrder.boardNo})}"
-                                     th:if="${iterStat.index < 3}">
-                                    <div class="row justify-content-center">
-                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
-                                             style="aspect-ratio: 1; border-radius: 5px;">
-                                            <div class="date-container px-2 py-1">
-                                                <div class="month"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctOrder.orderedDate)}"></div>
-                                                <div class="year"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctOrder.orderedDate)}"></div>
+                                        <div class="row justify-content-center">
+                                            <div class="col-10" style="color: white;" th:text="${myRctOrder.boardNo}">사진
                                             </div>
                                         </div>
-                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                        <!--                                    </div>-->
-                                        <div class="col-4" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
-                                             th:text="${myRctOrder.nickname}">닉네임
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                                 th:text="${myRctOrder.title}">이름
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;"></div>
                                         </div>
-                                        <div class="col-4"
-                                             style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
-                                             th:text="${myRctOrder.formattedOrderedDate}">시간
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                                 th:text="${myRctOrder.content}">내용
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;">→</div>
                                         </div>
-                                    </div>
-                                    <div class="row justify-content-center">
-                                        <div class="col-10" style="color: white;" th:text="${myRctOrder.boardNo}">사진
-                                        </div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
-                                             th:text="${myRctOrder.title}">이름
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
-                                             th:text="${myRctOrder.content}">내용
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                    </div>
 
+                                    </div>
+                                    <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
+                                    <div class="col-3" th:if="${myRctOrders.size() == 0}"></div>
+                                    <div class="col-3"
+                                         th:if="${myRctOrders.size() == 0 || myRctOrders.size() == 1}"></div>
+                                    <div class="col-3"
+                                         th:if="${myRctOrders.size() == 0 || myRctOrders.size() == 1 || myRctOrders.size() == 2}"></div>
                                 </div>
-                                <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
-                                <div class="col-3" th:if="${myRctOrders.size() == 0}"></div>
-                                <div class="col-3" th:if="${myRctOrders.size() == 0 || myRctOrders.size() == 1}"></div>
-                                <div class="col-3"
-                                     th:if="${myRctOrders.size() == 0 || myRctOrders.size() == 1 || myRctOrders.size() == 2}"></div>
-                            </div>
-                            <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
-                                <div class="col-3 clickable-row"
-                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
-                                     th:each="myRctOrder, iterStat : ${myRctOrders}"
-                                     th:attr="data-href=@{/recruit/free/view(no=${myRctOrder.boardNo})}"
-                                     th:if="${iterStat.index >= 3}">
-                                    <div class="row justify-content-center">
-                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
-                                             style="aspect-ratio: 1; border-radius: 5px;">
-                                            <div class="date-container px-2 py-1">
-                                                <div class="month"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctOrder.orderedDate)}"></div>
-                                                <div class="year"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctOrder.orderedDate)}"></div>
+                                <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
+                                    <div class="col-3 clickable-row"
+                                         style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                         th:each="myRctOrder, iterStat : ${myRctOrders}"
+                                         th:attr="data-href=@{/recruit/free/view(no=${myRctOrder.boardNo})}"
+                                         th:if="${iterStat.index >= 3}">
+                                        <div class="row justify-content-center">
+                                            <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                                 style="aspect-ratio: 1; border-radius: 5px;">
+                                                <div class="date-container px-2 py-1">
+                                                    <div class="month"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctOrder.orderedDate)}"></div>
+                                                    <div class="year"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctOrder.orderedDate)}"></div>
+                                                </div>
+                                            </div>
+                                            <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                            <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                            <!--                                    </div>-->
+                                            <div class="col-4"
+                                                 style="color: #333333; font-size: 0.8rem; font-weight: 530;"
+                                                 th:text="${myRctOrder.nickname}">닉네임
+                                            </div>
+                                            <div class="col-4"
+                                                 style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD;"
+                                                 th:text="${myRctOrder.formattedOrderedDate}">시간
                                             </div>
                                         </div>
-                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                        <!--                                    </div>-->
-                                        <div class="col-4" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
-                                             th:text="${myRctOrder.nickname}">닉네임
+                                        <div class="row justify-content-center">
+                                            <div class="col-10" style="color: white;" th:text="${myRctOrder.boardNo}">사진
+                                            </div>
                                         </div>
-                                        <div class="col-4"
-                                             style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD;"
-                                             th:text="${myRctOrder.formattedOrderedDate}">시간
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                                 th:text="${myRctOrder.title}">이름
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;"></div>
                                         </div>
-                                    </div>
-                                    <div class="row justify-content-center">
-                                        <div class="col-10" style="color: white;" th:text="${myRctOrder.boardNo}">사진
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                                 th:text="${myRctOrder.content}">내용
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;">→</div>
                                         </div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
-                                             th:text="${myRctOrder.title}">이름
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
-                                             th:text="${myRctOrder.content}">내용
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
+
                                     </div>
 
+                                    <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
+                                    <div class="col-3" th:if="${myRctOrders.size() <= 3}"></div>
+                                    <div class="col-3"
+                                         th:if="${myRctOrders.size() <= 3 || myRctOrders.size() == 4}"></div>
+                                    <div class="col-3"
+                                         th:if="${myRctOrders.size() <= 3 || myRctOrders.size() == 4 || myRctOrders.size() == 5}"></div>
                                 </div>
-
-                                <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
-                                <div class="col-3" th:if="${myRctOrders.size() <= 3}"></div>
-                                <div class="col-3" th:if="${myRctOrders.size() <= 3 || myRctOrders.size() == 4}"></div>
-                                <div class="col-3"
-                                     th:if="${myRctOrders.size() <= 3 || myRctOrders.size() == 4 || myRctOrders.size() == 5}"></div>
                             </div>
                         </div>
-                    </div>
-                    <div class="row justify-content-center">
-                        <!-- 페이징 -->
-                        <th:block th:if="${pages != null}">
-                            <div class="d-flex justify-content-center">
-                                <div class="btn-group">
-                                    <button type="button" class="btn btn-sm previous"
-                                            th:onclick="|location.href='@{/user/my/rct/order(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
-                                            th:disabled="${currentPage == 1}">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                             fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-                                            <path fill-rule="evenodd"
-                                                  d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                                        </svg>
-                                    </button>
-                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">
-                                        <button type="button" class="btn btn-sm me-2 pages"
-                                                th:text="${p}"
-                                                th:onclick="|location.href='@{/user/my/rct/order(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
-                                    </th:block>
-                                    <button type="button" class="btn btn-sm  next"
-                                            th:onclick="|location.href='@{/user/my/rct/order(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
-                                            th:disabled="${currentPage == pages}">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                             fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-                                            <path fill-rule="evenodd"
-                                                  d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
-                                        </svg>
-                                    </button>
+                        <div class="row justify-content-center">
+                            <!-- 페이징 -->
+                            <th:block th:if="${pages != null}">
+                                <div class="d-flex justify-content-center">
+                                    <div class="btn-group">
+                                        <button type="button" class="btn btn-sm previous"
+                                                th:onclick="|location.href='@{/user/my/rct/order(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
+                                                th:disabled="${currentPage == 1}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                                 fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+                                                <path fill-rule="evenodd"
+                                                      d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                                            </svg>
+                                        </button>
+                                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">
+                                            <button type="button" class="btn btn-sm me-2 pages"
+                                                    th:text="${p}"
+                                                    th:onclick="|location.href='@{/user/my/rct/order(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
+                                        </th:block>
+                                        <button type="button" class="btn btn-sm  next"
+                                                th:onclick="|location.href='@{/user/my/rct/order(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
+                                                th:disabled="${currentPage == pages}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                                 fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+                                                <path fill-rule="evenodd"
+                                                      d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                                            </svg>
+                                        </button>
+                                    </div>
                                 </div>
-                            </div>
-                        </th:block>
-                    </div>
-                </div><!--테이블 및 페이징 포함-->
+                            </th:block>
+                        </div>
+                    </div><!--테이블 및 페이징 포함-->
+                </div> <!--본화면-->
             </div> <!--본화면-->
-        </div> <!--본화면-->
 
 
-        <!--수정전-->
-        <!--    <div class="col-md-9">-->
-        <!--        <div class="review-list">-->
-        <!--            <h2>프리랜서 구매 목록</h2>-->
-        <!--            <form id="filter-and-sort-form" th:action="@{/user/my/rct/order}" method="get">-->
-        <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
-        <!--                <label>-->
-        <!--                    <select name="searchBy">-->
-        <!--                        <option value="boardNo" th:selected="${searchBy == 'boardNo'}">구매상품번호(추후 구매상품명)</option>-->
-        <!--                    </select>-->
-        <!--                </label>-->
-        <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
+            <!--수정전-->
+            <!--    <div class="col-md-9">-->
+            <!--        <div class="review-list">-->
+            <!--            <h2>프리랜서 구매 목록</h2>-->
+            <!--            <form id="filter-and-sort-form" th:action="@{/user/my/rct/order}" method="get">-->
+            <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
+            <!--                <label>-->
+            <!--                    <select name="searchBy">-->
+            <!--                        <option value="boardNo" th:selected="${searchBy == 'boardNo'}">구매상품번호(추후 구매상품명)</option>-->
+            <!--                    </select>-->
+            <!--                </label>-->
+            <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
 
-        <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
-        <!--                <button type="submit">검색</button>-->
+            <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
+            <!--                <button type="submit">검색</button>-->
 
-        <!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
-        <!--                <label>-->
-        <!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">마감된 작업-->
-        <!--                </label>-->
+            <!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
+            <!--                <label>-->
+            <!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">마감된 작업-->
+            <!--                </label>-->
 
-        <!--                <label>-->
-        <!--                    <select name="orderBy" onchange="submitForm()">-->
-        <!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최근주문순</option>-->
-        <!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
-        <!--                        <option value="expensive" th:selected="${orderBy == 'expensive'}">결제금액높은순</option>-->
-        <!--                        <option value="cheap" th:selected="${orderBy == 'cheap'}">결제금액낮은순</option>-->
-        <!--                    </select>-->
-        <!--                </label>-->
-        <!--            </form>-->
+            <!--                <label>-->
+            <!--                    <select name="orderBy" onchange="submitForm()">-->
+            <!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최근주문순</option>-->
+            <!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
+            <!--                        <option value="expensive" th:selected="${orderBy == 'expensive'}">결제금액높은순</option>-->
+            <!--                        <option value="cheap" th:selected="${orderBy == 'cheap'}">결제금액낮은순</option>-->
+            <!--                    </select>-->
+            <!--                </label>-->
+            <!--            </form>-->
 
 
-        <!--&lt;!&ndash;            <form id="filter-form" th:action="@{/user/my/rct/order}" method="get">&ndash;&gt;-->
-        <!--&lt;!&ndash;                <label>&ndash;&gt;-->
-        <!--&lt;!&ndash;                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="toggleCheckboxValue()">마감된 작업&ndash;&gt;-->
-        <!--&lt;!&ndash;                </label>&ndash;&gt;-->
-        <!--&lt;!&ndash;            </form>&ndash;&gt;-->
-        <!--            <table>-->
-        <!--                <thead>-->
-        <!--                <tr>-->
-        <!--                    <th>주문 번호</th>-->
-        <!--                    <th>구매자</th>-->
-        <!--                    <th>구매상품</th>-->
-        <!--                    <th>구매 갯수</th>-->
-        <!--                    <th>결제 금액</th>-->
-        <!--                    <th>구매 일자</th>-->
-        <!--                    <th>작업 상태</th>-->
-        <!--                </tr>-->
-        <!--                </thead>-->
-        <!--                <tbody>-->
-        <!--                <tr th:each="myRctOrder : ${myRctOrders}" class="clickable-row" th:attr="data-href=@{/recruit/free/view(no=${myRctOrder.boardNo})}">-->
-        <!--                    <td th:text="${myRctOrder.orderNo}">주문 번호</td>-->
-        <!--                    <td th:text="${myRctOrder.memberNo}">구매자</td>-->
-        <!--                    <td th:text="${myRctOrder.boardNo}">구매상품</td>-->
-        <!--                    <td th:text="${myRctOrder.quantity}">구매 갯수</td>-->
-        <!--                    <td th:text="${myRctOrder.price}">결제 금액</td>-->
-        <!--                    <td th:text="${myRctOrder.orderedDate}">구매 일자</td>-->
-        <!--                    <td th:text="${myRctOrder.status}">작업 상태</td>-->
-        <!--                </tr>-->
-        <!--                </tbody>-->
-        <!--            </table>-->
-        <!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
-        <!--            <th:block th:if="${pages != null}">-->
-        <!--                <div class="d-flex justify-content-center">-->
-        <!--                    <div class="btn-group">-->
-        <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/rct/order(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
-        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
-        <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
-        <!--                            </svg>-->
-        <!--                        </button>-->
-        <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
-        <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
-        <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/rct/order(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
-        <!--                        </th:block>-->
-        <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/rct/order(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
-        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
-        <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
-        <!--                            </svg>-->
-        <!--                        </button>-->
-        <!--                    </div>-->
-        <!--                </div>-->
-        <!--            </th:block>-->
-        <!--        </div>-->
-        <!--    </div>-->
+            <!--&lt;!&ndash;            <form id="filter-form" th:action="@{/user/my/rct/order}" method="get">&ndash;&gt;-->
+            <!--&lt;!&ndash;                <label>&ndash;&gt;-->
+            <!--&lt;!&ndash;                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="toggleCheckboxValue()">마감된 작업&ndash;&gt;-->
+            <!--&lt;!&ndash;                </label>&ndash;&gt;-->
+            <!--&lt;!&ndash;            </form>&ndash;&gt;-->
+            <!--            <table>-->
+            <!--                <thead>-->
+            <!--                <tr>-->
+            <!--                    <th>주문 번호</th>-->
+            <!--                    <th>구매자</th>-->
+            <!--                    <th>구매상품</th>-->
+            <!--                    <th>구매 갯수</th>-->
+            <!--                    <th>결제 금액</th>-->
+            <!--                    <th>구매 일자</th>-->
+            <!--                    <th>작업 상태</th>-->
+            <!--                </tr>-->
+            <!--                </thead>-->
+            <!--                <tbody>-->
+            <!--                <tr th:each="myRctOrder : ${myRctOrders}" class="clickable-row" th:attr="data-href=@{/recruit/free/view(no=${myRctOrder.boardNo})}">-->
+            <!--                    <td th:text="${myRctOrder.orderNo}">주문 번호</td>-->
+            <!--                    <td th:text="${myRctOrder.memberNo}">구매자</td>-->
+            <!--                    <td th:text="${myRctOrder.boardNo}">구매상품</td>-->
+            <!--                    <td th:text="${myRctOrder.quantity}">구매 갯수</td>-->
+            <!--                    <td th:text="${myRctOrder.price}">결제 금액</td>-->
+            <!--                    <td th:text="${myRctOrder.orderedDate}">구매 일자</td>-->
+            <!--                    <td th:text="${myRctOrder.status}">작업 상태</td>-->
+            <!--                </tr>-->
+            <!--                </tbody>-->
+            <!--            </table>-->
+            <!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
+            <!--            <th:block th:if="${pages != null}">-->
+            <!--                <div class="d-flex justify-content-center">-->
+            <!--                    <div class="btn-group">-->
+            <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/rct/order(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
+            <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
+            <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
+            <!--                            </svg>-->
+            <!--                        </button>-->
+            <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
+            <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
+            <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/rct/order(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
+            <!--                        </th:block>-->
+            <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/rct/order(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
+            <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
+            <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
+            <!--                            </svg>-->
+            <!--                        </button>-->
+            <!--                    </div>-->
+            <!--                </div>-->
+            <!--            </th:block>-->
+            <!--        </div>-->
+            <!--    </div>-->
+        </div>
     </div>
 </div>
 <div th:replace="common/footer.html"></div>

--- a/src/main/resources/templates/user/mypage_rct_order.html
+++ b/src/main/resources/templates/user/mypage_rct_order.html
@@ -124,33 +124,35 @@
         </div>
     </div>
 </div>
-<div class="row">
-    <aside class="col-md-3 px-4">
-        <div class="row">
-            <div class="col-3"></div>
-            <div class="col-6">
-                <div class="panel">
-                    <ul class="list-group">
-                        <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
-                        <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-                        <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color: #03C75A;">나의 채용</a></li>
-                        <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-                        <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                        <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-                    </ul>
+<div class="container" style="padding:0;">
+    <div class="row">
+        <aside class="col-md-3 px-4">
+            <div class="row">
+                <div class="col-3"></div>
+                <div class="col-6">
+                    <div class="panel">
+                        <ul class="list-group">
+                            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
+                            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2" style="color: #03C75A;">나의 채용</a>
+                            </li>
+                            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+                        </ul>
+                    </div>
                 </div>
             </div>
-        </div>
-    </aside>
-<!--    <script>-->
-<!--        function toggleCheckboxValue() {-->
-<!--            const checkbox = document.getElementById('isToggledCheckbox');-->
-<!--            if(!checkbox.checked) checkbox.value = 'N';-->
-<!--            else checkbox.value = 'Y';-->
-<!--            document.getElementById('filter-form').submit();-->
-<!--        }-->
-<!--    </script>-->
-    <script> // toggle + sorting
+        </aside>
+        <!--    <script>-->
+        <!--        function toggleCheckboxValue() {-->
+        <!--            const checkbox = document.getElementById('isToggledCheckbox');-->
+        <!--            if(!checkbox.checked) checkbox.value = 'N';-->
+        <!--            else checkbox.value = 'Y';-->
+        <!--            document.getElementById('filter-form').submit();-->
+        <!--        }-->
+        <!--    </script>-->
+        <script> // toggle + sorting
         function updateCheckboxValueAndSubmit() {
             const checkbox = document.getElementById('isToggledCheckbox');
             const form = document.getElementById('filter-and-sort-form');
@@ -163,383 +165,443 @@
         function submitForm() {
             document.getElementById('filter-and-sort-form').submit();
         }
-    </script>
-    <style>
-        .form-select {
-        background-color : #FCFCFC;
-        border : none;
-        width : 100%;
-        height : 50px;
-        }
-        select {
-        color : #828282;
-        }
-        .form-control {
-        background-color : #FCFCFC;
-        border : none;
-        width : 100%;
-        height : 50px;
-        }
+        </script>
+        <style>
+            .form-select {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
+            }
+            select {
+            color : #828282;
+            }
+            .form-control {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
+            }
 
 
-        .form-control::placeholder {
-        color : #BBBBBB;
-        }
+            .form-control::placeholder {
+            color : #BBBBBB;
+            }
 
-        .date-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    background-color: #8E4B6E;
-    color: white;
-    border-radius: 10px;
-    text-align:center;
-    font-family: "Work Sans", sans-serif;
-}
+            .date-container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        background-color: #8E4B6E;
+        color: white;
+        border-radius: 10px;
+        text-align:center;
+        font-family: "Work Sans", sans-serif;
+    }
 
-.month {
-    font-size: 1.1rem; /* M의 크기를 설정 */
-    font-weight: 550;
-    line-height: 1;
-}
+    .month {
+        font-size: 1.1rem; /* M의 크기를 설정 */
+        font-weight: 550;
+        line-height: 1;
+    }
 
-.year {
-    font-size: 0.65rem; /* yyyy의 크기를 설정 */
-    font-weight: 400;
-}
-:root {
-    --background-color-light: #FFFFFF;
-    --text-color-light: #000000;
-    --toggle-background-light: #CCCCCC;
-    --toggle-ball-light: #FFFFFF;
+    .year {
+        font-size: 0.65rem; /* yyyy의 크기를 설정 */
+        font-weight: 400;
+    }
+    :root {
+        --background-color-light: #FFFFFF;
+        --text-color-light: #000000;
+        --toggle-background-light: #CCCCCC;
+        --toggle-ball-light: #FFFFFF;
 
-    --background-color-dark: #333333;
-    --text-color-dark: #FFFFFF;
-    --toggle-background-dark: #03C75A;
-    --toggle-ball-dark: #FFFFFF;
+        --background-color-dark: #333333;
+        --text-color-dark: #FFFFFF;
+        --toggle-background-dark: #03C75A;
+        --toggle-ball-dark: #FFFFFF;
 
-    --font-size-base: 32px; /* 기본 텍스트 크기 */
-    --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
-}
+        --font-size-base: 32px; /* 기본 텍스트 크기 */
+        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+    }
 
 
 
-.toggle-switch {
-    position: relative;
-    display: inline-block;
-    width: 62px; /* 너비 조정 */
-    height: 38px; /* 높이 조정 */
-}
+    .toggle-switch {
+        position: relative;
+        display: inline-block;
+        width: 62px; /* 너비 조정 */
+        height: 38px; /* 높이 조정 */
+    }
 
-.toggle-switch .checkbox {
-    opacity: 0;
-    width: 0;
-    height: 0;
-}
-#isToggledCheckbox {
-     opacity: 0;
+    .toggle-switch .checkbox {
+        opacity: 0;
         width: 0;
         height: 0;
-}
+    }
+    #isToggledCheckbox {
+         opacity: 0;
+            width: 0;
+            height: 0;
+    }
 
-.toggle-switch .label {
-    position: absolute;
-    cursor: pointer;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: var(--toggle-background-light);
-    transition: background-color 0.4s;
-    border-radius: 38px; /* 둥근 모서리 반경 조정 */
-}
+    .toggle-switch .label {
+        position: absolute;
+        cursor: pointer;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: var(--toggle-background-light);
+        transition: background-color 0.4s;
+        border-radius: 38px; /* 둥근 모서리 반경 조정 */
+    }
 
-.toggle-switch .label:before {
-    position: absolute;
-    content: "";
-    height: 30px; /* 내부 원 높이 조정 */
-    width: 30px; /* 내부 원 너비 조정 */
-    left: 2px;
-    bottom: 0px;
-    background-color: var(--toggle-ball-light);
-    transition: transform 0.4s;
-    border-radius: 50%;
-}
+    .toggle-switch .label:before {
+        position: absolute;
+        content: "";
+        height: 30px; /* 내부 원 높이 조정 */
+        width: 30px; /* 내부 원 너비 조정 */
+        left: 2px;
+        bottom: 0px;
+        background-color: var(--toggle-ball-light);
+        transition: transform 0.4s;
+        border-radius: 50%;
+    }
 
-.toggle-switch input:checked + .label {
-    background-color: var(--toggle-background-dark);
-}
+    .toggle-switch input:checked + .label {
+        background-color: var(--toggle-background-dark);
+    }
 
-.toggle-switch input:checked + .label:before {
-    transform: translateX(28px); /* 내부 원 이동 거리 조정 */
-}
+    .toggle-switch input:checked + .label:before {
+        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+    }
 
-         #absdiv {
-            position: relative;
-            top: 60px; /* Move down by 20px from its current position */
-            z-index : 1000;
-        }
+             #absdiv {
+                position: relative;
+                top: 60px; /* Move down by 20px from its current position */
+                z-index : 1000;
+            }
 
-        #searchbutton {
-            background-color: #828282;
-        }
-    </style>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
-    <div class="col-md-9">
-        <div class="row" style="color: #828282;">
-            <div class="col-11">
-                <div class="row">
-                    <div class="col-12">
-                        <form id="filter-and-sort-form" th:action="@{/user/my/rct/order}" method="get">
-                            <div class="row">
-                                <div class="col-7">
-                                    <div class="row justify-content-start m-0">
-                                        <div class="col-4">
-                                            <!-- 검색 조건 -->
+            #searchbutton {
+                background-color: #828282;
+            }
+        </style>
+        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+              rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+              rel="stylesheet">
+        <div class="col-md-9">
+            <div class="row" style="color: #828282;">
+                <div class="col-11">
+                    <div class="row">
+                        <div class="col-12">
+                            <form id="filter-and-sort-form" th:action="@{/user/my/rct/order}" method="get">
+                                <div class="row">
+                                    <div class="col-7">
+                                        <div class="row justify-content-start m-0">
+                                            <div class="col-4">
+                                                <!-- 검색 조건 -->
+                                                <label>
+                                                    <select class="form-select px-3" name="searchBy">
+                                                        <option value="title" th:selected="${searchBy == 'title'}">
+                                                            구매상품명
+                                                        </option>
+                                                        <option value="nickname"
+                                                                th:selected="${searchBy == 'nickname'}">프리랜서닉네임
+                                                        </option>
+                                                    </select>
+                                                </label>
+                                            </div>
+                                            <div class="col-6">
+                                                <input class="form-control px-3" type="text" name="searchTerm"
+                                                       placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
+                                            </div>
+                                            <div class="col-2">
+                                                <!-- 검색 버튼 -->
+                                                <button id="searchbutton" type="submit" class="btn btn-primary">검색
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-1" style=""></div>
+                                    <div class="col-4">
+                                        <div class="row justify-content-end">
+                                            <!-- 정렬 또는 토글2 -->
                                             <label>
-                                                <select class="form-select px-3" name="searchBy">
-                                                    <option value="title" th:selected="${searchBy == 'title'}">구매상품명</option>
-                                                    <option value="nickname" th:selected="${searchBy == 'nickname'}">프리랜서닉네임</option>
+                                                <select class="form-select px-3" name="orderBy" onchange="submitForm()">
+                                                    <option value="recent" th:selected="${orderBy == 'recent'}">최근주문순
+                                                    </option>
+                                                    <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순
+                                                    </option>
+                                                    <option value="expensive" th:selected="${orderBy == 'expensive'}">
+                                                        결제금액높은순
+                                                    </option>
+                                                    <option value="cheap" th:selected="${orderBy == 'cheap'}">결제금액낮은순
+                                                    </option>
                                                 </select>
                                             </label>
                                         </div>
-                                        <div class="col-6">
-                                            <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
-                                        </div>
-                                        <div class="col-2">
-                                            <!-- 검색 버튼 -->
-                                            <button id="searchbutton" type="submit" class="btn btn-primary">검색</button>
-                                        </div>
                                     </div>
-                                </div>
-                                <div class="col-1" style=""></div>
-                                <div class="col-4">
-                                    <div class="row justify-content-end">
-                                        <!-- 정렬 또는 토글2 -->
-                                        <label>
-                                            <select class="form-select px-3" name="orderBy" onchange="submitForm()">
-                                                <option value="recent" th:selected="${orderBy == 'recent'}">최근주문순</option>
-                                                <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>
-                                                <option value="expensive" th:selected="${orderBy == 'expensive'}">결제금액높은순</option>
-                                                <option value="cheap" th:selected="${orderBy == 'cheap'}">결제금액낮은순</option>
-                                            </select>
-                                        </label>
-                                    </div>
-                                </div>
-                            </div> <!--검색, 소팅 (토글X)-->
-                            <div class="row justify-content-around">
-                                <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                <div class="col-3" style="padding: 0 1.2rem;">
-                                    <div id="absdiv" class="row justify-content-end">
-                                        <div class="col-3">
-                                            <div class="toggle-switch">
-                                                <!-- 정렬 또는 토글1 -->
-                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">
-                                                <label for="isToggledCheckbox" class="label">
-                                                    <div class="ball"></div>
-                                                </label>
+                                </div> <!--검색, 소팅 (토글X)-->
+                                <div class="row justify-content-around">
+                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                    <div class="col-3" style="padding: 0 1.2rem;">
+                                        <div id="absdiv" class="row justify-content-end">
+                                            <div class="col-3">
+                                                <div class="toggle-switch">
+                                                    <!-- 정렬 또는 토글1 -->
+                                                    <input type="checkbox" name="isToggled" id="isToggledCheckbox"
+                                                           value="Y" th:checked="${isToggled == 'Y'}"
+                                                           onchange="updateCheckboxValueAndSubmit()">
+                                                    <label for="isToggledCheckbox" class="label">
+                                                        <div class="ball"></div>
+                                                    </label>
+                                                </div>
+                                            </div>
+                                            <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">
+                                                마감된 작업
                                             </div>
                                         </div>
-                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">마감된 작업</div>
                                     </div>
-                                </div>
-                            </div> <!--토글-->
-                        </form>
-                    </div>
-                </div>
-                <div class="row justify-content-around">
-                    <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
-                        <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
-                            <div class="col-3 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:each="myRctOrder, iterStat : ${myRctOrders}" th:attr="data-href=@{/recruit/free/view(no=${myRctOrder.boardNo})}" th:if="${iterStat.index < 3}">
-                                <div class="row justify-content-center">
-                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                        <div class="date-container px-2 py-1">
-                                            <div class="month" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctOrder.orderedDate)}"></div>
-                                            <div class="year" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctOrder.orderedDate)}"></div>
-                                        </div>
-                                    </div>
-                                    <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                    <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                    <!--                                    </div>-->
-                                    <div class="col-4" style="color: #333333; font-size: 0.8rem; font-weight: 530;" th:text="${myRctOrder.nickname}">닉네임</div>
-                                    <div class="col-4" style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;" th:text="${myRctOrder.formattedOrderedDate}">시간</div>
-                                </div>
-                                <div class="row justify-content-center">
-                                    <div class="col-10" style="color: white;" th:text="${myRctOrder.boardNo}">사진</div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" th:text="${myRctOrder.title}">이름</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${myRctOrder.content}">내용</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                </div>
-
-                            </div>
-                            <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
-                            <div class="col-3" th:if="${myRctOrders.size() == 0}"></div>
-                            <div class="col-3" th:if="${myRctOrders.size() == 0 || myRctOrders.size() == 1}"></div>
-                            <div class="col-3" th:if="${myRctOrders.size() == 0 || myRctOrders.size() == 1 || myRctOrders.size() == 2}"></div>
-                        </div>
-                        <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
-                            <div class="col-3 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:each="myRctOrder, iterStat : ${myRctOrders}" th:attr="data-href=@{/recruit/free/view(no=${myRctOrder.boardNo})}"  th:if="${iterStat.index >= 3}">
-                                <div class="row justify-content-center">
-                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                        <div class="date-container px-2 py-1">
-                                            <div class="month" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctOrder.orderedDate)}"></div>
-                                            <div class="year" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctOrder.orderedDate)}"></div>
-                                        </div>
-                                    </div>
-                                    <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                    <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                    <!--                                    </div>-->
-                                    <div class="col-4" style="color: #333333; font-size: 0.8rem; font-weight: 530;" th:text="${myRctOrder.nickname}">닉네임</div>
-                                    <div class="col-4" style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD;" th:text="${myRctOrder.formattedOrderedDate}">시간</div>
-                                </div>
-                                <div class="row justify-content-center">
-                                    <div class="col-10" style="color: white;" th:text="${myRctOrder.boardNo}">사진</div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" th:text="${myRctOrder.title}">이름</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${myRctOrder.content}">내용</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                </div>
-
-                            </div>
-
-                            <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
-                            <div class="col-3" th:if="${myRctOrders.size() <= 3}"></div>
-                            <div class="col-3" th:if="${myRctOrders.size() <= 3 || myRctOrders.size() == 4}"></div>
-                            <div class="col-3" th:if="${myRctOrders.size() <= 3 || myRctOrders.size() == 4 || myRctOrders.size() == 5}"></div>
+                                </div> <!--토글-->
+                            </form>
                         </div>
                     </div>
-                </div>
-                <div class="row justify-content-center">
-                    <!-- 페이징 -->
-                    <th:block th:if="${pages != null}">
-                        <div class="d-flex justify-content-center">
-                            <div class="btn-group">
-                                <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/rct/order(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-                                        <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                                    </svg>
-                                </button>
-                                <th:block th:each="p : ${#numbers.sequence(1, pages)}">
-                                    <button type="button" class="btn btn-sm me-2 pages"
-                                            th:text="${p}" th:onclick="|location.href='@{/user/my/rct/order(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
-                                </th:block>
-                                <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/rct/order(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-                                        <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
-                                    </svg>
-                                </button>
+                    <div class="row justify-content-around">
+                        <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
+                            <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
+                                <div class="col-3 clickable-row"
+                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                     th:each="myRctOrder, iterStat : ${myRctOrders}"
+                                     th:attr="data-href=@{/recruit/free/view(no=${myRctOrder.boardNo})}"
+                                     th:if="${iterStat.index < 3}">
+                                    <div class="row justify-content-center">
+                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                             style="aspect-ratio: 1; border-radius: 5px;">
+                                            <div class="date-container px-2 py-1">
+                                                <div class="month"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctOrder.orderedDate)}"></div>
+                                                <div class="year"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctOrder.orderedDate)}"></div>
+                                            </div>
+                                        </div>
+                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                        <!--                                    </div>-->
+                                        <div class="col-4" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
+                                             th:text="${myRctOrder.nickname}">닉네임
+                                        </div>
+                                        <div class="col-4"
+                                             style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
+                                             th:text="${myRctOrder.formattedOrderedDate}">시간
+                                        </div>
+                                    </div>
+                                    <div class="row justify-content-center">
+                                        <div class="col-10" style="color: white;" th:text="${myRctOrder.boardNo}">사진
+                                        </div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                             th:text="${myRctOrder.title}">이름
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                             th:text="${myRctOrder.content}">내용
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                    </div>
+
+                                </div>
+                                <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
+                                <div class="col-3" th:if="${myRctOrders.size() == 0}"></div>
+                                <div class="col-3" th:if="${myRctOrders.size() == 0 || myRctOrders.size() == 1}"></div>
+                                <div class="col-3"
+                                     th:if="${myRctOrders.size() == 0 || myRctOrders.size() == 1 || myRctOrders.size() == 2}"></div>
+                            </div>
+                            <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
+                                <div class="col-3 clickable-row"
+                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                     th:each="myRctOrder, iterStat : ${myRctOrders}"
+                                     th:attr="data-href=@{/recruit/free/view(no=${myRctOrder.boardNo})}"
+                                     th:if="${iterStat.index >= 3}">
+                                    <div class="row justify-content-center">
+                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                             style="aspect-ratio: 1; border-radius: 5px;">
+                                            <div class="date-container px-2 py-1">
+                                                <div class="month"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(myRctOrder.orderedDate)}"></div>
+                                                <div class="year"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(myRctOrder.orderedDate)}"></div>
+                                            </div>
+                                        </div>
+                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                        <!--                                    </div>-->
+                                        <div class="col-4" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
+                                             th:text="${myRctOrder.nickname}">닉네임
+                                        </div>
+                                        <div class="col-4"
+                                             style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD;"
+                                             th:text="${myRctOrder.formattedOrderedDate}">시간
+                                        </div>
+                                    </div>
+                                    <div class="row justify-content-center">
+                                        <div class="col-10" style="color: white;" th:text="${myRctOrder.boardNo}">사진
+                                        </div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                             th:text="${myRctOrder.title}">이름
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                             th:text="${myRctOrder.content}">내용
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                    </div>
+
+                                </div>
+
+                                <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
+                                <div class="col-3" th:if="${myRctOrders.size() <= 3}"></div>
+                                <div class="col-3" th:if="${myRctOrders.size() <= 3 || myRctOrders.size() == 4}"></div>
+                                <div class="col-3"
+                                     th:if="${myRctOrders.size() <= 3 || myRctOrders.size() == 4 || myRctOrders.size() == 5}"></div>
                             </div>
                         </div>
-                    </th:block>
-                </div>
-            </div><!--테이블 및 페이징 포함-->
+                    </div>
+                    <div class="row justify-content-center">
+                        <!-- 페이징 -->
+                        <th:block th:if="${pages != null}">
+                            <div class="d-flex justify-content-center">
+                                <div class="btn-group">
+                                    <button type="button" class="btn btn-sm previous"
+                                            th:onclick="|location.href='@{/user/my/rct/order(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
+                                            th:disabled="${currentPage == 1}">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                             fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+                                            <path fill-rule="evenodd"
+                                                  d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                                        </svg>
+                                    </button>
+                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">
+                                        <button type="button" class="btn btn-sm me-2 pages"
+                                                th:text="${p}"
+                                                th:onclick="|location.href='@{/user/my/rct/order(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
+                                    </th:block>
+                                    <button type="button" class="btn btn-sm  next"
+                                            th:onclick="|location.href='@{/user/my/rct/order(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
+                                            th:disabled="${currentPage == pages}">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                             fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+                                            <path fill-rule="evenodd"
+                                                  d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                                        </svg>
+                                    </button>
+                                </div>
+                            </div>
+                        </th:block>
+                    </div>
+                </div><!--테이블 및 페이징 포함-->
+            </div> <!--본화면-->
         </div> <!--본화면-->
-    </div> <!--본화면-->
 
 
+        <!--수정전-->
+        <!--    <div class="col-md-9">-->
+        <!--        <div class="review-list">-->
+        <!--            <h2>프리랜서 구매 목록</h2>-->
+        <!--            <form id="filter-and-sort-form" th:action="@{/user/my/rct/order}" method="get">-->
+        <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
+        <!--                <label>-->
+        <!--                    <select name="searchBy">-->
+        <!--                        <option value="boardNo" th:selected="${searchBy == 'boardNo'}">구매상품번호(추후 구매상품명)</option>-->
+        <!--                    </select>-->
+        <!--                </label>-->
+        <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
+
+        <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
+        <!--                <button type="submit">검색</button>-->
+
+        <!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
+        <!--                <label>-->
+        <!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">마감된 작업-->
+        <!--                </label>-->
+
+        <!--                <label>-->
+        <!--                    <select name="orderBy" onchange="submitForm()">-->
+        <!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최근주문순</option>-->
+        <!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
+        <!--                        <option value="expensive" th:selected="${orderBy == 'expensive'}">결제금액높은순</option>-->
+        <!--                        <option value="cheap" th:selected="${orderBy == 'cheap'}">결제금액낮은순</option>-->
+        <!--                    </select>-->
+        <!--                </label>-->
+        <!--            </form>-->
 
 
-
-
-
-    <!--수정전-->
-<!--    <div class="col-md-9">-->
-<!--        <div class="review-list">-->
-<!--            <h2>프리랜서 구매 목록</h2>-->
-<!--            <form id="filter-and-sort-form" th:action="@{/user/my/rct/order}" method="get">-->
-<!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
-<!--                <label>-->
-<!--                    <select name="searchBy">-->
-<!--                        <option value="boardNo" th:selected="${searchBy == 'boardNo'}">구매상품번호(추후 구매상품명)</option>-->
-<!--                    </select>-->
-<!--                </label>-->
-<!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
-
-<!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
-<!--                <button type="submit">검색</button>-->
-
-<!--                &lt;!&ndash; 정렬 또는 토글 &ndash;&gt;-->
-<!--                <label>-->
-<!--                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">마감된 작업-->
-<!--                </label>-->
-
-<!--                <label>-->
-<!--                    <select name="orderBy" onchange="submitForm()">-->
-<!--                        <option value="recent" th:selected="${orderBy == 'recent'}">최근주문순</option>-->
-<!--                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
-<!--                        <option value="expensive" th:selected="${orderBy == 'expensive'}">결제금액높은순</option>-->
-<!--                        <option value="cheap" th:selected="${orderBy == 'cheap'}">결제금액낮은순</option>-->
-<!--                    </select>-->
-<!--                </label>-->
-<!--            </form>-->
-
-
-
-
-<!--&lt;!&ndash;            <form id="filter-form" th:action="@{/user/my/rct/order}" method="get">&ndash;&gt;-->
-<!--&lt;!&ndash;                <label>&ndash;&gt;-->
-<!--&lt;!&ndash;                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="toggleCheckboxValue()">마감된 작업&ndash;&gt;-->
-<!--&lt;!&ndash;                </label>&ndash;&gt;-->
-<!--&lt;!&ndash;            </form>&ndash;&gt;-->
-<!--            <table>-->
-<!--                <thead>-->
-<!--                <tr>-->
-<!--                    <th>주문 번호</th>-->
-<!--                    <th>구매자</th>-->
-<!--                    <th>구매상품</th>-->
-<!--                    <th>구매 갯수</th>-->
-<!--                    <th>결제 금액</th>-->
-<!--                    <th>구매 일자</th>-->
-<!--                    <th>작업 상태</th>-->
-<!--                </tr>-->
-<!--                </thead>-->
-<!--                <tbody>-->
-<!--                <tr th:each="myRctOrder : ${myRctOrders}" class="clickable-row" th:attr="data-href=@{/recruit/free/view(no=${myRctOrder.boardNo})}">-->
-<!--                    <td th:text="${myRctOrder.orderNo}">주문 번호</td>-->
-<!--                    <td th:text="${myRctOrder.memberNo}">구매자</td>-->
-<!--                    <td th:text="${myRctOrder.boardNo}">구매상품</td>-->
-<!--                    <td th:text="${myRctOrder.quantity}">구매 갯수</td>-->
-<!--                    <td th:text="${myRctOrder.price}">결제 금액</td>-->
-<!--                    <td th:text="${myRctOrder.orderedDate}">구매 일자</td>-->
-<!--                    <td th:text="${myRctOrder.status}">작업 상태</td>-->
-<!--                </tr>-->
-<!--                </tbody>-->
-<!--            </table>-->
-<!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
-<!--            <th:block th:if="${pages != null}">-->
-<!--                <div class="d-flex justify-content-center">-->
-<!--                    <div class="btn-group">-->
-<!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/rct/order(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
-<!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
-<!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
-<!--                            </svg>-->
-<!--                        </button>-->
-<!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
-<!--                            <button type="button" class="btn btn-sm me-2 pages"-->
-<!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/rct/order(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
-<!--                        </th:block>-->
-<!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/rct/order(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
-<!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
-<!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
-<!--                            </svg>-->
-<!--                        </button>-->
-<!--                    </div>-->
-<!--                </div>-->
-<!--            </th:block>-->
-<!--        </div>-->
-<!--    </div>-->
+        <!--&lt;!&ndash;            <form id="filter-form" th:action="@{/user/my/rct/order}" method="get">&ndash;&gt;-->
+        <!--&lt;!&ndash;                <label>&ndash;&gt;-->
+        <!--&lt;!&ndash;                    <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="toggleCheckboxValue()">마감된 작업&ndash;&gt;-->
+        <!--&lt;!&ndash;                </label>&ndash;&gt;-->
+        <!--&lt;!&ndash;            </form>&ndash;&gt;-->
+        <!--            <table>-->
+        <!--                <thead>-->
+        <!--                <tr>-->
+        <!--                    <th>주문 번호</th>-->
+        <!--                    <th>구매자</th>-->
+        <!--                    <th>구매상품</th>-->
+        <!--                    <th>구매 갯수</th>-->
+        <!--                    <th>결제 금액</th>-->
+        <!--                    <th>구매 일자</th>-->
+        <!--                    <th>작업 상태</th>-->
+        <!--                </tr>-->
+        <!--                </thead>-->
+        <!--                <tbody>-->
+        <!--                <tr th:each="myRctOrder : ${myRctOrders}" class="clickable-row" th:attr="data-href=@{/recruit/free/view(no=${myRctOrder.boardNo})}">-->
+        <!--                    <td th:text="${myRctOrder.orderNo}">주문 번호</td>-->
+        <!--                    <td th:text="${myRctOrder.memberNo}">구매자</td>-->
+        <!--                    <td th:text="${myRctOrder.boardNo}">구매상품</td>-->
+        <!--                    <td th:text="${myRctOrder.quantity}">구매 갯수</td>-->
+        <!--                    <td th:text="${myRctOrder.price}">결제 금액</td>-->
+        <!--                    <td th:text="${myRctOrder.orderedDate}">구매 일자</td>-->
+        <!--                    <td th:text="${myRctOrder.status}">작업 상태</td>-->
+        <!--                </tr>-->
+        <!--                </tbody>-->
+        <!--            </table>-->
+        <!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
+        <!--            <th:block th:if="${pages != null}">-->
+        <!--                <div class="d-flex justify-content-center">-->
+        <!--                    <div class="btn-group">-->
+        <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/rct/order(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
+        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
+        <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
+        <!--                            </svg>-->
+        <!--                        </button>-->
+        <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
+        <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
+        <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/rct/order(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
+        <!--                        </th:block>-->
+        <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/rct/order(isToggled=${isToggled}, orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
+        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
+        <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
+        <!--                            </svg>-->
+        <!--                        </button>-->
+        <!--                    </div>-->
+        <!--                </div>-->
+        <!--            </th:block>-->
+        <!--        </div>-->
+        <!--    </div>-->
+    </div>
 </div>
 <div th:replace="common/footer.html"></div>
 </body>

--- a/src/main/resources/templates/user/mypage_rct_order.html
+++ b/src/main/resources/templates/user/mypage_rct_order.html
@@ -351,7 +351,7 @@
                                 }
 
                                 .search-container button i {
-                                    color: #666;
+                                    color: #A6AAB5;
                                 }
 
                                 .search-container button:hover i {

--- a/src/main/resources/templates/user/mypage_rct_order.html
+++ b/src/main/resources/templates/user/mypage_rct_order.html
@@ -134,7 +134,7 @@
     <div class="row">
         <aside class="col-md-3 px-4">
             <div class="row">
-                <div class="col-3"></div>
+                <div class="col-1"></div>
                 <div class="col-6">
                     <div class="panel">
                         <ul class="list-group">

--- a/src/main/resources/templates/user/mypage_rct_order.html
+++ b/src/main/resources/templates/user/mypage_rct_order.html
@@ -112,12 +112,12 @@
             <div class="col-md-9">
                 <nav class="navbar navbar-expand-md">
                     <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                        <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 등록 현황</a></li>
                         <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
-                        <li><a th:href="@{/user/my/rct/creator}" class="nav-link px-2">창작자 등록 현황</a></li>
-                        <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a></li>
-                        <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
-                        <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2" style="color:#000;">프리랜서 구매 목록</a>
+                        <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a>
                         </li>
+                        <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
+                        <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2" style="color:#000;">프리랜서 구매 목록</a></li>
                     </ul>
                 </nav>
             </div>

--- a/src/main/resources/templates/user/mypage_rct_order.html
+++ b/src/main/resources/templates/user/mypage_rct_order.html
@@ -104,20 +104,23 @@
   }
 </style>
 <div class="jumbotron">
-    <div class="row">
-        <div class="col-md-3 px-4">
-            <h3>나의 채용</h3>
-        </div>
-        <div class="col-md-9">
-            <nav class="navbar navbar-expand-md">
-                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                    <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
-                    <li><a th:href="@{/user/my/rct/creator}" class="nav-link px-2">창작자 등록 현황</a></li>
-                    <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a></li>
-                    <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
-                    <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2" style="color:#000;">프리랜서 구매 목록</a></li>
-                </ul>
-            </nav>
+    <div class="container">
+        <div class="row">
+            <div class="col-md-3 px-4">
+                <h3>나의 채용</h3>
+            </div>
+            <div class="col-md-9">
+                <nav class="navbar navbar-expand-md">
+                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                        <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
+                        <li><a th:href="@{/user/my/rct/creator}" class="nav-link px-2">창작자 등록 현황</a></li>
+                        <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a></li>
+                        <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
+                        <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2" style="color:#000;">프리랜서 구매 목록</a>
+                        </li>
+                    </ul>
+                </nav>
+            </div>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/user/mypage_rct_order.html
+++ b/src/main/resources/templates/user/mypage_rct_order.html
@@ -106,20 +106,26 @@
 <div class="jumbotron">
     <div class="container">
         <div class="row">
-            <div class="col-md-3 px-4">
-                <h3>나의 채용</h3>
-            </div>
-            <div class="col-md-9">
-                <nav class="navbar navbar-expand-md">
-                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                        <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
-                        <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a>
-                        </li>
-                        <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
-                        <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2" style="color:#000;">프리랜서 구매 목록</a></li>
-                        <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보 수정</a></li>
-                    </ul>
-                </nav>
+            <div class="col-9">
+                <div class="row">
+                    <div class="col-md-3 px-4">
+                        <h3>나의 채용</h3>
+                    </div>
+                    <div class="col-md-9">
+                        <nav class="navbar navbar-expand-md">
+                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
+                                <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a>
+                                </li>
+                                <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
+                                <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2" style="color:#000;">프리랜서 구매
+                                    목록</a></li>
+                                <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보
+                                    수정</a></li>
+                            </ul>
+                        </nav>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/user/mypage_rct_order.html
+++ b/src/main/resources/templates/user/mypage_rct_order.html
@@ -112,12 +112,12 @@
             <div class="col-md-9">
                 <nav class="navbar navbar-expand-md">
                     <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                        <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 등록 현황</a></li>
                         <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">내가 올린 공고</a></li>
                         <li><a th:href="@{/user/my/rct/apply}" class="nav-link px-2">나의 지원서 관리</a>
                         </li>
                         <li><a th:href="@{/user/my/rct/free}" class="nav-link px-2">프리랜서 게시글 관리</a></li>
                         <li><a th:href="@{/user/my/rct/order}" class="nav-link px-2" style="color:#000;">프리랜서 구매 목록</a></li>
+                        <li><a th:href="@{/recruit/creator/mypage_editCreator}" class="nav-link px-2">창작자 정보 수정</a></li>
                     </ul>
                 </nav>
             </div>

--- a/src/main/resources/templates/user/mypage_rct_order.html
+++ b/src/main/resources/templates/user/mypage_rct_order.html
@@ -301,14 +301,69 @@
             <div class="row" style="color: #828282;">
                 <div class="col-11">
                     <div class="row">
-                        <div class="col-12">
+                        <div class="col-12 p-0">
+                            <style>
+                                .col-4 select {
+                                    border-radius: 50px;
+                                    text-align: center;
+                                }
+                                /* 검색창 스타일 */
+                                .search-container {
+                                    width: 300px;
+                                }
+
+                                .search-container select {
+                                    position: absolute;
+                                    left: 0%;
+                                    width: 30%;
+                                    height: 50px;
+                                    color: #828282;
+                                    font-size: 1rem;
+                                    border-radius: 50px 0 0 50px;
+                                    outline: none;
+                                }
+                                .search-container input[type="text"] {
+                                    position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
+                                    left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
+                                    width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
+                                    height: 50px;
+                                    padding: 10px 40px 10px 15px;
+                                    font-size: 1rem;
+                                    outline: none;
+                                    border-radius: 0 50px 50px 0;
+                                    transition: border-color 0.3s, background-color 0.3s;
+                                    color: #828282; /* 입력 텍스트 색상 변경 */
+                                }
+
+                                .search-container input[type="text"]::placeholder {
+                                    color: #BBBBBB; /* placeholder 색상 변경 */
+                                }
+
+
+                                .search-container button {
+                                    position: absolute;
+                                    right: 1rem;
+                                    top: 25px;
+                                    background: none;
+                                    transform: translateY(-50%);
+                                    border: none;
+                                    cursor: pointer;
+                                }
+
+                                .search-container button i {
+                                    color: #666;
+                                }
+
+                                .search-container button:hover i {
+                                    color: #03C75A;
+                                }
+                            </style>
                             <form id="filter-and-sort-form" th:action="@{/user/my/rct/order}" method="get">
-                                <div class="row">
-                                    <div class="col-7">
+                                <div class="row m-0">
+                                    <div class="col-7 p-0">
                                         <div class="row justify-content-start m-0">
-                                            <div class="col-4">
-                                                <!-- 검색 조건 -->
-                                                <label>
+                                            <div class="col-12 p-0">
+                                                <div class="search-container">
                                                     <select class="form-select px-3" name="searchBy">
                                                         <option value="title" th:selected="${searchBy == 'title'}">
                                                             구매상품명
@@ -317,16 +372,12 @@
                                                                 th:selected="${searchBy == 'nickname'}">프리랜서닉네임
                                                         </option>
                                                     </select>
-                                                </label>
-                                            </div>
-                                            <div class="col-6">
-                                                <input class="form-control px-3" type="text" name="searchTerm"
-                                                       placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
-                                            </div>
-                                            <div class="col-2">
-                                                <!-- 검색 버튼 -->
-                                                <button id="searchbutton" type="submit" class="btn btn-primary">검색
-                                                </button>
+                                                    <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
+                                                    <!-- 검색 버튼 -->
+                                                    <button type="submit">
+                                                        <i class="fas fa-search"></i>
+                                                    </button>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>

--- a/src/main/resources/templates/user/mypage_rct_order.html
+++ b/src/main/resources/templates/user/mypage_rct_order.html
@@ -135,7 +135,7 @@
         <aside class="col-md-3 px-4">
             <div class="row">
                 <div class="col-1"></div>
-                <div class="col-6">
+                <div class="col-8">
                     <div class="panel">
                         <ul class="list-group">
                             <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>

--- a/src/main/resources/templates/user/mypage_so_diary.html
+++ b/src/main/resources/templates/user/mypage_so_diary.html
@@ -293,14 +293,69 @@
             <div class="row" style="color: #828282;">
                 <div class="col-11">
                     <div class="row mb-4">
-                        <div class="col-12">
+                        <div class="col-12 p-0">
+                            <style>
+                                .col-4 select {
+                                    border-radius: 50px;
+                                    text-align: center;
+                                }
+                                /* 검색창 스타일 */
+                                .search-container {
+                                    width: 300px;
+                                }
+
+                                .search-container select {
+                                    position: absolute;
+                                    left: 0%;
+                                    width: 30%;
+                                    height: 50px;
+                                    color: #828282;
+                                    font-size: 1rem;
+                                    border-radius: 50px 0 0 50px;
+                                    outline: none;
+                                }
+                                .search-container input[type="text"] {
+                                    position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
+                                    left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
+                                    width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
+                                    height: 50px;
+                                    padding: 10px 40px 10px 15px;
+                                    font-size: 1rem;
+                                    outline: none;
+                                    border-radius: 0 50px 50px 0;
+                                    transition: border-color 0.3s, background-color 0.3s;
+                                    color: #828282; /* 입력 텍스트 색상 변경 */
+                                }
+
+                                .search-container input[type="text"]::placeholder {
+                                    color: #BBBBBB; /* placeholder 색상 변경 */
+                                }
+
+
+                                .search-container button {
+                                    position: absolute;
+                                    right: 1rem;
+                                    top: 25px;
+                                    background: none;
+                                    transform: translateY(-50%);
+                                    border: none;
+                                    cursor: pointer;
+                                }
+
+                                .search-container button i {
+                                    color: #666;
+                                }
+
+                                .search-container button:hover i {
+                                    color: #03C75A;
+                                }
+                            </style>
                             <form id="sort-form" th:action="@{/user/my/so/diary}" method="get">
-                                <div class="row">
-                                    <div class="col-7">
+                                <div class="row m-0">
+                                    <div class="col-7 p-0">
                                         <div class="row justify-content-start m-0">
-                                            <div class="col-4">
-                                                <!-- 검색 조건 -->
-                                                <label>
+                                            <div class="col-12 p-0">
+                                                <div class="search-container">
                                                     <select class="form-select px-3" name="searchBy">
                                                         <option value="comment" th:selected="${searchBy == 'comment'}">
                                                             댓글내용
@@ -316,16 +371,12 @@
                                                         <!--                        <option value="genre" th:selected="${searchBy == 'genre'}">장르</option>-->
                                                         <!--                        <option value="tag" th:selected="${searchBy == 'tag'}">태그</option>-->
                                                     </select>
-                                                </label>
-                                            </div>
-                                            <div class="col-6">
-                                                <input class="form-control px-3" type="text" name="searchTerm"
-                                                       placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
-                                            </div>
-                                            <div class="col-2">
-                                                <!-- 검색 버튼 -->
-                                                <button id="searchbutton" type="submit" class="btn btn-primary">검색
-                                                </button>
+                                                    <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
+                                                    <!-- 검색 버튼 -->
+                                                    <button type="submit">
+                                                        <i class="fas fa-search"></i>
+                                                    </button>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>

--- a/src/main/resources/templates/user/mypage_so_diary.html
+++ b/src/main/resources/templates/user/mypage_so_diary.html
@@ -343,7 +343,7 @@
                                 }
 
                                 .search-container button i {
-                                    color: #666;
+                                    color: #A6AAB5;
                                 }
 
                                 .search-container button:hover i {

--- a/src/main/resources/templates/user/mypage_so_diary.html
+++ b/src/main/resources/templates/user/mypage_so_diary.html
@@ -107,17 +107,22 @@
 <div class="jumbotron">
     <div class="container">
         <div class="row">
-            <div class="col-md-3 px-4">
-                <h3>나의 소셜</h3>
-            </div>
-            <div class="col-md-9">
-                <nav class="navbar navbar-expand-md">
-                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                        <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">좋아요한 리뷰</a></li>
-                        <li><a th:href="@{/user/my/so/diary}" class="nav-link px-2" style="color:#000;">내가 남긴 다이어리
-                            댓글</a></li>
-                    </ul>
-                </nav>
+            <div class="col-9">
+                <div class="row">
+                    <div class="col-md-3 px-4">
+                        <h3>나의 소셜</h3>
+                    </div>
+                    <div class="col-md-9">
+                        <nav class="navbar navbar-expand-md">
+                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">좋아요한 리뷰</a></li>
+                                <li><a th:href="@{/user/my/so/diary}" class="nav-link px-2" style="color:#000;">내가 남긴
+                                    다이어리
+                                    댓글</a></li>
+                            </ul>
+                        </nav>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/user/mypage_so_diary.html
+++ b/src/main/resources/templates/user/mypage_so_diary.html
@@ -105,17 +105,20 @@
   }
 </style>
 <div class="jumbotron">
-    <div class="row">
-        <div class="col-md-3 px-4">
-            <h3>나의 소셜</h3>
-        </div>
-        <div class="col-md-9">
-            <nav class="navbar navbar-expand-md">
-                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                    <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">좋아요한 리뷰</a></li>
-                    <li><a th:href="@{/user/my/so/diary}" class="nav-link px-2" style="color:#000;">내가 남긴 다이어리 댓글</a></li>
-                </ul>
-            </nav>
+    <div class="container">
+        <div class="row">
+            <div class="col-md-3 px-4">
+                <h3>나의 소셜</h3>
+            </div>
+            <div class="col-md-9">
+                <nav class="navbar navbar-expand-md">
+                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                        <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">좋아요한 리뷰</a></li>
+                        <li><a th:href="@{/user/my/so/diary}" class="nav-link px-2" style="color:#000;">내가 남긴 다이어리
+                            댓글</a></li>
+                    </ul>
+                </nav>
+            </div>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/user/mypage_so_diary.html
+++ b/src/main/resources/templates/user/mypage_so_diary.html
@@ -87,610 +87,640 @@
 
 <div th:replace="~{common/menubar}"></div>
 <style>
-    .jumbotron {
-    position : relative;
-    background-color : #EEEEEE;
+    html, body {
+        height: 100%;
+        margin: 0;
     }
-    .jumbotron .row {
-    position : absolute;
-    width : 100%;
-    bottom: 0%;
+    body {
+        display: flex;
+        flex-direction: column;
     }
-    .nav-link {
-            color: #828282;
-        }
-    ul {
-  list-style: none;
-  padding-left : 0px;
-  }
+    .content-wrapper {
+        flex: 1 0 auto;
+    }
+    footer {
+        flex-shrink: 0;
+    }
+
 </style>
-<div class="jumbotron">
-    <div class="container">
-        <div class="row">
-            <div class="col-9">
-                <div class="row">
-                    <div class="col-md-3 px-4">
-                        <h3>나의 소셜</h3>
-                    </div>
-                    <div class="col-md-9">
-                        <nav class="navbar navbar-expand-md">
-                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                                <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">좋아요한 리뷰</a></li>
-                                <li><a th:href="@{/user/my/so/diary}" class="nav-link px-2" style="color:#000;">내가 남긴
-                                    다이어리
-                                    댓글</a></li>
-                            </ul>
-                        </nav>
+<div class="content-wrapper">
+    <style>
+        .jumbotron {
+        position : relative;
+        background-color : #EEEEEE;
+        }
+        .jumbotron .row {
+        position : absolute;
+        width : 100%;
+        bottom: 0%;
+        }
+        .nav-link {
+                color: #828282;
+            }
+        ul {
+      list-style: none;
+      padding-left : 0px;
+      }
+    </style>
+    <div class="jumbotron">
+        <div class="container">
+            <div class="row">
+                <div class="col-9">
+                    <div class="row">
+                        <div class="col-md-3 px-4">
+                            <h3>나의 소셜</h3>
+                        </div>
+                        <div class="col-md-9">
+                            <nav class="navbar navbar-expand-md">
+                                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                    <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">좋아요한 리뷰</a></li>
+                                    <li><a th:href="@{/user/my/so/diary}" class="nav-link px-2" style="color:#000;">내가
+                                        남긴
+                                        다이어리
+                                        댓글</a></li>
+                                </ul>
+                            </nav>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
-<div class="container" style="padding:0;">
-    <div class="row">
-        <aside class="col-md-3 px-4">
-            <div class="row">
-                <div class="col-1"></div>
-                <div class="col-8">
-                    <div class="panel">
-                        <ul class="list-group">
-                            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
-                            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2" style="color: #03C75A;">나의
-                                소셜</a></li>
-                            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
-                            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-                        </ul>
+    <div class="container" style="padding:0;">
+        <div class="row">
+            <aside class="col-md-3 px-4">
+                <div class="row">
+                    <div class="col-1"></div>
+                    <div class="col-8">
+                        <div class="panel">
+                            <ul class="list-group">
+                                <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
+                                <li><a th:href="@{/user/my/so/review}" class="nav-link px-2" style="color: #03C75A;">나의
+                                    소셜</a></li>
+                                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
+                                <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                                <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                                <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </aside>
-        <style>
-            .form-select {
-            background-color : #FCFCFC;
-            border : none;
-            width : 100%;
-            height : 50px;
-            }
-            select {
-            color : #828282;
-            }
-            .form-control {
-            background-color : #FCFCFC;
-            border : none;
-            width : 100%;
-            height : 50px;
-            }
-
-
-            .form-control::placeholder {
-            color : #BBBBBB;
-            }
-
-            .date-container {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        background-color: #8E4B6E;
-        color: white;
-        border-radius: 10px;
-        text-align:center;
-        font-family: "Work Sans", sans-serif;
-    }
-
-    .platform-1 {
-        background-color: #03C75A;
-    }
-
-    .platform-2 {
-        background-color: #F5BF41;
-    }
-
-    .month {
-        font-size: 1.1rem; /* M의 크기를 설정 */
-        font-weight: 550;
-        line-height: 1;
-    }
-
-    .year {
-        font-size: 0.65rem; /* yyyy의 크기를 설정 */
-        font-weight: 400;
-    }
-    :root {
-        --background-color-light: #FFFFFF;
-        --text-color-light: #000000;
-        --toggle-background-light: #CCCCCC;
-        --toggle-ball-light: #FFFFFF;
-
-        --background-color-dark: #333333;
-        --text-color-dark: #FFFFFF;
-        --toggle-background-dark: #03C75A;
-        --toggle-ball-dark: #FFFFFF;
-
-        --font-size-base: 32px; /* 기본 텍스트 크기 */
-        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
-    }
-
-
-
-    .toggle-switch {
-        position: relative;
-        display: inline-block;
-        width: 62px; /* 너비 조정 */
-        height: 38px; /* 높이 조정 */
-    }
-
-    .toggle-switch .checkbox {
-        opacity: 0;
-        width: 0;
-        height: 0;
-    }
-    #isToggledCheckbox {
-         opacity: 0;
-            width: 0;
-            height: 0;
-    }
-
-    .toggle-switch .label {
-        position: absolute;
-        cursor: pointer;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background-color: var(--toggle-background-light);
-        transition: background-color 0.4s;
-        border-radius: 38px; /* 둥근 모서리 반경 조정 */
-    }
-
-    .toggle-switch .label:before {
-        position: absolute;
-        content: "";
-        height: 30px; /* 내부 원 높이 조정 */
-        width: 30px; /* 내부 원 너비 조정 */
-        left: 2px;
-        bottom: 0px;
-        background-color: var(--toggle-ball-light);
-        transition: transform 0.4s;
-        border-radius: 50%;
-    }
-
-    .toggle-switch input:checked + .label {
-        background-color: var(--toggle-background-dark);
-    }
-
-    .toggle-switch input:checked + .label:before {
-        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
-    }
-
-             #absdiv {
-                position: relative;
-                top: 60px; /* Move down by 20px from its current position */
-                z-index : 1000;
-            }
-
-            #searchbutton {
-                background-color: #828282;
-            }
-
-            .card-img-top {
-                    width: 100%;
-                    height: 100px;
-                    object-fit: cover;
+            </aside>
+            <style>
+                .form-select {
+                background-color : #FCFCFC;
+                border : none;
+                width : 100%;
+                height : 50px;
+                }
+                select {
+                color : #828282;
+                }
+                .form-control {
+                background-color : #FCFCFC;
+                border : none;
+                width : 100%;
+                height : 50px;
                 }
 
-        </style>
-        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
-              rel="stylesheet">
-        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
-              rel="stylesheet">
+
+                .form-control::placeholder {
+                color : #BBBBBB;
+                }
+
+                .date-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            background-color: #8E4B6E;
+            color: white;
+            border-radius: 10px;
+            text-align:center;
+            font-family: "Work Sans", sans-serif;
+        }
+
+        .platform-1 {
+            background-color: #03C75A;
+        }
+
+        .platform-2 {
+            background-color: #F5BF41;
+        }
+
+        .month {
+            font-size: 1.1rem; /* M의 크기를 설정 */
+            font-weight: 550;
+            line-height: 1;
+        }
+
+        .year {
+            font-size: 0.65rem; /* yyyy의 크기를 설정 */
+            font-weight: 400;
+        }
+        :root {
+            --background-color-light: #FFFFFF;
+            --text-color-light: #000000;
+            --toggle-background-light: #CCCCCC;
+            --toggle-ball-light: #FFFFFF;
+
+            --background-color-dark: #333333;
+            --text-color-dark: #FFFFFF;
+            --toggle-background-dark: #03C75A;
+            --toggle-ball-dark: #FFFFFF;
+
+            --font-size-base: 32px; /* 기본 텍스트 크기 */
+            --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+        }
 
 
-        <div class="col-md-9">
-            <div class="row" style="color: #828282;">
-                <div class="col-11">
-                    <div class="row mb-4">
-                        <div class="col-12 p-0">
-                            <style>
-                                .col-4 select {
-                                    border-radius: 50px;
-                                    text-align: center;
-                                }
-                                /* 검색창 스타일 */
-                                .search-container {
-                                    width: 300px;
-                                }
 
-                                .search-container select {
-                                    position: absolute;
-                                    left: 0%;
-                                    width: 30%;
-                                    height: 50px;
-                                    color: #828282;
-                                    font-size: 1rem;
-                                    border-radius: 50px 0 0 50px;
-                                    outline: none;
-                                }
-                                .search-container input[type="text"] {
-                                    position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
-                                    left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
-                                    width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
-                                    height: 50px;
-                                    padding: 10px 40px 10px 15px;
-                                    font-size: 1rem;
-                                    outline: none;
-                                    border-radius: 0 50px 50px 0;
-                                    transition: border-color 0.3s, background-color 0.3s;
-                                    color: #828282; /* 입력 텍스트 색상 변경 */
-                                }
+        .toggle-switch {
+            position: relative;
+            display: inline-block;
+            width: 62px; /* 너비 조정 */
+            height: 38px; /* 높이 조정 */
+        }
 
-                                .search-container input[type="text"]::placeholder {
-                                    color: #BBBBBB; /* placeholder 색상 변경 */
-                                }
+        .toggle-switch .checkbox {
+            opacity: 0;
+            width: 0;
+            height: 0;
+        }
+        #isToggledCheckbox {
+             opacity: 0;
+                width: 0;
+                height: 0;
+        }
+
+        .toggle-switch .label {
+            position: absolute;
+            cursor: pointer;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: var(--toggle-background-light);
+            transition: background-color 0.4s;
+            border-radius: 38px; /* 둥근 모서리 반경 조정 */
+        }
+
+        .toggle-switch .label:before {
+            position: absolute;
+            content: "";
+            height: 30px; /* 내부 원 높이 조정 */
+            width: 30px; /* 내부 원 너비 조정 */
+            left: 2px;
+            bottom: 0px;
+            background-color: var(--toggle-ball-light);
+            transition: transform 0.4s;
+            border-radius: 50%;
+        }
+
+        .toggle-switch input:checked + .label {
+            background-color: var(--toggle-background-dark);
+        }
+
+        .toggle-switch input:checked + .label:before {
+            transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+        }
+
+                 #absdiv {
+                    position: relative;
+                    top: 60px; /* Move down by 20px from its current position */
+                    z-index : 1000;
+                }
+
+                #searchbutton {
+                    background-color: #828282;
+                }
+
+                .card-img-top {
+                        width: 100%;
+                        height: 100px;
+                        object-fit: cover;
+                    }
+
+            </style>
+            <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+                  rel="stylesheet">
+            <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+                  rel="stylesheet">
 
 
-                                .search-container button {
-                                    position: absolute;
-                                    right: 1rem;
-                                    top: 25px;
-                                    background: none;
-                                    transform: translateY(-50%);
-                                    border: none;
-                                    cursor: pointer;
-                                }
+            <div class="col-md-9">
+                <div class="row" style="color: #828282;">
+                    <div class="col-11">
+                        <div class="row mb-4">
+                            <div class="col-12 p-0">
+                                <style>
+                                    .col-4 select {
+                                        border-radius: 50px;
+                                        text-align: center;
+                                    }
+                                    /* 검색창 스타일 */
+                                    .search-container {
+                                        width: 300px;
+                                    }
 
-                                .search-container button i {
-                                    color: #A6AAB5;
-                                }
+                                    .search-container select {
+                                        position: absolute;
+                                        left: 0%;
+                                        width: 30%;
+                                        height: 50px;
+                                        color: #828282;
+                                        font-size: 1rem;
+                                        border-radius: 50px 0 0 50px;
+                                        outline: none;
+                                    }
+                                    .search-container input[type="text"] {
+                                        position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
+                                        left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
+                                        width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
+                                        height: 50px;
+                                        padding: 10px 40px 10px 15px;
+                                        font-size: 1rem;
+                                        outline: none;
+                                        border-radius: 0 50px 50px 0;
+                                        transition: border-color 0.3s, background-color 0.3s;
+                                        color: #828282; /* 입력 텍스트 색상 변경 */
+                                    }
 
-                                .search-container button:hover i {
-                                    color: #03C75A;
-                                }
-                            </style>
-                            <form id="sort-form" th:action="@{/user/my/so/diary}" method="get">
-                                <div class="row m-0">
-                                    <div class="col-7 p-0">
-                                        <div class="row justify-content-start m-0">
-                                            <div class="col-12 p-0">
-                                                <div class="search-container">
-                                                    <select class="form-select px-3" name="searchBy">
-                                                        <option value="comment" th:selected="${searchBy == 'comment'}">
-                                                            댓글내용
-                                                        </option>
-                                                        <option value="rTitle" th:selected="${searchBy == 'dTitle'}">
-                                                            다이어리제목
-                                                        </option>
-                                                        <option value="rTitle" th:selected="${searchBy == 'dContent'}">
-                                                            다이어리내용
-                                                        </option>
-                                                        <!--                        <option value="title" th:selected="${searchBy == 'title'}">웹툰제목</option>-->
-                                                        <!--                        <option value="author" th:selected="${searchBy == 'author'}">작가</option>-->
-                                                        <!--                        <option value="genre" th:selected="${searchBy == 'genre'}">장르</option>-->
-                                                        <!--                        <option value="tag" th:selected="${searchBy == 'tag'}">태그</option>-->
-                                                    </select>
-                                                    <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
-                                                    <!-- 검색 버튼 -->
-                                                    <button type="submit">
-                                                        <i class="fas fa-search"></i>
-                                                    </button>
+                                    .search-container input[type="text"]::placeholder {
+                                        color: #BBBBBB; /* placeholder 색상 변경 */
+                                    }
+
+
+                                    .search-container button {
+                                        position: absolute;
+                                        right: 1rem;
+                                        top: 25px;
+                                        background: none;
+                                        transform: translateY(-50%);
+                                        border: none;
+                                        cursor: pointer;
+                                    }
+
+                                    .search-container button i {
+                                        color: #A6AAB5;
+                                    }
+
+                                    .search-container button:hover i {
+                                        color: #03C75A;
+                                    }
+                                </style>
+                                <form id="sort-form" th:action="@{/user/my/so/diary}" method="get">
+                                    <div class="row m-0">
+                                        <div class="col-7 p-0">
+                                            <div class="row justify-content-start m-0">
+                                                <div class="col-12 p-0">
+                                                    <div class="search-container">
+                                                        <select class="form-select px-3" name="searchBy">
+                                                            <option value="comment"
+                                                                    th:selected="${searchBy == 'comment'}">
+                                                                댓글내용
+                                                            </option>
+                                                            <option value="rTitle"
+                                                                    th:selected="${searchBy == 'dTitle'}">
+                                                                다이어리제목
+                                                            </option>
+                                                            <option value="rTitle"
+                                                                    th:selected="${searchBy == 'dContent'}">
+                                                                다이어리내용
+                                                            </option>
+                                                            <!--                        <option value="title" th:selected="${searchBy == 'title'}">웹툰제목</option>-->
+                                                            <!--                        <option value="author" th:selected="${searchBy == 'author'}">작가</option>-->
+                                                            <!--                        <option value="genre" th:selected="${searchBy == 'genre'}">장르</option>-->
+                                                            <!--                        <option value="tag" th:selected="${searchBy == 'tag'}">태그</option>-->
+                                                        </select>
+                                                        <input class="form-control px-3" type="text" name="searchTerm"
+                                                               placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
+                                                        <!-- 검색 버튼 -->
+                                                        <button type="submit">
+                                                            <i class="fas fa-search"></i>
+                                                        </button>
+                                                    </div>
                                                 </div>
                                             </div>
                                         </div>
-                                    </div>
-                                    <div class="col-1" style=""></div>
-                                    <div class="col-4">
-                                        <div class="row justify-content-end">
-                                            <!-- 정렬 또는 토글2 -->
-                                            <label>
-                                                <select class="form-select px-3" name="orderBy"
-                                                        onchange="this.form.submit()">
-                                                    <option value="recentposted"
-                                                            th:selected="${orderBy == 'recentposted'}">최근남긴순
-                                                    </option>
-                                                    <option value="oldestposted"
-                                                            th:selected="${orderBy == 'oldestposted'}">오래된순
-                                                    </option>
+                                        <div class="col-1" style=""></div>
+                                        <div class="col-4">
+                                            <div class="row justify-content-end">
+                                                <!-- 정렬 또는 토글2 -->
+                                                <label>
+                                                    <select class="form-select px-3" name="orderBy"
+                                                            onchange="this.form.submit()">
+                                                        <option value="recentposted"
+                                                                th:selected="${orderBy == 'recentposted'}">최근남긴순
+                                                        </option>
+                                                        <option value="oldestposted"
+                                                                th:selected="${orderBy == 'oldestposted'}">오래된순
+                                                        </option>
 
-                                                    <option value="recentadded"
-                                                            th:selected="${orderBy == 'recentadded'}">최근작성순
-                                                    </option>
-                                                    <option value="oldestadded"
-                                                            th:selected="${orderBy == 'oldestadded'}">오래된작성순
-                                                    </option>
+                                                        <option value="recentadded"
+                                                                th:selected="${orderBy == 'recentadded'}">최근작성순
+                                                        </option>
+                                                        <option value="oldestadded"
+                                                                th:selected="${orderBy == 'oldestadded'}">오래된작성순
+                                                        </option>
 
-                                                    <option value="views" th:selected="${orderBy == 'views'}">조회수높은순
-                                                    </option>
-                                                    <option value="title" th:selected="${orderBy == 'title'}">제목가나다순
-                                                    </option>
-                                                </select>
-                                            </label>
-                                        </div>
-                                    </div>
-                                </div> <!--검색, 소팅 (토글X)-->
-                                <div class="row justify-content-around">
-                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                    <div class="col-3" style="padding: 0 1.2rem;">
-                                        <div id="absdiv" class="row justify-content-end">
-                                            <!--                                        <div class="col-3">-->
-                                            <!--                                            <div class="toggle-switch">-->
-                                            <!--                                                &lt;!&ndash; 정렬 또는 토글1 &ndash;&gt;-->
-                                            <!--                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">-->
-                                            <!--                                                <label for="isToggledCheckbox" class="label">-->
-                                            <!--                                                    <div class="ball"></div>-->
-                                            <!--                                                </label>-->
-                                            <!--                                            </div>-->
-                                            <!--                                        </div>-->
-                                            <!--                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">진행중인 행사</div>-->
-                                        </div>
-                                    </div>
-                                </div> <!--토글-->
-                            </form>
-                        </div>
-                    </div>
-                    <div class="row justify-content-around mt-4">
-                        <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
-                            <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
-                                <div class="col-3 clickable-row"
-                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
-                                     th:each="mySoDiary, iterStat : ${mySoDiaries}"
-                                     th:attr="data-href=@{/social/users/{userId}/diaries/{diaryNo}(userId=${mySoDiary.writerUserId},diaryNo=${mySoDiary.diaryNo})}"
-                                     th:if="${iterStat.index < 3}">
-                                    <div class="row justify-content-center">
-                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
-                                             style="aspect-ratio: 1; border-radius: 5px;">
-                                            <div class="date-container px-2 py-1">
-                                                <div class="month"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(mySoDiary.commentCreatedDate)}"></div>
-                                                <div class="year"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(mySoDiary.commentCreatedDate)}"></div>
+                                                        <option value="views" th:selected="${orderBy == 'views'}">조회수높은순
+                                                        </option>
+                                                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순
+                                                        </option>
+                                                    </select>
+                                                </label>
                                             </div>
                                         </div>
-                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                        <!--                                    </div>-->
-                                        <div class="col-5" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
-                                             th:text="${mySoDiary.writerNickname}">닉네임
-                                        </div>
-
-                                        <div class="col-3"
-                                             style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
-                                             th:text="${mySoDiary.formattedCommentCreatedDate}">시간
-                                        </div>
-                                    </div>
-                                    <div class="row justify-content-center">
-                                        <div class="col-12 my-3" style="">
-                                            <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                            <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                            <!-- 썸네일 이미지 있을때  -->
-                                            <img th:if="${mySoDiary.thumbnailUrl != null}"
-                                                 th:src="${mySoDiary.thumbnailUrl}" class="card-img-top" alt="썸네일 이미지">
-                                        </div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
-                                             th:text="${mySoDiary.title}">이름
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
-                                             th:text="${mySoDiary.commentContent}">내용
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                    </div>
-
-                                </div>
-                                <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
-                                <div class="col-3" th:if="${mySoDiaries.size() == 0}"></div>
-                                <div class="col-3" th:if="${mySoDiaries.size() == 0 || mySoDiaries.size() == 1}"></div>
-                                <div class="col-3"
-                                     th:if="${mySoDiaries.size() == 0 || mySoDiaries.size() == 1 || mySoDiaries.size() == 2}"></div>
-                            </div>
-                            <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
-                                <div class="col-3 clickable-row"
-                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
-                                     th:each="mySoDiary, iterStat : ${mySoDiaries}"
-                                     th:attr="data-href=@{/social/users/{userId}/diaries/{diaryNo}(userId=${mySoDiary.writerUserId},diaryNo=${mySoDiary.diaryNo})}"
-                                     th:if="${iterStat.index >= 3}">
-                                    <div class="row justify-content-center">
-                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
-                                             style="aspect-ratio: 1; border-radius: 5px;">
-                                            <div class="date-container px-2 py-1">
-                                                <div class="month"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(mySoDiary.commentCreatedDate)}"></div>
-                                                <div class="year"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(mySoDiary.commentCreatedDate)}"></div>
+                                    </div> <!--검색, 소팅 (토글X)-->
+                                    <div class="row justify-content-around">
+                                        <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                        <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                        <div class="col-3" style="padding: 0 1.2rem;">
+                                            <div id="absdiv" class="row justify-content-end">
+                                                <!--                                        <div class="col-3">-->
+                                                <!--                                            <div class="toggle-switch">-->
+                                                <!--                                                &lt;!&ndash; 정렬 또는 토글1 &ndash;&gt;-->
+                                                <!--                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">-->
+                                                <!--                                                <label for="isToggledCheckbox" class="label">-->
+                                                <!--                                                    <div class="ball"></div>-->
+                                                <!--                                                </label>-->
+                                                <!--                                            </div>-->
+                                                <!--                                        </div>-->
+                                                <!--                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">진행중인 행사</div>-->
                                             </div>
                                         </div>
-                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                        <!--                                    </div>-->
-                                        <div class="col-5" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
-                                             th:text="${mySoDiary.writerNickname}">닉네임
-                                        </div>
-
-                                        <div class="col-3"
-                                             style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
-                                             th:text="${mySoDiary.formattedCommentCreatedDate}">시간
-                                        </div>
-                                    </div>
-                                    <div class="row justify-content-center">
-                                        <div class="col-12 my-3" style="">
-                                            <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                            <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                            <!-- 썸네일 이미지 있을때  -->
-                                            <img th:if="${mySoDiary.thumbnailUrl != null}"
-                                                 th:src="${mySoDiary.thumbnailUrl}" class="card-img-top" alt="썸네일 이미지">
-                                        </div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
-                                             th:text="${mySoDiary.title}">이름
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
-                                             th:text="${mySoDiary.commentContent}">내용
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                    </div>
-
-                                </div>
-
-                                <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
-                                <div class="col-3" th:if="${mySoDiaries.size() <= 3}"></div>
-                                <div class="col-3" th:if="${mySoDiaries.size() <= 3 || mySoDiaries.size() == 4}"></div>
-                                <div class="col-3"
-                                     th:if="${mySoDiaries.size() <= 3 || mySoDiaries.size() == 4 || mySoDiaries.size() == 5}"></div>
+                                    </div> <!--토글-->
+                                </form>
                             </div>
                         </div>
-                    </div>
-                    <div class="row justify-content-center">
-                        <!-- 페이징 -->
-                        <th:block th:if="${pages != null}">
-                            <div class="d-flex justify-content-center">
-                                <div class="btn-group">
-                                    <button type="button" class="btn btn-sm previous"
-                                            th:onclick="|location.href='@{/user/my/so/diary(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
-                                            th:disabled="${currentPage == 1}">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                             fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-                                            <path fill-rule="evenodd"
-                                                  d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                                        </svg>
-                                    </button>
-                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">
-                                        <button type="button" class="btn btn-sm me-2 pages"
-                                                th:text="${p}"
-                                                th:onclick="|location.href='@{/user/my/so/diary(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
-                                    </th:block>
-                                    <button type="button" class="btn btn-sm  next"
-                                            th:onclick="|location.href='@{/user/my/so/diary(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
-                                            th:disabled="${currentPage == pages}">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                             fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-                                            <path fill-rule="evenodd"
-                                                  d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
-                                        </svg>
-                                    </button>
+                        <div class="row justify-content-around mt-4">
+                            <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
+                                <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
+                                    <div class="col-3 clickable-row"
+                                         style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                         th:each="mySoDiary, iterStat : ${mySoDiaries}"
+                                         th:attr="data-href=@{/social/users/{userId}/diaries/{diaryNo}(userId=${mySoDiary.writerUserId},diaryNo=${mySoDiary.diaryNo})}"
+                                         th:if="${iterStat.index < 3}">
+                                        <div class="row justify-content-center">
+                                            <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                                 style="aspect-ratio: 1; border-radius: 5px;">
+                                                <div class="date-container px-2 py-1">
+                                                    <div class="month"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(mySoDiary.commentCreatedDate)}"></div>
+                                                    <div class="year"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(mySoDiary.commentCreatedDate)}"></div>
+                                                </div>
+                                            </div>
+                                            <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                            <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                            <!--                                    </div>-->
+                                            <div class="col-5"
+                                                 style="color: #333333; font-size: 0.8rem; font-weight: 530;"
+                                                 th:text="${mySoDiary.writerNickname}">닉네임
+                                            </div>
+
+                                            <div class="col-3"
+                                                 style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
+                                                 th:text="${mySoDiary.formattedCommentCreatedDate}">시간
+                                            </div>
+                                        </div>
+                                        <div class="row justify-content-center">
+                                            <div class="col-12 my-3" style="">
+                                                <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                                <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                                <!-- 썸네일 이미지 있을때  -->
+                                                <img th:if="${mySoDiary.thumbnailUrl != null}"
+                                                     th:src="${mySoDiary.thumbnailUrl}" class="card-img-top"
+                                                     alt="썸네일 이미지">
+                                            </div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                                 th:text="${mySoDiary.title}">이름
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                                 th:text="${mySoDiary.commentContent}">내용
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                        </div>
+
+                                    </div>
+                                    <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
+                                    <div class="col-3" th:if="${mySoDiaries.size() == 0}"></div>
+                                    <div class="col-3"
+                                         th:if="${mySoDiaries.size() == 0 || mySoDiaries.size() == 1}"></div>
+                                    <div class="col-3"
+                                         th:if="${mySoDiaries.size() == 0 || mySoDiaries.size() == 1 || mySoDiaries.size() == 2}"></div>
+                                </div>
+                                <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
+                                    <div class="col-3 clickable-row"
+                                         style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                         th:each="mySoDiary, iterStat : ${mySoDiaries}"
+                                         th:attr="data-href=@{/social/users/{userId}/diaries/{diaryNo}(userId=${mySoDiary.writerUserId},diaryNo=${mySoDiary.diaryNo})}"
+                                         th:if="${iterStat.index >= 3}">
+                                        <div class="row justify-content-center">
+                                            <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                                 style="aspect-ratio: 1; border-radius: 5px;">
+                                                <div class="date-container px-2 py-1">
+                                                    <div class="month"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(mySoDiary.commentCreatedDate)}"></div>
+                                                    <div class="year"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(mySoDiary.commentCreatedDate)}"></div>
+                                                </div>
+                                            </div>
+                                            <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                            <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                            <!--                                    </div>-->
+                                            <div class="col-5"
+                                                 style="color: #333333; font-size: 0.8rem; font-weight: 530;"
+                                                 th:text="${mySoDiary.writerNickname}">닉네임
+                                            </div>
+
+                                            <div class="col-3"
+                                                 style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
+                                                 th:text="${mySoDiary.formattedCommentCreatedDate}">시간
+                                            </div>
+                                        </div>
+                                        <div class="row justify-content-center">
+                                            <div class="col-12 my-3" style="">
+                                                <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                                <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                                <!-- 썸네일 이미지 있을때  -->
+                                                <img th:if="${mySoDiary.thumbnailUrl != null}"
+                                                     th:src="${mySoDiary.thumbnailUrl}" class="card-img-top"
+                                                     alt="썸네일 이미지">
+                                            </div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                                 th:text="${mySoDiary.title}">이름
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                                 th:text="${mySoDiary.commentContent}">내용
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                        </div>
+
+                                    </div>
+
+                                    <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
+                                    <div class="col-3" th:if="${mySoDiaries.size() <= 3}"></div>
+                                    <div class="col-3"
+                                         th:if="${mySoDiaries.size() <= 3 || mySoDiaries.size() == 4}"></div>
+                                    <div class="col-3"
+                                         th:if="${mySoDiaries.size() <= 3 || mySoDiaries.size() == 4 || mySoDiaries.size() == 5}"></div>
                                 </div>
                             </div>
-                        </th:block>
-                    </div>
-                </div><!--테이블 및 페이징 포함-->
+                        </div>
+                        <div class="row justify-content-center">
+                            <!-- 페이징 -->
+                            <th:block th:if="${pages != null}">
+                                <div class="d-flex justify-content-center">
+                                    <div class="btn-group">
+                                        <button type="button" class="btn btn-sm previous"
+                                                th:onclick="|location.href='@{/user/my/so/diary(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
+                                                th:disabled="${currentPage == 1}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                                 fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+                                                <path fill-rule="evenodd"
+                                                      d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                                            </svg>
+                                        </button>
+                                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">
+                                            <button type="button" class="btn btn-sm me-2 pages"
+                                                    th:text="${p}"
+                                                    th:onclick="|location.href='@{/user/my/so/diary(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
+                                        </th:block>
+                                        <button type="button" class="btn btn-sm  next"
+                                                th:onclick="|location.href='@{/user/my/so/diary(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
+                                                th:disabled="${currentPage == pages}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                                 fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+                                                <path fill-rule="evenodd"
+                                                      d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                                            </svg>
+                                        </button>
+                                    </div>
+                                </div>
+                            </th:block>
+                        </div>
+                    </div><!--테이블 및 페이징 포함-->
+                </div> <!--본화면-->
             </div> <!--본화면-->
-        </div> <!--본화면-->
 
-        <!--수정전-->
-        <!--    <div class="col-md-9">-->
-        <!--        <div class="review-list">-->
-        <!--            <h2>내가 남긴 다이어리 댓글</h2>-->
-        <!--            <form id="sort-form" th:action="@{/user/my/so/diary}" method="get">-->
-        <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
-        <!--                <label>-->
-        <!--                    <select name="searchBy">-->
-        <!--                        <option value="comment" th:selected="${searchBy == 'comment'}">댓글내용</option>-->
-        <!--                        <option value="rTitle" th:selected="${searchBy == 'dTitle'}">다이어리제목</option>-->
-        <!--                        <option value="rTitle" th:selected="${searchBy == 'dContent'}">다이어리내용</option>-->
-        <!--                        &lt;!&ndash;                        <option value="title" th:selected="${searchBy == 'title'}">웹툰제목</option>&ndash;&gt;-->
-        <!--                        &lt;!&ndash;                        <option value="author" th:selected="${searchBy == 'author'}">작가</option>&ndash;&gt;-->
-        <!--                        &lt;!&ndash;                        <option value="genre" th:selected="${searchBy == 'genre'}">장르</option>&ndash;&gt;-->
-        <!--                        &lt;!&ndash;                        <option value="tag" th:selected="${searchBy == 'tag'}">태그</option>&ndash;&gt;-->
-        <!--                    </select>-->
-        <!--                </label>-->
-        <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
+            <!--수정전-->
+            <!--    <div class="col-md-9">-->
+            <!--        <div class="review-list">-->
+            <!--            <h2>내가 남긴 다이어리 댓글</h2>-->
+            <!--            <form id="sort-form" th:action="@{/user/my/so/diary}" method="get">-->
+            <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
+            <!--                <label>-->
+            <!--                    <select name="searchBy">-->
+            <!--                        <option value="comment" th:selected="${searchBy == 'comment'}">댓글내용</option>-->
+            <!--                        <option value="rTitle" th:selected="${searchBy == 'dTitle'}">다이어리제목</option>-->
+            <!--                        <option value="rTitle" th:selected="${searchBy == 'dContent'}">다이어리내용</option>-->
+            <!--                        &lt;!&ndash;                        <option value="title" th:selected="${searchBy == 'title'}">웹툰제목</option>&ndash;&gt;-->
+            <!--                        &lt;!&ndash;                        <option value="author" th:selected="${searchBy == 'author'}">작가</option>&ndash;&gt;-->
+            <!--                        &lt;!&ndash;                        <option value="genre" th:selected="${searchBy == 'genre'}">장르</option>&ndash;&gt;-->
+            <!--                        &lt;!&ndash;                        <option value="tag" th:selected="${searchBy == 'tag'}">태그</option>&ndash;&gt;-->
+            <!--                    </select>-->
+            <!--                </label>-->
+            <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
 
-        <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
-        <!--                <button type="submit">검색</button>-->
+            <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
+            <!--                <button type="submit">검색</button>-->
 
-        <!--                &lt;!&ndash; 정렬 조건 &ndash;&gt;-->
-        <!--                <label>-->
-        <!--                    <select name="orderBy" onchange="this.form.submit()">-->
-        <!--                        <option value="recentposted" th:selected="${orderBy == 'recentposted'}">최근남긴순</option>-->
-        <!--                        <option value="oldestposted" th:selected="${orderBy == 'oldestposted'}">오래된순</option>-->
+            <!--                &lt;!&ndash; 정렬 조건 &ndash;&gt;-->
+            <!--                <label>-->
+            <!--                    <select name="orderBy" onchange="this.form.submit()">-->
+            <!--                        <option value="recentposted" th:selected="${orderBy == 'recentposted'}">최근남긴순</option>-->
+            <!--                        <option value="oldestposted" th:selected="${orderBy == 'oldestposted'}">오래된순</option>-->
 
-        <!--                        <option value="recentadded" th:selected="${orderBy == 'recentadded'}">최근작성순</option>-->
-        <!--                        <option value="oldestadded" th:selected="${orderBy == 'oldestadded'}">오래된작성순</option>-->
+            <!--                        <option value="recentadded" th:selected="${orderBy == 'recentadded'}">최근작성순</option>-->
+            <!--                        <option value="oldestadded" th:selected="${orderBy == 'oldestadded'}">오래된작성순</option>-->
 
-        <!--                        <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>-->
-        <!--                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
-        <!--                    </select>-->
-        <!--                </label>-->
-        <!--            </form>-->
-        <!--            <table>-->
-        <!--                <thead>-->
-        <!--                <tr>-->
-        <!--                    <th>댓글 번호</th>-->
-        <!--                    <th>다이어리 번호</th>-->
-        <!--                    <th>댓글 작성자</th>-->
-        <!--                    <th>댓글 내용</th>-->
-        <!--                    <th>댓글 작성일시</th>-->
-        <!--                    <th>웹툰 번호</th>-->
-        <!--                    <th>작성자</th>-->
-        <!--                    <th>제목</th>-->
-        <!--                    <th>다이어리 내용</th>-->
-        <!--                    <th>상태 코드</th>-->
-        <!--                    <th>다이어리 작성일시</th>-->
-        <!--                    <th>다이어리 수정일시</th>-->
-        <!--                    <th>조회수</th>-->
-        <!--                    <th>*작성자ID</th>-->
-        <!--                    <th>*작성자닉네임</th>-->
-        <!--                    <th>*썸네일URL</th>-->
-        <!--                </tr>-->
-        <!--                </thead>-->
-        <!--                <tbody>-->
-        <!--                <tr th:each="mySoDiary : ${mySoDiaries}" class="clickable-row" th:attr="data-href=@{/social/users/{userId}/diaries/{diaryNo}(userId=${mySoDiary.writerUserId},diaryNo=${mySoDiary.diaryNo})}">-->
-        <!--                    <td th:text="${mySoDiary.commentNo}">댓글 번호</td>-->
-        <!--                    <td th:text="${mySoDiary.diaryNo}">다이어리 번호</td>-->
-        <!--                    <td th:text="${mySoDiary.commenterNo}">댓글 작성자</td>-->
-        <!--                    <td th:text="${mySoDiary.commentContent}">댓글 내용</td>-->
-        <!--                    <td th:text="${mySoDiary.commentCreatedDate}">댓글 작성일시</td>-->
-        <!--                    <td th:text="${mySoDiary.webtoonNo}">웹툰 번호</td>-->
-        <!--                    <td th:text="${mySoDiary.writerNo}">작성자</td>-->
-        <!--                    <td th:text="${mySoDiary.title}">제목</td>-->
-        <!--                    <td th:text="${mySoDiary.diaryContent}">다이어리 내용</td>-->
-        <!--                    <td th:text="${mySoDiary.statusCode}">상태 코드</td>-->
-        <!--                    <td th:text="${mySoDiary.diaryCreatedDate}">다이어리 작성일시</td>-->
-        <!--                    <td th:text="${mySoDiary.diaryModifiedDate}">다이어리 수정일시</td>-->
-        <!--                    <td th:text="${mySoDiary.viewCnt}">조회수</td>-->
-        <!--                    <td th:text="${mySoDiary.writerUserId}">*작성자ID</td>-->
-        <!--                    <td th:text="${mySoDiary.writerUserId}">*작성자닉네임</td>-->
-        <!--                    <td th:text="${mySoDiary.thumbnailUrl}">*썸네일URL</td>-->
-        <!--                </tr>-->
-        <!--                </tbody>-->
-        <!--            </table>-->
-        <!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
-        <!--            <th:block th:if="${pages != null}">-->
-        <!--                <div class="d-flex justify-content-center">-->
-        <!--                    <div class="btn-group">-->
-        <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/so/diary(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
-        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
-        <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
-        <!--                            </svg>-->
-        <!--                        </button>-->
-        <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
-        <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
-        <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/so/diary(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
-        <!--                        </th:block>-->
-        <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/so/diary(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
-        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
-        <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
-        <!--                            </svg>-->
-        <!--                        </button>-->
-        <!--                    </div>-->
-        <!--                </div>-->
-        <!--            </th:block>-->
-        <!--        </div>-->
-        <!--    </div>-->
+            <!--                        <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>-->
+            <!--                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
+            <!--                    </select>-->
+            <!--                </label>-->
+            <!--            </form>-->
+            <!--            <table>-->
+            <!--                <thead>-->
+            <!--                <tr>-->
+            <!--                    <th>댓글 번호</th>-->
+            <!--                    <th>다이어리 번호</th>-->
+            <!--                    <th>댓글 작성자</th>-->
+            <!--                    <th>댓글 내용</th>-->
+            <!--                    <th>댓글 작성일시</th>-->
+            <!--                    <th>웹툰 번호</th>-->
+            <!--                    <th>작성자</th>-->
+            <!--                    <th>제목</th>-->
+            <!--                    <th>다이어리 내용</th>-->
+            <!--                    <th>상태 코드</th>-->
+            <!--                    <th>다이어리 작성일시</th>-->
+            <!--                    <th>다이어리 수정일시</th>-->
+            <!--                    <th>조회수</th>-->
+            <!--                    <th>*작성자ID</th>-->
+            <!--                    <th>*작성자닉네임</th>-->
+            <!--                    <th>*썸네일URL</th>-->
+            <!--                </tr>-->
+            <!--                </thead>-->
+            <!--                <tbody>-->
+            <!--                <tr th:each="mySoDiary : ${mySoDiaries}" class="clickable-row" th:attr="data-href=@{/social/users/{userId}/diaries/{diaryNo}(userId=${mySoDiary.writerUserId},diaryNo=${mySoDiary.diaryNo})}">-->
+            <!--                    <td th:text="${mySoDiary.commentNo}">댓글 번호</td>-->
+            <!--                    <td th:text="${mySoDiary.diaryNo}">다이어리 번호</td>-->
+            <!--                    <td th:text="${mySoDiary.commenterNo}">댓글 작성자</td>-->
+            <!--                    <td th:text="${mySoDiary.commentContent}">댓글 내용</td>-->
+            <!--                    <td th:text="${mySoDiary.commentCreatedDate}">댓글 작성일시</td>-->
+            <!--                    <td th:text="${mySoDiary.webtoonNo}">웹툰 번호</td>-->
+            <!--                    <td th:text="${mySoDiary.writerNo}">작성자</td>-->
+            <!--                    <td th:text="${mySoDiary.title}">제목</td>-->
+            <!--                    <td th:text="${mySoDiary.diaryContent}">다이어리 내용</td>-->
+            <!--                    <td th:text="${mySoDiary.statusCode}">상태 코드</td>-->
+            <!--                    <td th:text="${mySoDiary.diaryCreatedDate}">다이어리 작성일시</td>-->
+            <!--                    <td th:text="${mySoDiary.diaryModifiedDate}">다이어리 수정일시</td>-->
+            <!--                    <td th:text="${mySoDiary.viewCnt}">조회수</td>-->
+            <!--                    <td th:text="${mySoDiary.writerUserId}">*작성자ID</td>-->
+            <!--                    <td th:text="${mySoDiary.writerUserId}">*작성자닉네임</td>-->
+            <!--                    <td th:text="${mySoDiary.thumbnailUrl}">*썸네일URL</td>-->
+            <!--                </tr>-->
+            <!--                </tbody>-->
+            <!--            </table>-->
+            <!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
+            <!--            <th:block th:if="${pages != null}">-->
+            <!--                <div class="d-flex justify-content-center">-->
+            <!--                    <div class="btn-group">-->
+            <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/so/diary(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
+            <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
+            <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
+            <!--                            </svg>-->
+            <!--                        </button>-->
+            <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
+            <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
+            <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/so/diary(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
+            <!--                        </th:block>-->
+            <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/so/diary(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
+            <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
+            <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
+            <!--                            </svg>-->
+            <!--                        </button>-->
+            <!--                    </div>-->
+            <!--                </div>-->
+            <!--            </th:block>-->
+            <!--        </div>-->
+            <!--    </div>-->
+        </div>
     </div>
 </div>
 <div th:replace="common/footer.html"></div>

--- a/src/main/resources/templates/user/mypage_so_diary.html
+++ b/src/main/resources/templates/user/mypage_so_diary.html
@@ -132,7 +132,7 @@
         <aside class="col-md-3 px-4">
             <div class="row">
                 <div class="col-1"></div>
-                <div class="col-6">
+                <div class="col-8">
                     <div class="panel">
                         <ul class="list-group">
                             <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>

--- a/src/main/resources/templates/user/mypage_so_diary.html
+++ b/src/main/resources/templates/user/mypage_so_diary.html
@@ -122,451 +122,520 @@
         </div>
     </div>
 </div>
-<div class="row">
-    <aside class="col-md-3 px-4">
-        <div class="row">
-            <div class="col-3"></div>
-            <div class="col-6">
-                <div class="panel">
-                    <ul class="list-group">
-                        <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
-                        <li><a th:href="@{/user/my/so/review}" class="nav-link px-2" style="color: #03C75A;">나의 소셜</a></li>
-                        <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
-                        <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-                        <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                        <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-                    </ul>
+<div class="container" style="padding:0;">
+    <div class="row">
+        <aside class="col-md-3 px-4">
+            <div class="row">
+                <div class="col-3"></div>
+                <div class="col-6">
+                    <div class="panel">
+                        <ul class="list-group">
+                            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
+                            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2" style="color: #03C75A;">나의
+                                소셜</a></li>
+                            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
+                            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+                        </ul>
+                    </div>
                 </div>
             </div>
-        </div>
-    </aside>
-    <style>
-        .form-select {
-        background-color : #FCFCFC;
-        border : none;
-        width : 100%;
-        height : 50px;
-        }
-        select {
-        color : #828282;
-        }
-        .form-control {
-        background-color : #FCFCFC;
-        border : none;
-        width : 100%;
-        height : 50px;
-        }
-
-
-        .form-control::placeholder {
-        color : #BBBBBB;
-        }
-
-        .date-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    background-color: #8E4B6E;
-    color: white;
-    border-radius: 10px;
-    text-align:center;
-    font-family: "Work Sans", sans-serif;
-}
-
-.platform-1 {
-    background-color: #03C75A;
-}
-
-.platform-2 {
-    background-color: #F5BF41;
-}
-
-.month {
-    font-size: 1.1rem; /* M의 크기를 설정 */
-    font-weight: 550;
-    line-height: 1;
-}
-
-.year {
-    font-size: 0.65rem; /* yyyy의 크기를 설정 */
-    font-weight: 400;
-}
-:root {
-    --background-color-light: #FFFFFF;
-    --text-color-light: #000000;
-    --toggle-background-light: #CCCCCC;
-    --toggle-ball-light: #FFFFFF;
-
-    --background-color-dark: #333333;
-    --text-color-dark: #FFFFFF;
-    --toggle-background-dark: #03C75A;
-    --toggle-ball-dark: #FFFFFF;
-
-    --font-size-base: 32px; /* 기본 텍스트 크기 */
-    --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
-}
-
-
-
-.toggle-switch {
-    position: relative;
-    display: inline-block;
-    width: 62px; /* 너비 조정 */
-    height: 38px; /* 높이 조정 */
-}
-
-.toggle-switch .checkbox {
-    opacity: 0;
-    width: 0;
-    height: 0;
-}
-#isToggledCheckbox {
-     opacity: 0;
-        width: 0;
-        height: 0;
-}
-
-.toggle-switch .label {
-    position: absolute;
-    cursor: pointer;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: var(--toggle-background-light);
-    transition: background-color 0.4s;
-    border-radius: 38px; /* 둥근 모서리 반경 조정 */
-}
-
-.toggle-switch .label:before {
-    position: absolute;
-    content: "";
-    height: 30px; /* 내부 원 높이 조정 */
-    width: 30px; /* 내부 원 너비 조정 */
-    left: 2px;
-    bottom: 0px;
-    background-color: var(--toggle-ball-light);
-    transition: transform 0.4s;
-    border-radius: 50%;
-}
-
-.toggle-switch input:checked + .label {
-    background-color: var(--toggle-background-dark);
-}
-
-.toggle-switch input:checked + .label:before {
-    transform: translateX(28px); /* 내부 원 이동 거리 조정 */
-}
-
-         #absdiv {
-            position: relative;
-            top: 60px; /* Move down by 20px from its current position */
-            z-index : 1000;
-        }
-
-        #searchbutton {
-            background-color: #828282;
-        }
-
-        .card-img-top {
-                width: 100%;
-                height: 100px;
-                object-fit: cover;
+        </aside>
+        <style>
+            .form-select {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
+            }
+            select {
+            color : #828282;
+            }
+            .form-control {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
             }
 
-    </style>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+
+            .form-control::placeholder {
+            color : #BBBBBB;
+            }
+
+            .date-container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        background-color: #8E4B6E;
+        color: white;
+        border-radius: 10px;
+        text-align:center;
+        font-family: "Work Sans", sans-serif;
+    }
+
+    .platform-1 {
+        background-color: #03C75A;
+    }
+
+    .platform-2 {
+        background-color: #F5BF41;
+    }
+
+    .month {
+        font-size: 1.1rem; /* M의 크기를 설정 */
+        font-weight: 550;
+        line-height: 1;
+    }
+
+    .year {
+        font-size: 0.65rem; /* yyyy의 크기를 설정 */
+        font-weight: 400;
+    }
+    :root {
+        --background-color-light: #FFFFFF;
+        --text-color-light: #000000;
+        --toggle-background-light: #CCCCCC;
+        --toggle-ball-light: #FFFFFF;
+
+        --background-color-dark: #333333;
+        --text-color-dark: #FFFFFF;
+        --toggle-background-dark: #03C75A;
+        --toggle-ball-dark: #FFFFFF;
+
+        --font-size-base: 32px; /* 기본 텍스트 크기 */
+        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+    }
 
 
-    <div class="col-md-9">
-        <div class="row" style="color: #828282;">
-            <div class="col-11">
-                <div class="row mb-4">
-                    <div class="col-12">
-                        <form id="sort-form" th:action="@{/user/my/so/diary}" method="get">
-                            <div class="row">
-                                <div class="col-7">
-                                    <div class="row justify-content-start m-0">
-                                        <div class="col-4">
-                                            <!-- 검색 조건 -->
+
+    .toggle-switch {
+        position: relative;
+        display: inline-block;
+        width: 62px; /* 너비 조정 */
+        height: 38px; /* 높이 조정 */
+    }
+
+    .toggle-switch .checkbox {
+        opacity: 0;
+        width: 0;
+        height: 0;
+    }
+    #isToggledCheckbox {
+         opacity: 0;
+            width: 0;
+            height: 0;
+    }
+
+    .toggle-switch .label {
+        position: absolute;
+        cursor: pointer;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: var(--toggle-background-light);
+        transition: background-color 0.4s;
+        border-radius: 38px; /* 둥근 모서리 반경 조정 */
+    }
+
+    .toggle-switch .label:before {
+        position: absolute;
+        content: "";
+        height: 30px; /* 내부 원 높이 조정 */
+        width: 30px; /* 내부 원 너비 조정 */
+        left: 2px;
+        bottom: 0px;
+        background-color: var(--toggle-ball-light);
+        transition: transform 0.4s;
+        border-radius: 50%;
+    }
+
+    .toggle-switch input:checked + .label {
+        background-color: var(--toggle-background-dark);
+    }
+
+    .toggle-switch input:checked + .label:before {
+        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+    }
+
+             #absdiv {
+                position: relative;
+                top: 60px; /* Move down by 20px from its current position */
+                z-index : 1000;
+            }
+
+            #searchbutton {
+                background-color: #828282;
+            }
+
+            .card-img-top {
+                    width: 100%;
+                    height: 100px;
+                    object-fit: cover;
+                }
+
+        </style>
+        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+              rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+              rel="stylesheet">
+
+
+        <div class="col-md-9">
+            <div class="row" style="color: #828282;">
+                <div class="col-11">
+                    <div class="row mb-4">
+                        <div class="col-12">
+                            <form id="sort-form" th:action="@{/user/my/so/diary}" method="get">
+                                <div class="row">
+                                    <div class="col-7">
+                                        <div class="row justify-content-start m-0">
+                                            <div class="col-4">
+                                                <!-- 검색 조건 -->
+                                                <label>
+                                                    <select class="form-select px-3" name="searchBy">
+                                                        <option value="comment" th:selected="${searchBy == 'comment'}">
+                                                            댓글내용
+                                                        </option>
+                                                        <option value="rTitle" th:selected="${searchBy == 'dTitle'}">
+                                                            다이어리제목
+                                                        </option>
+                                                        <option value="rTitle" th:selected="${searchBy == 'dContent'}">
+                                                            다이어리내용
+                                                        </option>
+                                                        <!--                        <option value="title" th:selected="${searchBy == 'title'}">웹툰제목</option>-->
+                                                        <!--                        <option value="author" th:selected="${searchBy == 'author'}">작가</option>-->
+                                                        <!--                        <option value="genre" th:selected="${searchBy == 'genre'}">장르</option>-->
+                                                        <!--                        <option value="tag" th:selected="${searchBy == 'tag'}">태그</option>-->
+                                                    </select>
+                                                </label>
+                                            </div>
+                                            <div class="col-6">
+                                                <input class="form-control px-3" type="text" name="searchTerm"
+                                                       placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
+                                            </div>
+                                            <div class="col-2">
+                                                <!-- 검색 버튼 -->
+                                                <button id="searchbutton" type="submit" class="btn btn-primary">검색
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-1" style=""></div>
+                                    <div class="col-4">
+                                        <div class="row justify-content-end">
+                                            <!-- 정렬 또는 토글2 -->
                                             <label>
-                                                <select class="form-select px-3" name="searchBy">
-                                                    <option value="comment" th:selected="${searchBy == 'comment'}">댓글내용</option>
-                                                    <option value="rTitle" th:selected="${searchBy == 'dTitle'}">다이어리제목</option>
-                                                    <option value="rTitle" th:selected="${searchBy == 'dContent'}">다이어리내용</option>
-                                                    <!--                        <option value="title" th:selected="${searchBy == 'title'}">웹툰제목</option>-->
-                                                    <!--                        <option value="author" th:selected="${searchBy == 'author'}">작가</option>-->
-                                                    <!--                        <option value="genre" th:selected="${searchBy == 'genre'}">장르</option>-->
-                                                    <!--                        <option value="tag" th:selected="${searchBy == 'tag'}">태그</option>-->
+                                                <select class="form-select px-3" name="orderBy"
+                                                        onchange="this.form.submit()">
+                                                    <option value="recentposted"
+                                                            th:selected="${orderBy == 'recentposted'}">최근남긴순
+                                                    </option>
+                                                    <option value="oldestposted"
+                                                            th:selected="${orderBy == 'oldestposted'}">오래된순
+                                                    </option>
+
+                                                    <option value="recentadded"
+                                                            th:selected="${orderBy == 'recentadded'}">최근작성순
+                                                    </option>
+                                                    <option value="oldestadded"
+                                                            th:selected="${orderBy == 'oldestadded'}">오래된작성순
+                                                    </option>
+
+                                                    <option value="views" th:selected="${orderBy == 'views'}">조회수높은순
+                                                    </option>
+                                                    <option value="title" th:selected="${orderBy == 'title'}">제목가나다순
+                                                    </option>
                                                 </select>
                                             </label>
                                         </div>
-                                        <div class="col-6">
-                                            <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
-                                        </div>
-                                        <div class="col-2">
-                                            <!-- 검색 버튼 -->
-                                            <button id="searchbutton" type="submit" class="btn btn-primary">검색</button>
-                                        </div>
                                     </div>
-                                </div>
-                                <div class="col-1" style=""></div>
-                                <div class="col-4">
-                                    <div class="row justify-content-end">
-                                        <!-- 정렬 또는 토글2 -->
-                                        <label>
-                                            <select class="form-select px-3" name="orderBy" onchange="this.form.submit()">
-                                                <option value="recentposted" th:selected="${orderBy == 'recentposted'}">최근남긴순</option>
-                                                <option value="oldestposted" th:selected="${orderBy == 'oldestposted'}">오래된순</option>
-
-                                                <option value="recentadded" th:selected="${orderBy == 'recentadded'}">최근작성순</option>
-                                                <option value="oldestadded" th:selected="${orderBy == 'oldestadded'}">오래된작성순</option>
-
-                                                <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>
-                                                <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>
-                                            </select>
-                                        </label>
-                                    </div>
-                                </div>
-                            </div> <!--검색, 소팅 (토글X)-->
-                            <div class="row justify-content-around">
-                                <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                <div class="col-3" style="padding: 0 1.2rem;">
-                                    <div id="absdiv" class="row justify-content-end">
-                                        <!--                                        <div class="col-3">-->
-                                        <!--                                            <div class="toggle-switch">-->
-                                        <!--                                                &lt;!&ndash; 정렬 또는 토글1 &ndash;&gt;-->
-                                        <!--                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">-->
-                                        <!--                                                <label for="isToggledCheckbox" class="label">-->
-                                        <!--                                                    <div class="ball"></div>-->
-                                        <!--                                                </label>-->
-                                        <!--                                            </div>-->
-                                        <!--                                        </div>-->
-                                        <!--                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">진행중인 행사</div>-->
-                                    </div>
-                                </div>
-                            </div> <!--토글-->
-                        </form>
-                    </div>
-                </div>
-                <div class="row justify-content-around mt-4">
-                    <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
-                        <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
-                            <div class="col-3 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:each="mySoDiary, iterStat : ${mySoDiaries}" th:attr="data-href=@{/social/users/{userId}/diaries/{diaryNo}(userId=${mySoDiary.writerUserId},diaryNo=${mySoDiary.diaryNo})}" th:if="${iterStat.index < 3}">
-                                <div class="row justify-content-center">
-                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                        <div class="date-container px-2 py-1">
-                                            <div class="month" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(mySoDiary.commentCreatedDate)}"></div>
-                                            <div class="year" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(mySoDiary.commentCreatedDate)}"></div>
+                                </div> <!--검색, 소팅 (토글X)-->
+                                <div class="row justify-content-around">
+                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                    <div class="col-3" style="padding: 0 1.2rem;">
+                                        <div id="absdiv" class="row justify-content-end">
+                                            <!--                                        <div class="col-3">-->
+                                            <!--                                            <div class="toggle-switch">-->
+                                            <!--                                                &lt;!&ndash; 정렬 또는 토글1 &ndash;&gt;-->
+                                            <!--                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">-->
+                                            <!--                                                <label for="isToggledCheckbox" class="label">-->
+                                            <!--                                                    <div class="ball"></div>-->
+                                            <!--                                                </label>-->
+                                            <!--                                            </div>-->
+                                            <!--                                        </div>-->
+                                            <!--                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">진행중인 행사</div>-->
                                         </div>
                                     </div>
-                                    <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                    <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                    <!--                                    </div>-->
-                                    <div class="col-5" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
-                                         th:text="${mySoDiary.writerNickname}">닉네임
-                                    </div>
-
-                                    <div class="col-3" style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;" th:text="${mySoDiary.formattedCommentCreatedDate}">시간</div>
-                                </div>
-                                <div class="row justify-content-center">
-                                    <div class="col-12 my-3" style="">
-                                        <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                        <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                        <!-- 썸네일 이미지 있을때  -->
-                                        <img th:if="${mySoDiary.thumbnailUrl != null}" th:src="${mySoDiary.thumbnailUrl}" class="card-img-top" alt="썸네일 이미지">
-                                    </div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" th:text="${mySoDiary.title}">이름</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${mySoDiary.commentContent}">내용</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                </div>
-
-                            </div>
-                            <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
-                            <div class="col-3" th:if="${mySoDiaries.size() == 0}"></div>
-                            <div class="col-3" th:if="${mySoDiaries.size() == 0 || mySoDiaries.size() == 1}"></div>
-                            <div class="col-3" th:if="${mySoDiaries.size() == 0 || mySoDiaries.size() == 1 || mySoDiaries.size() == 2}"></div>
-                        </div>
-                        <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
-                            <div class="col-3 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:each="mySoDiary, iterStat : ${mySoDiaries}" th:attr="data-href=@{/social/users/{userId}/diaries/{diaryNo}(userId=${mySoDiary.writerUserId},diaryNo=${mySoDiary.diaryNo})}" th:if="${iterStat.index >= 3}">
-                                <div class="row justify-content-center">
-                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                        <div class="date-container px-2 py-1">
-                                            <div class="month" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(mySoDiary.commentCreatedDate)}"></div>
-                                            <div class="year" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(mySoDiary.commentCreatedDate)}"></div>
-                                        </div>
-                                    </div>
-                                    <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                    <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                    <!--                                    </div>-->
-                                    <div class="col-5" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
-                                         th:text="${mySoDiary.writerNickname}">닉네임
-                                    </div>
-
-                                    <div class="col-3" style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;" th:text="${mySoDiary.formattedCommentCreatedDate}">시간</div>
-                                </div>
-                                <div class="row justify-content-center">
-                                    <div class="col-12 my-3" style="">
-                                        <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                        <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                        <!-- 썸네일 이미지 있을때  -->
-                                        <img th:if="${mySoDiary.thumbnailUrl != null}" th:src="${mySoDiary.thumbnailUrl}" class="card-img-top" alt="썸네일 이미지">
-                                    </div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" th:text="${mySoDiary.title}">이름</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${mySoDiary.commentContent}">내용</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                </div>
-
-                            </div>
-
-                            <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
-                            <div class="col-3" th:if="${mySoDiaries.size() <= 3}"></div>
-                            <div class="col-3" th:if="${mySoDiaries.size() <= 3 || mySoDiaries.size() == 4}"></div>
-                            <div class="col-3" th:if="${mySoDiaries.size() <= 3 || mySoDiaries.size() == 4 || mySoDiaries.size() == 5}"></div>
+                                </div> <!--토글-->
+                            </form>
                         </div>
                     </div>
-                </div>
-                <div class="row justify-content-center">
-                    <!-- 페이징 -->
-                    <th:block th:if="${pages != null}">
-                        <div class="d-flex justify-content-center">
-                            <div class="btn-group">
-                                <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/so/diary(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-                                        <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                                    </svg>
-                                </button>
-                                <th:block th:each="p : ${#numbers.sequence(1, pages)}">
-                                    <button type="button" class="btn btn-sm me-2 pages"
-                                            th:text="${p}" th:onclick="|location.href='@{/user/my/so/diary(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
-                                </th:block>
-                                <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/so/diary(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-                                        <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
-                                    </svg>
-                                </button>
+                    <div class="row justify-content-around mt-4">
+                        <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
+                            <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
+                                <div class="col-3 clickable-row"
+                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                     th:each="mySoDiary, iterStat : ${mySoDiaries}"
+                                     th:attr="data-href=@{/social/users/{userId}/diaries/{diaryNo}(userId=${mySoDiary.writerUserId},diaryNo=${mySoDiary.diaryNo})}"
+                                     th:if="${iterStat.index < 3}">
+                                    <div class="row justify-content-center">
+                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                             style="aspect-ratio: 1; border-radius: 5px;">
+                                            <div class="date-container px-2 py-1">
+                                                <div class="month"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(mySoDiary.commentCreatedDate)}"></div>
+                                                <div class="year"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(mySoDiary.commentCreatedDate)}"></div>
+                                            </div>
+                                        </div>
+                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                        <!--                                    </div>-->
+                                        <div class="col-5" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
+                                             th:text="${mySoDiary.writerNickname}">닉네임
+                                        </div>
+
+                                        <div class="col-3"
+                                             style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
+                                             th:text="${mySoDiary.formattedCommentCreatedDate}">시간
+                                        </div>
+                                    </div>
+                                    <div class="row justify-content-center">
+                                        <div class="col-12 my-3" style="">
+                                            <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                            <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                            <!-- 썸네일 이미지 있을때  -->
+                                            <img th:if="${mySoDiary.thumbnailUrl != null}"
+                                                 th:src="${mySoDiary.thumbnailUrl}" class="card-img-top" alt="썸네일 이미지">
+                                        </div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                             th:text="${mySoDiary.title}">이름
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                             th:text="${mySoDiary.commentContent}">내용
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                    </div>
+
+                                </div>
+                                <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
+                                <div class="col-3" th:if="${mySoDiaries.size() == 0}"></div>
+                                <div class="col-3" th:if="${mySoDiaries.size() == 0 || mySoDiaries.size() == 1}"></div>
+                                <div class="col-3"
+                                     th:if="${mySoDiaries.size() == 0 || mySoDiaries.size() == 1 || mySoDiaries.size() == 2}"></div>
+                            </div>
+                            <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
+                                <div class="col-3 clickable-row"
+                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                     th:each="mySoDiary, iterStat : ${mySoDiaries}"
+                                     th:attr="data-href=@{/social/users/{userId}/diaries/{diaryNo}(userId=${mySoDiary.writerUserId},diaryNo=${mySoDiary.diaryNo})}"
+                                     th:if="${iterStat.index >= 3}">
+                                    <div class="row justify-content-center">
+                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                             style="aspect-ratio: 1; border-radius: 5px;">
+                                            <div class="date-container px-2 py-1">
+                                                <div class="month"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(mySoDiary.commentCreatedDate)}"></div>
+                                                <div class="year"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(mySoDiary.commentCreatedDate)}"></div>
+                                            </div>
+                                        </div>
+                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                        <!--                                    </div>-->
+                                        <div class="col-5" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
+                                             th:text="${mySoDiary.writerNickname}">닉네임
+                                        </div>
+
+                                        <div class="col-3"
+                                             style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
+                                             th:text="${mySoDiary.formattedCommentCreatedDate}">시간
+                                        </div>
+                                    </div>
+                                    <div class="row justify-content-center">
+                                        <div class="col-12 my-3" style="">
+                                            <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                            <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                            <!-- 썸네일 이미지 있을때  -->
+                                            <img th:if="${mySoDiary.thumbnailUrl != null}"
+                                                 th:src="${mySoDiary.thumbnailUrl}" class="card-img-top" alt="썸네일 이미지">
+                                        </div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                             th:text="${mySoDiary.title}">이름
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                             th:text="${mySoDiary.commentContent}">내용
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                    </div>
+
+                                </div>
+
+                                <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
+                                <div class="col-3" th:if="${mySoDiaries.size() <= 3}"></div>
+                                <div class="col-3" th:if="${mySoDiaries.size() <= 3 || mySoDiaries.size() == 4}"></div>
+                                <div class="col-3"
+                                     th:if="${mySoDiaries.size() <= 3 || mySoDiaries.size() == 4 || mySoDiaries.size() == 5}"></div>
                             </div>
                         </div>
-                    </th:block>
-                </div>
-            </div><!--테이블 및 페이징 포함-->
+                    </div>
+                    <div class="row justify-content-center">
+                        <!-- 페이징 -->
+                        <th:block th:if="${pages != null}">
+                            <div class="d-flex justify-content-center">
+                                <div class="btn-group">
+                                    <button type="button" class="btn btn-sm previous"
+                                            th:onclick="|location.href='@{/user/my/so/diary(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
+                                            th:disabled="${currentPage == 1}">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                             fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+                                            <path fill-rule="evenodd"
+                                                  d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                                        </svg>
+                                    </button>
+                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">
+                                        <button type="button" class="btn btn-sm me-2 pages"
+                                                th:text="${p}"
+                                                th:onclick="|location.href='@{/user/my/so/diary(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
+                                    </th:block>
+                                    <button type="button" class="btn btn-sm  next"
+                                            th:onclick="|location.href='@{/user/my/so/diary(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
+                                            th:disabled="${currentPage == pages}">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                             fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+                                            <path fill-rule="evenodd"
+                                                  d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                                        </svg>
+                                    </button>
+                                </div>
+                            </div>
+                        </th:block>
+                    </div>
+                </div><!--테이블 및 페이징 포함-->
+            </div> <!--본화면-->
         </div> <!--본화면-->
-    </div> <!--본화면-->
 
-    <!--수정전-->
-<!--    <div class="col-md-9">-->
-<!--        <div class="review-list">-->
-<!--            <h2>내가 남긴 다이어리 댓글</h2>-->
-<!--            <form id="sort-form" th:action="@{/user/my/so/diary}" method="get">-->
-<!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
-<!--                <label>-->
-<!--                    <select name="searchBy">-->
-<!--                        <option value="comment" th:selected="${searchBy == 'comment'}">댓글내용</option>-->
-<!--                        <option value="rTitle" th:selected="${searchBy == 'dTitle'}">다이어리제목</option>-->
-<!--                        <option value="rTitle" th:selected="${searchBy == 'dContent'}">다이어리내용</option>-->
-<!--                        &lt;!&ndash;                        <option value="title" th:selected="${searchBy == 'title'}">웹툰제목</option>&ndash;&gt;-->
-<!--                        &lt;!&ndash;                        <option value="author" th:selected="${searchBy == 'author'}">작가</option>&ndash;&gt;-->
-<!--                        &lt;!&ndash;                        <option value="genre" th:selected="${searchBy == 'genre'}">장르</option>&ndash;&gt;-->
-<!--                        &lt;!&ndash;                        <option value="tag" th:selected="${searchBy == 'tag'}">태그</option>&ndash;&gt;-->
-<!--                    </select>-->
-<!--                </label>-->
-<!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
+        <!--수정전-->
+        <!--    <div class="col-md-9">-->
+        <!--        <div class="review-list">-->
+        <!--            <h2>내가 남긴 다이어리 댓글</h2>-->
+        <!--            <form id="sort-form" th:action="@{/user/my/so/diary}" method="get">-->
+        <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
+        <!--                <label>-->
+        <!--                    <select name="searchBy">-->
+        <!--                        <option value="comment" th:selected="${searchBy == 'comment'}">댓글내용</option>-->
+        <!--                        <option value="rTitle" th:selected="${searchBy == 'dTitle'}">다이어리제목</option>-->
+        <!--                        <option value="rTitle" th:selected="${searchBy == 'dContent'}">다이어리내용</option>-->
+        <!--                        &lt;!&ndash;                        <option value="title" th:selected="${searchBy == 'title'}">웹툰제목</option>&ndash;&gt;-->
+        <!--                        &lt;!&ndash;                        <option value="author" th:selected="${searchBy == 'author'}">작가</option>&ndash;&gt;-->
+        <!--                        &lt;!&ndash;                        <option value="genre" th:selected="${searchBy == 'genre'}">장르</option>&ndash;&gt;-->
+        <!--                        &lt;!&ndash;                        <option value="tag" th:selected="${searchBy == 'tag'}">태그</option>&ndash;&gt;-->
+        <!--                    </select>-->
+        <!--                </label>-->
+        <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
 
-<!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
-<!--                <button type="submit">검색</button>-->
+        <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
+        <!--                <button type="submit">검색</button>-->
 
-<!--                &lt;!&ndash; 정렬 조건 &ndash;&gt;-->
-<!--                <label>-->
-<!--                    <select name="orderBy" onchange="this.form.submit()">-->
-<!--                        <option value="recentposted" th:selected="${orderBy == 'recentposted'}">최근남긴순</option>-->
-<!--                        <option value="oldestposted" th:selected="${orderBy == 'oldestposted'}">오래된순</option>-->
+        <!--                &lt;!&ndash; 정렬 조건 &ndash;&gt;-->
+        <!--                <label>-->
+        <!--                    <select name="orderBy" onchange="this.form.submit()">-->
+        <!--                        <option value="recentposted" th:selected="${orderBy == 'recentposted'}">최근남긴순</option>-->
+        <!--                        <option value="oldestposted" th:selected="${orderBy == 'oldestposted'}">오래된순</option>-->
 
-<!--                        <option value="recentadded" th:selected="${orderBy == 'recentadded'}">최근작성순</option>-->
-<!--                        <option value="oldestadded" th:selected="${orderBy == 'oldestadded'}">오래된작성순</option>-->
+        <!--                        <option value="recentadded" th:selected="${orderBy == 'recentadded'}">최근작성순</option>-->
+        <!--                        <option value="oldestadded" th:selected="${orderBy == 'oldestadded'}">오래된작성순</option>-->
 
-<!--                        <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>-->
-<!--                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
-<!--                    </select>-->
-<!--                </label>-->
-<!--            </form>-->
-<!--            <table>-->
-<!--                <thead>-->
-<!--                <tr>-->
-<!--                    <th>댓글 번호</th>-->
-<!--                    <th>다이어리 번호</th>-->
-<!--                    <th>댓글 작성자</th>-->
-<!--                    <th>댓글 내용</th>-->
-<!--                    <th>댓글 작성일시</th>-->
-<!--                    <th>웹툰 번호</th>-->
-<!--                    <th>작성자</th>-->
-<!--                    <th>제목</th>-->
-<!--                    <th>다이어리 내용</th>-->
-<!--                    <th>상태 코드</th>-->
-<!--                    <th>다이어리 작성일시</th>-->
-<!--                    <th>다이어리 수정일시</th>-->
-<!--                    <th>조회수</th>-->
-<!--                    <th>*작성자ID</th>-->
-<!--                    <th>*작성자닉네임</th>-->
-<!--                    <th>*썸네일URL</th>-->
-<!--                </tr>-->
-<!--                </thead>-->
-<!--                <tbody>-->
-<!--                <tr th:each="mySoDiary : ${mySoDiaries}" class="clickable-row" th:attr="data-href=@{/social/users/{userId}/diaries/{diaryNo}(userId=${mySoDiary.writerUserId},diaryNo=${mySoDiary.diaryNo})}">-->
-<!--                    <td th:text="${mySoDiary.commentNo}">댓글 번호</td>-->
-<!--                    <td th:text="${mySoDiary.diaryNo}">다이어리 번호</td>-->
-<!--                    <td th:text="${mySoDiary.commenterNo}">댓글 작성자</td>-->
-<!--                    <td th:text="${mySoDiary.commentContent}">댓글 내용</td>-->
-<!--                    <td th:text="${mySoDiary.commentCreatedDate}">댓글 작성일시</td>-->
-<!--                    <td th:text="${mySoDiary.webtoonNo}">웹툰 번호</td>-->
-<!--                    <td th:text="${mySoDiary.writerNo}">작성자</td>-->
-<!--                    <td th:text="${mySoDiary.title}">제목</td>-->
-<!--                    <td th:text="${mySoDiary.diaryContent}">다이어리 내용</td>-->
-<!--                    <td th:text="${mySoDiary.statusCode}">상태 코드</td>-->
-<!--                    <td th:text="${mySoDiary.diaryCreatedDate}">다이어리 작성일시</td>-->
-<!--                    <td th:text="${mySoDiary.diaryModifiedDate}">다이어리 수정일시</td>-->
-<!--                    <td th:text="${mySoDiary.viewCnt}">조회수</td>-->
-<!--                    <td th:text="${mySoDiary.writerUserId}">*작성자ID</td>-->
-<!--                    <td th:text="${mySoDiary.writerUserId}">*작성자닉네임</td>-->
-<!--                    <td th:text="${mySoDiary.thumbnailUrl}">*썸네일URL</td>-->
-<!--                </tr>-->
-<!--                </tbody>-->
-<!--            </table>-->
-<!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
-<!--            <th:block th:if="${pages != null}">-->
-<!--                <div class="d-flex justify-content-center">-->
-<!--                    <div class="btn-group">-->
-<!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/so/diary(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
-<!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
-<!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
-<!--                            </svg>-->
-<!--                        </button>-->
-<!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
-<!--                            <button type="button" class="btn btn-sm me-2 pages"-->
-<!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/so/diary(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
-<!--                        </th:block>-->
-<!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/so/diary(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
-<!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
-<!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
-<!--                            </svg>-->
-<!--                        </button>-->
-<!--                    </div>-->
-<!--                </div>-->
-<!--            </th:block>-->
-<!--        </div>-->
-<!--    </div>-->
+        <!--                        <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>-->
+        <!--                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
+        <!--                    </select>-->
+        <!--                </label>-->
+        <!--            </form>-->
+        <!--            <table>-->
+        <!--                <thead>-->
+        <!--                <tr>-->
+        <!--                    <th>댓글 번호</th>-->
+        <!--                    <th>다이어리 번호</th>-->
+        <!--                    <th>댓글 작성자</th>-->
+        <!--                    <th>댓글 내용</th>-->
+        <!--                    <th>댓글 작성일시</th>-->
+        <!--                    <th>웹툰 번호</th>-->
+        <!--                    <th>작성자</th>-->
+        <!--                    <th>제목</th>-->
+        <!--                    <th>다이어리 내용</th>-->
+        <!--                    <th>상태 코드</th>-->
+        <!--                    <th>다이어리 작성일시</th>-->
+        <!--                    <th>다이어리 수정일시</th>-->
+        <!--                    <th>조회수</th>-->
+        <!--                    <th>*작성자ID</th>-->
+        <!--                    <th>*작성자닉네임</th>-->
+        <!--                    <th>*썸네일URL</th>-->
+        <!--                </tr>-->
+        <!--                </thead>-->
+        <!--                <tbody>-->
+        <!--                <tr th:each="mySoDiary : ${mySoDiaries}" class="clickable-row" th:attr="data-href=@{/social/users/{userId}/diaries/{diaryNo}(userId=${mySoDiary.writerUserId},diaryNo=${mySoDiary.diaryNo})}">-->
+        <!--                    <td th:text="${mySoDiary.commentNo}">댓글 번호</td>-->
+        <!--                    <td th:text="${mySoDiary.diaryNo}">다이어리 번호</td>-->
+        <!--                    <td th:text="${mySoDiary.commenterNo}">댓글 작성자</td>-->
+        <!--                    <td th:text="${mySoDiary.commentContent}">댓글 내용</td>-->
+        <!--                    <td th:text="${mySoDiary.commentCreatedDate}">댓글 작성일시</td>-->
+        <!--                    <td th:text="${mySoDiary.webtoonNo}">웹툰 번호</td>-->
+        <!--                    <td th:text="${mySoDiary.writerNo}">작성자</td>-->
+        <!--                    <td th:text="${mySoDiary.title}">제목</td>-->
+        <!--                    <td th:text="${mySoDiary.diaryContent}">다이어리 내용</td>-->
+        <!--                    <td th:text="${mySoDiary.statusCode}">상태 코드</td>-->
+        <!--                    <td th:text="${mySoDiary.diaryCreatedDate}">다이어리 작성일시</td>-->
+        <!--                    <td th:text="${mySoDiary.diaryModifiedDate}">다이어리 수정일시</td>-->
+        <!--                    <td th:text="${mySoDiary.viewCnt}">조회수</td>-->
+        <!--                    <td th:text="${mySoDiary.writerUserId}">*작성자ID</td>-->
+        <!--                    <td th:text="${mySoDiary.writerUserId}">*작성자닉네임</td>-->
+        <!--                    <td th:text="${mySoDiary.thumbnailUrl}">*썸네일URL</td>-->
+        <!--                </tr>-->
+        <!--                </tbody>-->
+        <!--            </table>-->
+        <!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
+        <!--            <th:block th:if="${pages != null}">-->
+        <!--                <div class="d-flex justify-content-center">-->
+        <!--                    <div class="btn-group">-->
+        <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/so/diary(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
+        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
+        <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
+        <!--                            </svg>-->
+        <!--                        </button>-->
+        <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
+        <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
+        <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/so/diary(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
+        <!--                        </th:block>-->
+        <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/so/diary(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
+        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
+        <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
+        <!--                            </svg>-->
+        <!--                        </button>-->
+        <!--                    </div>-->
+        <!--                </div>-->
+        <!--            </th:block>-->
+        <!--        </div>-->
+        <!--    </div>-->
+    </div>
 </div>
 <div th:replace="common/footer.html"></div>
 </body>

--- a/src/main/resources/templates/user/mypage_so_diary.html
+++ b/src/main/resources/templates/user/mypage_so_diary.html
@@ -131,7 +131,7 @@
     <div class="row">
         <aside class="col-md-3 px-4">
             <div class="row">
-                <div class="col-3"></div>
+                <div class="col-1"></div>
                 <div class="col-6">
                     <div class="panel">
                         <ul class="list-group">

--- a/src/main/resources/templates/user/mypage_so_review.html
+++ b/src/main/resources/templates/user/mypage_so_review.html
@@ -343,7 +343,7 @@
                                 }
 
                                 .search-container button i {
-                                    color: #666;
+                                    color: #A6AAB5;
                                 }
 
                                 .search-container button:hover i {

--- a/src/main/resources/templates/user/mypage_so_review.html
+++ b/src/main/resources/templates/user/mypage_so_review.html
@@ -122,452 +122,523 @@
         </div>
     </div>
 </div>
-<div class="row">
-    <aside class="col-md-3 px-4">
-        <div class="row">
-            <div class="col-3"></div>
-            <div class="col-6">
-                <div class="panel">
-                    <ul class="list-group">
-                        <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
-                        <li><a th:href="@{/user/my/so/review}" class="nav-link px-2" style="color: #03C75A;">나의 소셜</a></li>
-                        <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
-                        <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-                        <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                        <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-                    </ul>
+<div class="container" style="padding:0;">
+    <div class="row">
+        <aside class="col-md-3 px-4">
+            <div class="row">
+                <div class="col-3"></div>
+                <div class="col-6">
+                    <div class="panel">
+                        <ul class="list-group">
+                            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
+                            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2" style="color: #03C75A;">나의
+                                소셜</a></li>
+                            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
+                            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+                        </ul>
+                    </div>
                 </div>
             </div>
-        </div>
-    </aside>
-    <style>
-        .form-select {
-        background-color : #FCFCFC;
-        border : none;
-        width : 100%;
-        height : 50px;
-        }
-        select {
-        color : #828282;
-        }
-        .form-control {
-        background-color : #FCFCFC;
-        border : none;
-        width : 100%;
-        height : 50px;
-        }
-
-
-        .form-control::placeholder {
-        color : #BBBBBB;
-        }
-
-        .date-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    background-color: #8E4B6E;
-    color: white;
-    border-radius: 10px;
-    text-align:center;
-    font-family: "Work Sans", sans-serif;
-}
-
-.platform-1 {
-    background-color: #03C75A;
-}
-
-.platform-2 {
-    background-color: #F5BF41;
-}
-
-.month {
-    font-size: 1.1rem; /* M의 크기를 설정 */
-    font-weight: 550;
-    line-height: 1;
-}
-
-.year {
-    font-size: 0.65rem; /* yyyy의 크기를 설정 */
-    font-weight: 400;
-}
-:root {
-    --background-color-light: #FFFFFF;
-    --text-color-light: #000000;
-    --toggle-background-light: #CCCCCC;
-    --toggle-ball-light: #FFFFFF;
-
-    --background-color-dark: #333333;
-    --text-color-dark: #FFFFFF;
-    --toggle-background-dark: #03C75A;
-    --toggle-ball-dark: #FFFFFF;
-
-    --font-size-base: 32px; /* 기본 텍스트 크기 */
-    --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
-}
-
-
-
-.toggle-switch {
-    position: relative;
-    display: inline-block;
-    width: 62px; /* 너비 조정 */
-    height: 38px; /* 높이 조정 */
-}
-
-.toggle-switch .checkbox {
-    opacity: 0;
-    width: 0;
-    height: 0;
-}
-#isToggledCheckbox {
-     opacity: 0;
-        width: 0;
-        height: 0;
-}
-
-.toggle-switch .label {
-    position: absolute;
-    cursor: pointer;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: var(--toggle-background-light);
-    transition: background-color 0.4s;
-    border-radius: 38px; /* 둥근 모서리 반경 조정 */
-}
-
-.toggle-switch .label:before {
-    position: absolute;
-    content: "";
-    height: 30px; /* 내부 원 높이 조정 */
-    width: 30px; /* 내부 원 너비 조정 */
-    left: 2px;
-    bottom: 0px;
-    background-color: var(--toggle-ball-light);
-    transition: transform 0.4s;
-    border-radius: 50%;
-}
-
-.toggle-switch input:checked + .label {
-    background-color: var(--toggle-background-dark);
-}
-
-.toggle-switch input:checked + .label:before {
-    transform: translateX(28px); /* 내부 원 이동 거리 조정 */
-}
-
-         #absdiv {
-            position: relative;
-            top: 60px; /* Move down by 20px from its current position */
-            z-index : 1000;
-        }
-
-        #searchbutton {
-            background-color: #828282;
-        }
-
-        .card-img-top {
-                width: 100%;
-                height: 100px;
-                object-fit: cover;
+        </aside>
+        <style>
+            .form-select {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
+            }
+            select {
+            color : #828282;
+            }
+            .form-control {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
             }
 
-    </style>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+
+            .form-control::placeholder {
+            color : #BBBBBB;
+            }
+
+            .date-container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        background-color: #8E4B6E;
+        color: white;
+        border-radius: 10px;
+        text-align:center;
+        font-family: "Work Sans", sans-serif;
+    }
+
+    .platform-1 {
+        background-color: #03C75A;
+    }
+
+    .platform-2 {
+        background-color: #F5BF41;
+    }
+
+    .month {
+        font-size: 1.1rem; /* M의 크기를 설정 */
+        font-weight: 550;
+        line-height: 1;
+    }
+
+    .year {
+        font-size: 0.65rem; /* yyyy의 크기를 설정 */
+        font-weight: 400;
+    }
+    :root {
+        --background-color-light: #FFFFFF;
+        --text-color-light: #000000;
+        --toggle-background-light: #CCCCCC;
+        --toggle-ball-light: #FFFFFF;
+
+        --background-color-dark: #333333;
+        --text-color-dark: #FFFFFF;
+        --toggle-background-dark: #03C75A;
+        --toggle-ball-dark: #FFFFFF;
+
+        --font-size-base: 32px; /* 기본 텍스트 크기 */
+        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+    }
 
 
-    <div class="col-md-9">
-        <div class="row" style="color: #828282;">
-            <div class="col-11">
-                <div class="row mb-4">
-                    <div class="col-12">
-                        <form id="sort-form" th:action="@{/user/my/so/review}" method="get">
-                            <div class="row">
-                                <div class="col-7">
-                                    <div class="row justify-content-start m-0">
-                                        <div class="col-4">
-                                            <!-- 검색 조건 -->
+
+    .toggle-switch {
+        position: relative;
+        display: inline-block;
+        width: 62px; /* 너비 조정 */
+        height: 38px; /* 높이 조정 */
+    }
+
+    .toggle-switch .checkbox {
+        opacity: 0;
+        width: 0;
+        height: 0;
+    }
+    #isToggledCheckbox {
+         opacity: 0;
+            width: 0;
+            height: 0;
+    }
+
+    .toggle-switch .label {
+        position: absolute;
+        cursor: pointer;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: var(--toggle-background-light);
+        transition: background-color 0.4s;
+        border-radius: 38px; /* 둥근 모서리 반경 조정 */
+    }
+
+    .toggle-switch .label:before {
+        position: absolute;
+        content: "";
+        height: 30px; /* 내부 원 높이 조정 */
+        width: 30px; /* 내부 원 너비 조정 */
+        left: 2px;
+        bottom: 0px;
+        background-color: var(--toggle-ball-light);
+        transition: transform 0.4s;
+        border-radius: 50%;
+    }
+
+    .toggle-switch input:checked + .label {
+        background-color: var(--toggle-background-dark);
+    }
+
+    .toggle-switch input:checked + .label:before {
+        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+    }
+
+             #absdiv {
+                position: relative;
+                top: 60px; /* Move down by 20px from its current position */
+                z-index : 1000;
+            }
+
+            #searchbutton {
+                background-color: #828282;
+            }
+
+            .card-img-top {
+                    width: 100%;
+                    height: 100px;
+                    object-fit: cover;
+                }
+
+        </style>
+        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+              rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+              rel="stylesheet">
+
+
+        <div class="col-md-9">
+            <div class="row" style="color: #828282;">
+                <div class="col-11">
+                    <div class="row mb-4">
+                        <div class="col-12">
+                            <form id="sort-form" th:action="@{/user/my/so/review}" method="get">
+                                <div class="row">
+                                    <div class="col-7">
+                                        <div class="row justify-content-start m-0">
+                                            <div class="col-4">
+                                                <!-- 검색 조건 -->
+                                                <label>
+                                                    <select class="form-select px-3" name="searchBy">
+                                                        <option value="rTitle" th:selected="${searchBy == 'rTitle'}">
+                                                            리뷰제목
+                                                        </option>
+                                                        <option value="rContent"
+                                                                th:selected="${searchBy == 'rContent'}">리뷰내용
+                                                        </option>
+                                                        <!--                        <option value="title" th:selected="${searchBy == 'title'}">웹툰제목</option>-->
+                                                        <!--                        <option value="author" th:selected="${searchBy == 'author'}">작가</option>-->
+                                                        <!--                        <option value="genre" th:selected="${searchBy == 'genre'}">장르</option>-->
+                                                        <!--                        <option value="tag" th:selected="${searchBy == 'tag'}">태그</option>-->
+                                                    </select>
+                                                </label>
+                                            </div>
+                                            <div class="col-6">
+                                                <input class="form-control px-3" type="text" name="searchTerm"
+                                                       placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
+                                            </div>
+                                            <div class="col-2">
+                                                <!-- 검색 버튼 -->
+                                                <button id="searchbutton" type="submit" class="btn btn-primary">검색
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-1" style=""></div>
+                                    <div class="col-4">
+                                        <div class="row justify-content-end">
+                                            <!-- 정렬 또는 토글2 -->
                                             <label>
-                                                <select class="form-select px-3" name="searchBy">
-                                                    <option value="rTitle" th:selected="${searchBy == 'rTitle'}">리뷰제목</option>
-                                                    <option value="rContent" th:selected="${searchBy == 'rContent'}">리뷰내용</option>
-                                                    <!--                        <option value="title" th:selected="${searchBy == 'title'}">웹툰제목</option>-->
-                                                    <!--                        <option value="author" th:selected="${searchBy == 'author'}">작가</option>-->
-                                                    <!--                        <option value="genre" th:selected="${searchBy == 'genre'}">장르</option>-->
-                                                    <!--                        <option value="tag" th:selected="${searchBy == 'tag'}">태그</option>-->
+                                                <select class="form-select px-3" name="orderBy"
+                                                        onchange="this.form.submit()">
+                                                    <option value="recentliked"
+                                                            th:selected="${orderBy == 'recentliked'}">최근좋아요순
+                                                    </option>
+                                                    <option value="oldestliked"
+                                                            th:selected="${orderBy == 'oldestliked'}">오래된좋아요순
+                                                    </option>
+
+                                                    <option value="recentadded"
+                                                            th:selected="${orderBy == 'recentadded'}">최근작성순
+                                                    </option>
+                                                    <option value="oldestadded"
+                                                            th:selected="${orderBy == 'oldestadded'}">오래된작성순
+                                                    </option>
+
+                                                    <option value="highrated" th:selected="${orderBy == 'highrated'}">
+                                                        별점높은순
+                                                    </option>
+                                                    <option value="lowrated" th:selected="${orderBy == 'lowrated'}">
+                                                        별점낮은순
+                                                    </option>
+
+                                                    <option value="views" th:selected="${orderBy == 'views'}">조회수높은순
+                                                    </option>
+                                                    <option value="title" th:selected="${orderBy == 'title'}">제목가나다순
+                                                    </option>
                                                 </select>
                                             </label>
                                         </div>
-                                        <div class="col-6">
-                                            <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
-                                        </div>
-                                        <div class="col-2">
-                                            <!-- 검색 버튼 -->
-                                            <button id="searchbutton" type="submit" class="btn btn-primary">검색</button>
-                                        </div>
                                     </div>
-                                </div>
-                                <div class="col-1" style=""></div>
-                                <div class="col-4">
-                                    <div class="row justify-content-end">
-                                        <!-- 정렬 또는 토글2 -->
-                                        <label>
-                                            <select class="form-select px-3" name="orderBy" onchange="this.form.submit()">
-                                                <option value="recentliked" th:selected="${orderBy == 'recentliked'}">최근좋아요순</option>
-                                                <option value="oldestliked" th:selected="${orderBy == 'oldestliked'}">오래된좋아요순</option>
-
-                                                <option value="recentadded" th:selected="${orderBy == 'recentadded'}">최근작성순</option>
-                                                <option value="oldestadded" th:selected="${orderBy == 'oldestadded'}">오래된작성순</option>
-
-                                                <option value="highrated" th:selected="${orderBy == 'highrated'}">별점높은순</option>
-                                                <option value="lowrated" th:selected="${orderBy == 'lowrated'}">별점낮은순</option>
-
-                                                <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>
-                                                <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>
-                                            </select>
-                                        </label>
-                                    </div>
-                                </div>
-                            </div> <!--검색, 소팅 (토글X)-->
-                            <div class="row justify-content-around">
-                                <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                <div class="col-3" style="padding: 0 1.2rem;">
-                                    <div id="absdiv" class="row justify-content-end">
-                                        <!--                                        <div class="col-3">-->
-                                        <!--                                            <div class="toggle-switch">-->
-                                        <!--                                                &lt;!&ndash; 정렬 또는 토글1 &ndash;&gt;-->
-                                        <!--                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">-->
-                                        <!--                                                <label for="isToggledCheckbox" class="label">-->
-                                        <!--                                                    <div class="ball"></div>-->
-                                        <!--                                                </label>-->
-                                        <!--                                            </div>-->
-                                        <!--                                        </div>-->
-                                        <!--                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">진행중인 행사</div>-->
-                                    </div>
-                                </div>
-                            </div> <!--토글-->
-                        </form>
-                    </div>
-                </div>
-                <div class="row justify-content-around mt-4">
-                    <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
-                        <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
-                            <div class="col-3 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:each="mySoReview, iterStat : ${mySoReviews}" th:attr="data-href=@{/social/users/{userId}/reviews/{reviewNo}(userId=${mySoReview.writerUserId},reviewNo=${mySoReview.reviewNo})}" th:if="${iterStat.index < 3}">
-                                <div class="row justify-content-center">
-                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                        <div class="date-container px-2 py-1">
-                                            <div class="month" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(mySoReview.likedDate)}"></div>
-                                            <div class="year" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(mySoReview.likedDate)}"></div>
+                                </div> <!--검색, 소팅 (토글X)-->
+                                <div class="row justify-content-around">
+                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                    <div class="col-3" style="padding: 0 1.2rem;">
+                                        <div id="absdiv" class="row justify-content-end">
+                                            <!--                                        <div class="col-3">-->
+                                            <!--                                            <div class="toggle-switch">-->
+                                            <!--                                                &lt;!&ndash; 정렬 또는 토글1 &ndash;&gt;-->
+                                            <!--                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">-->
+                                            <!--                                                <label for="isToggledCheckbox" class="label">-->
+                                            <!--                                                    <div class="ball"></div>-->
+                                            <!--                                                </label>-->
+                                            <!--                                            </div>-->
+                                            <!--                                        </div>-->
+                                            <!--                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">진행중인 행사</div>-->
                                         </div>
                                     </div>
-                                    <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                    <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                    <!--                                    </div>-->
-                                    <div class="col-5" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
-                                         th:text="${mySoReview.writerNickname}">닉네임
-                                    </div>
-
-                                    <div class="col-3" style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;" th:text="${mySoReview.formattedLikedDate}">시간</div>
-                                </div>
-                                <div class="row justify-content-center">
-                                    <div class="col-12 my-3" style="">
-                                        <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                        <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                        <!-- 썸네일 이미지 있을때  -->
-                                        <img th:if="${mySoReview.thumbnailUrl != null}" th:src="${mySoReview.thumbnailUrl}" class="card-img-top" alt="썸네일 이미지">
-                                    </div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" th:text="${mySoReview.title}">이름</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${mySoReview.content}">내용</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                </div>
-
-                            </div>
-                            <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
-                            <div class="col-3" th:if="${mySoReviews.size() == 0}"></div>
-                            <div class="col-3" th:if="${mySoReviews.size() == 0 || mySoReviews.size() == 1}"></div>
-                            <div class="col-3" th:if="${mySoReviews.size() == 0 || mySoReviews.size() == 1 || mySoReviews.size() == 2}"></div>
-                        </div>
-                        <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
-                            <div class="col-3 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:each="mySoReview, iterStat : ${mySoReviews}" th:attr="data-href=@{/social/users/{userId}/reviews/{reviewNo}(userId=${mySoReview.writerUserId},reviewNo=${mySoReview.reviewNo})}" th:if="${iterStat.index >= 3}">
-                                <div class="row justify-content-center">
-                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                        <div class="date-container px-2 py-1">
-                                            <div class="month" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(mySoReview.likedDate)}"></div>
-                                            <div class="year" th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(mySoReview.likedDate)}"></div>
-                                        </div>
-                                    </div>
-                                    <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                    <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                    <!--                                    </div>-->
-                                    <div class="col-5" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
-                                         th:text="${mySoReview.writerNickname}">닉네임
-                                    </div>
-
-                                    <div class="col-3" style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;" th:text="${mySoReview.formattedLikedDate}">시간</div>
-                                </div>
-                                <div class="row justify-content-center">
-                                    <div class="col-12 my-3" style="">
-                                        <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                        <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                        <!-- 썸네일 이미지 있을때  -->
-                                        <img th:if="${mySoReview.thumbnailUrl != null}" th:src="${mySoReview.thumbnailUrl}" class="card-img-top" alt="썸네일 이미지">
-                                    </div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" th:text="${mySoReview.title}">이름</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${mySoReview.content}">내용</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                </div>
-
-                            </div>
-
-                            <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
-                            <div class="col-3" th:if="${mySoReviews.size() <= 3}"></div>
-                            <div class="col-3" th:if="${mySoReviews.size() <= 3 || mySoReviews.size() == 4}"></div>
-                            <div class="col-3" th:if="${mySoReviews.size() <= 3 || mySoReviews.size() == 4 || mySoReviews.size() == 5}"></div>
+                                </div> <!--토글-->
+                            </form>
                         </div>
                     </div>
-                </div>
-                <div class="row justify-content-center">
-                    <!-- 페이징 -->
-                    <th:block th:if="${pages != null}">
-                        <div class="d-flex justify-content-center">
-                            <div class="btn-group">
-                                <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/so/review(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-                                        <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                                    </svg>
-                                </button>
-                                <th:block th:each="p : ${#numbers.sequence(1, pages)}">
-                                    <button type="button" class="btn btn-sm me-2 pages"
-                                            th:text="${p}" th:onclick="|location.href='@{/user/my/so/review(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
-                                </th:block>
-                                <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/so/review(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-                                        <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
-                                    </svg>
-                                </button>
+                    <div class="row justify-content-around mt-4">
+                        <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
+                            <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
+                                <div class="col-3 clickable-row"
+                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                     th:each="mySoReview, iterStat : ${mySoReviews}"
+                                     th:attr="data-href=@{/social/users/{userId}/reviews/{reviewNo}(userId=${mySoReview.writerUserId},reviewNo=${mySoReview.reviewNo})}"
+                                     th:if="${iterStat.index < 3}">
+                                    <div class="row justify-content-center">
+                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                             style="aspect-ratio: 1; border-radius: 5px;">
+                                            <div class="date-container px-2 py-1">
+                                                <div class="month"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(mySoReview.likedDate)}"></div>
+                                                <div class="year"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(mySoReview.likedDate)}"></div>
+                                            </div>
+                                        </div>
+                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                        <!--                                    </div>-->
+                                        <div class="col-5" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
+                                             th:text="${mySoReview.writerNickname}">닉네임
+                                        </div>
+
+                                        <div class="col-3"
+                                             style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
+                                             th:text="${mySoReview.formattedLikedDate}">시간
+                                        </div>
+                                    </div>
+                                    <div class="row justify-content-center">
+                                        <div class="col-12 my-3" style="">
+                                            <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                            <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                            <!-- 썸네일 이미지 있을때  -->
+                                            <img th:if="${mySoReview.thumbnailUrl != null}"
+                                                 th:src="${mySoReview.thumbnailUrl}" class="card-img-top" alt="썸네일 이미지">
+                                        </div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                             th:text="${mySoReview.title}">이름
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                             th:text="${mySoReview.content}">내용
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                    </div>
+
+                                </div>
+                                <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
+                                <div class="col-3" th:if="${mySoReviews.size() == 0}"></div>
+                                <div class="col-3" th:if="${mySoReviews.size() == 0 || mySoReviews.size() == 1}"></div>
+                                <div class="col-3"
+                                     th:if="${mySoReviews.size() == 0 || mySoReviews.size() == 1 || mySoReviews.size() == 2}"></div>
+                            </div>
+                            <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
+                                <div class="col-3 clickable-row"
+                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                     th:each="mySoReview, iterStat : ${mySoReviews}"
+                                     th:attr="data-href=@{/social/users/{userId}/reviews/{reviewNo}(userId=${mySoReview.writerUserId},reviewNo=${mySoReview.reviewNo})}"
+                                     th:if="${iterStat.index >= 3}">
+                                    <div class="row justify-content-center">
+                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                             style="aspect-ratio: 1; border-radius: 5px;">
+                                            <div class="date-container px-2 py-1">
+                                                <div class="month"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(mySoReview.likedDate)}"></div>
+                                                <div class="year"
+                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(mySoReview.likedDate)}"></div>
+                                            </div>
+                                        </div>
+                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                        <!--                                    </div>-->
+                                        <div class="col-5" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
+                                             th:text="${mySoReview.writerNickname}">닉네임
+                                        </div>
+
+                                        <div class="col-3"
+                                             style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
+                                             th:text="${mySoReview.formattedLikedDate}">시간
+                                        </div>
+                                    </div>
+                                    <div class="row justify-content-center">
+                                        <div class="col-12 my-3" style="">
+                                            <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                            <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                            <!-- 썸네일 이미지 있을때  -->
+                                            <img th:if="${mySoReview.thumbnailUrl != null}"
+                                                 th:src="${mySoReview.thumbnailUrl}" class="card-img-top" alt="썸네일 이미지">
+                                        </div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                             th:text="${mySoReview.title}">이름
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                             th:text="${mySoReview.content}">내용
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                    </div>
+
+                                </div>
+
+                                <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
+                                <div class="col-3" th:if="${mySoReviews.size() <= 3}"></div>
+                                <div class="col-3" th:if="${mySoReviews.size() <= 3 || mySoReviews.size() == 4}"></div>
+                                <div class="col-3"
+                                     th:if="${mySoReviews.size() <= 3 || mySoReviews.size() == 4 || mySoReviews.size() == 5}"></div>
                             </div>
                         </div>
-                    </th:block>
-                </div>
-            </div><!--테이블 및 페이징 포함-->
+                    </div>
+                    <div class="row justify-content-center">
+                        <!-- 페이징 -->
+                        <th:block th:if="${pages != null}">
+                            <div class="d-flex justify-content-center">
+                                <div class="btn-group">
+                                    <button type="button" class="btn btn-sm previous"
+                                            th:onclick="|location.href='@{/user/my/so/review(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
+                                            th:disabled="${currentPage == 1}">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                             fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+                                            <path fill-rule="evenodd"
+                                                  d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                                        </svg>
+                                    </button>
+                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">
+                                        <button type="button" class="btn btn-sm me-2 pages"
+                                                th:text="${p}"
+                                                th:onclick="|location.href='@{/user/my/so/review(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
+                                    </th:block>
+                                    <button type="button" class="btn btn-sm  next"
+                                            th:onclick="|location.href='@{/user/my/so/review(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
+                                            th:disabled="${currentPage == pages}">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                             fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+                                            <path fill-rule="evenodd"
+                                                  d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                                        </svg>
+                                    </button>
+                                </div>
+                            </div>
+                        </th:block>
+                    </div>
+                </div><!--테이블 및 페이징 포함-->
+            </div> <!--본화면-->
         </div> <!--본화면-->
-    </div> <!--본화면-->
 
-    <!--수정전-->
-<!--    <div class="col-md-9">-->
-<!--        <div class="review-list">-->
-<!--            <h2>좋아요한 리뷰</h2>-->
-<!--            <form id="sort-form" th:action="@{/user/my/so/review}" method="get">-->
-<!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
-<!--                <label>-->
-<!--                    <select name="searchBy">-->
-<!--                        <option value="rTitle" th:selected="${searchBy == 'rTitle'}">리뷰제목</option>-->
-<!--                        <option value="rContent" th:selected="${searchBy == 'rContent'}">리뷰내용</option>-->
-<!--&lt;!&ndash;                        <option value="title" th:selected="${searchBy == 'title'}">웹툰제목</option>&ndash;&gt;-->
-<!--&lt;!&ndash;                        <option value="author" th:selected="${searchBy == 'author'}">작가</option>&ndash;&gt;-->
-<!--&lt;!&ndash;                        <option value="genre" th:selected="${searchBy == 'genre'}">장르</option>&ndash;&gt;-->
-<!--&lt;!&ndash;                        <option value="tag" th:selected="${searchBy == 'tag'}">태그</option>&ndash;&gt;-->
-<!--                    </select>-->
-<!--                </label>-->
-<!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
+        <!--수정전-->
+        <!--    <div class="col-md-9">-->
+        <!--        <div class="review-list">-->
+        <!--            <h2>좋아요한 리뷰</h2>-->
+        <!--            <form id="sort-form" th:action="@{/user/my/so/review}" method="get">-->
+        <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
+        <!--                <label>-->
+        <!--                    <select name="searchBy">-->
+        <!--                        <option value="rTitle" th:selected="${searchBy == 'rTitle'}">리뷰제목</option>-->
+        <!--                        <option value="rContent" th:selected="${searchBy == 'rContent'}">리뷰내용</option>-->
+        <!--&lt;!&ndash;                        <option value="title" th:selected="${searchBy == 'title'}">웹툰제목</option>&ndash;&gt;-->
+        <!--&lt;!&ndash;                        <option value="author" th:selected="${searchBy == 'author'}">작가</option>&ndash;&gt;-->
+        <!--&lt;!&ndash;                        <option value="genre" th:selected="${searchBy == 'genre'}">장르</option>&ndash;&gt;-->
+        <!--&lt;!&ndash;                        <option value="tag" th:selected="${searchBy == 'tag'}">태그</option>&ndash;&gt;-->
+        <!--                    </select>-->
+        <!--                </label>-->
+        <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
 
-<!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
-<!--                <button type="submit">검색</button>-->
+        <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
+        <!--                <button type="submit">검색</button>-->
 
-<!--                &lt;!&ndash; 정렬 조건 &ndash;&gt;-->
-<!--                <label>-->
-<!--                    <select name="orderBy" onchange="this.form.submit()">-->
-<!--                        <option value="recentliked" th:selected="${orderBy == 'recentliked'}">최근좋아요순</option>-->
-<!--                        <option value="oldestliked" th:selected="${orderBy == 'oldestliked'}">오래된좋아요순</option>-->
+        <!--                &lt;!&ndash; 정렬 조건 &ndash;&gt;-->
+        <!--                <label>-->
+        <!--                    <select name="orderBy" onchange="this.form.submit()">-->
+        <!--                        <option value="recentliked" th:selected="${orderBy == 'recentliked'}">최근좋아요순</option>-->
+        <!--                        <option value="oldestliked" th:selected="${orderBy == 'oldestliked'}">오래된좋아요순</option>-->
 
-<!--                        <option value="recentadded" th:selected="${orderBy == 'recentadded'}">최근작성순</option>-->
-<!--                        <option value="oldestadded" th:selected="${orderBy == 'oldestadded'}">오래된작성순</option>-->
+        <!--                        <option value="recentadded" th:selected="${orderBy == 'recentadded'}">최근작성순</option>-->
+        <!--                        <option value="oldestadded" th:selected="${orderBy == 'oldestadded'}">오래된작성순</option>-->
 
-<!--                        <option value="highrated" th:selected="${orderBy == 'highrated'}">별점높은순</option>-->
-<!--                        <option value="lowrated" th:selected="${orderBy == 'lowrated'}">별점낮은순</option>-->
+        <!--                        <option value="highrated" th:selected="${orderBy == 'highrated'}">별점높은순</option>-->
+        <!--                        <option value="lowrated" th:selected="${orderBy == 'lowrated'}">별점낮은순</option>-->
 
-<!--                        <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>-->
-<!--                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
-<!--                    </select>-->
-<!--                </label>-->
-<!--            </form>-->
+        <!--                        <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>-->
+        <!--                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
+        <!--                    </select>-->
+        <!--                </label>-->
+        <!--            </form>-->
 
-<!--            <table>-->
-<!--                <thead>-->
-<!--                <tr>-->
-<!--                    <th>좋아요 번호</th>-->
-<!--                    <th>리뷰 번호</th>-->
-<!--                    <th>좋아요 한 회원</th>-->
-<!--                    <th>좋아요 일시</th>-->
-<!--                    <th>웹툰 번호</th>-->
-<!--                    <th>제목</th>-->
-<!--                    <th>내용</th>-->
-<!--                    <th>별점 평가</th>-->
-<!--                    <th>작성일시</th>-->
-<!--                    <th>수정일시</th>-->
-<!--                    <th>조회수</th>-->
-<!--                    <th>*리뷰작성자ID</th>-->
-<!--                    <th>*리뷰작성자닉네임</th>-->
-<!--                    <th>*썸네일URL</th>-->
-<!--                </tr>-->
-<!--                </thead>-->
-<!--                <tbody>-->
-<!--                <tr th:each="mySoReview : ${mySoReviews}" class="clickable-row" th:attr="data-href=@{/social/users/{userId}/reviews/{reviewNo}(userId=${mySoReview.writerUserId},reviewNo=${mySoReview.reviewNo})}">-->
-<!--                    <td th:text="${mySoReview.likeNo}">좋아요 번호</td>-->
-<!--                    <td th:text="${mySoReview.reviewNo}">리뷰 번호</td>-->
-<!--                    <td th:text="${mySoReview.likedUser}">좋아요 한 회원</td>-->
-<!--                    <td th:text="${mySoReview.likedDate}">좋아요 일시</td>-->
-<!--                    <td th:text="${mySoReview.webtoonNo}">웹툰 번호</td>-->
-<!--                    <td th:text="${mySoReview.title}">제목</td>-->
-<!--                    <td th:text="${mySoReview.content}">내용</td>-->
-<!--                    <td th:text="${mySoReview.starRating}">별점 평가</td>-->
-<!--                    <td th:text="${mySoReview.createdDate}">작성일시</td>-->
-<!--                    <td th:text="${mySoReview.modifiedDate}">수정일시</td>-->
-<!--                    <td th:text="${mySoReview.viewCnt}">조회수</td>-->
-<!--                    <td th:text="${mySoReview.writerUserId}">*리뷰작성자ID</td>-->
-<!--                    <td th:text="${mySoReview.writerNickname}">*리뷰작성자닉네임</td>-->
-<!--                    <td th:text="${mySoReview.thumbnailUrl}">*썸네일URL</td>-->
-<!--                </tr>-->
-<!--                </tbody>-->
-<!--            </table>-->
-<!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
-<!--            <th:block th:if="${pages != null}">-->
-<!--                <div class="d-flex justify-content-center">-->
-<!--                    <div class="btn-group">-->
-<!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/so/review(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
-<!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
-<!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
-<!--                            </svg>-->
-<!--                        </button>-->
-<!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
-<!--                            <button type="button" class="btn btn-sm me-2 pages"-->
-<!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/so/review(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
-<!--                        </th:block>-->
-<!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/so/review(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
-<!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
-<!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
-<!--                            </svg>-->
-<!--                        </button>-->
-<!--                    </div>-->
-<!--                </div>-->
-<!--            </th:block>-->
-<!--        </div>-->
-<!--    </div>-->
+        <!--            <table>-->
+        <!--                <thead>-->
+        <!--                <tr>-->
+        <!--                    <th>좋아요 번호</th>-->
+        <!--                    <th>리뷰 번호</th>-->
+        <!--                    <th>좋아요 한 회원</th>-->
+        <!--                    <th>좋아요 일시</th>-->
+        <!--                    <th>웹툰 번호</th>-->
+        <!--                    <th>제목</th>-->
+        <!--                    <th>내용</th>-->
+        <!--                    <th>별점 평가</th>-->
+        <!--                    <th>작성일시</th>-->
+        <!--                    <th>수정일시</th>-->
+        <!--                    <th>조회수</th>-->
+        <!--                    <th>*리뷰작성자ID</th>-->
+        <!--                    <th>*리뷰작성자닉네임</th>-->
+        <!--                    <th>*썸네일URL</th>-->
+        <!--                </tr>-->
+        <!--                </thead>-->
+        <!--                <tbody>-->
+        <!--                <tr th:each="mySoReview : ${mySoReviews}" class="clickable-row" th:attr="data-href=@{/social/users/{userId}/reviews/{reviewNo}(userId=${mySoReview.writerUserId},reviewNo=${mySoReview.reviewNo})}">-->
+        <!--                    <td th:text="${mySoReview.likeNo}">좋아요 번호</td>-->
+        <!--                    <td th:text="${mySoReview.reviewNo}">리뷰 번호</td>-->
+        <!--                    <td th:text="${mySoReview.likedUser}">좋아요 한 회원</td>-->
+        <!--                    <td th:text="${mySoReview.likedDate}">좋아요 일시</td>-->
+        <!--                    <td th:text="${mySoReview.webtoonNo}">웹툰 번호</td>-->
+        <!--                    <td th:text="${mySoReview.title}">제목</td>-->
+        <!--                    <td th:text="${mySoReview.content}">내용</td>-->
+        <!--                    <td th:text="${mySoReview.starRating}">별점 평가</td>-->
+        <!--                    <td th:text="${mySoReview.createdDate}">작성일시</td>-->
+        <!--                    <td th:text="${mySoReview.modifiedDate}">수정일시</td>-->
+        <!--                    <td th:text="${mySoReview.viewCnt}">조회수</td>-->
+        <!--                    <td th:text="${mySoReview.writerUserId}">*리뷰작성자ID</td>-->
+        <!--                    <td th:text="${mySoReview.writerNickname}">*리뷰작성자닉네임</td>-->
+        <!--                    <td th:text="${mySoReview.thumbnailUrl}">*썸네일URL</td>-->
+        <!--                </tr>-->
+        <!--                </tbody>-->
+        <!--            </table>-->
+        <!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
+        <!--            <th:block th:if="${pages != null}">-->
+        <!--                <div class="d-flex justify-content-center">-->
+        <!--                    <div class="btn-group">-->
+        <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/so/review(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
+        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
+        <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
+        <!--                            </svg>-->
+        <!--                        </button>-->
+        <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
+        <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
+        <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/so/review(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
+        <!--                        </th:block>-->
+        <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/so/review(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
+        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
+        <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
+        <!--                            </svg>-->
+        <!--                        </button>-->
+        <!--                    </div>-->
+        <!--                </div>-->
+        <!--            </th:block>-->
+        <!--        </div>-->
+        <!--    </div>-->
+    </div>
 </div>
 <div th:replace="common/footer.html"></div>
 </body>

--- a/src/main/resources/templates/user/mypage_so_review.html
+++ b/src/main/resources/templates/user/mypage_so_review.html
@@ -105,17 +105,20 @@
   }
 </style>
 <div class="jumbotron">
-    <div class="row">
-        <div class="col-md-3 px-4">
-            <h3>나의 소셜</h3>
-        </div>
-        <div class="col-md-9">
-            <nav class="navbar navbar-expand-md">
-                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                    <li><a th:href="@{/user/my/so/review}" class="nav-link px-2" style="color: #000;">좋아요한 리뷰</a></li>
-                    <li><a th:href="@{/user/my/so/diary}" class="nav-link px-2">내가 남긴 다이어리 댓글</a></li>
-                </ul>
-            </nav>
+    <div class="container">
+        <div class="row">
+            <div class="col-md-3 px-4">
+                <h3>나의 소셜</h3>
+            </div>
+            <div class="col-md-9">
+                <nav class="navbar navbar-expand-md">
+                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                        <li><a th:href="@{/user/my/so/review}" class="nav-link px-2" style="color: #000;">좋아요한 리뷰</a>
+                        </li>
+                        <li><a th:href="@{/user/my/so/diary}" class="nav-link px-2">내가 남긴 다이어리 댓글</a></li>
+                    </ul>
+                </nav>
+            </div>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/user/mypage_so_review.html
+++ b/src/main/resources/templates/user/mypage_so_review.html
@@ -107,17 +107,22 @@
 <div class="jumbotron">
     <div class="container">
         <div class="row">
-            <div class="col-md-3 px-4">
-                <h3>나의 소셜</h3>
-            </div>
-            <div class="col-md-9">
-                <nav class="navbar navbar-expand-md">
-                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                        <li><a th:href="@{/user/my/so/review}" class="nav-link px-2" style="color: #000;">좋아요한 리뷰</a>
-                        </li>
-                        <li><a th:href="@{/user/my/so/diary}" class="nav-link px-2">내가 남긴 다이어리 댓글</a></li>
-                    </ul>
-                </nav>
+            <div class="col-9">
+                <div class="row">
+                    <div class="col-md-3 px-4">
+                        <h3>나의 소셜</h3>
+                    </div>
+                    <div class="col-md-9">
+                        <nav class="navbar navbar-expand-md">
+                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                <li><a th:href="@{/user/my/so/review}" class="nav-link px-2" style="color: #000;">좋아요한
+                                    리뷰</a>
+                                </li>
+                                <li><a th:href="@{/user/my/so/diary}" class="nav-link px-2">내가 남긴 다이어리 댓글</a></li>
+                            </ul>
+                        </nav>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/user/mypage_so_review.html
+++ b/src/main/resources/templates/user/mypage_so_review.html
@@ -87,609 +87,637 @@
 
 <div th:replace="~{common/menubar}"></div>
 <style>
-    .jumbotron {
-    position : relative;
-    background-color : #EEEEEE;
+    html, body {
+        height: 100%;
+        margin: 0;
     }
-    .jumbotron .row {
-    position : absolute;
-    width : 100%;
-    bottom: 0%;
+    body {
+        display: flex;
+        flex-direction: column;
     }
-    .nav-link {
-            color: #828282;
-        }
-    ul {
-  list-style: none;
-  padding-left : 0px;
-  }
+    .content-wrapper {
+        flex: 1 0 auto;
+    }
+    footer {
+        flex-shrink: 0;
+    }
+
 </style>
-<div class="jumbotron">
-    <div class="container">
-        <div class="row">
-            <div class="col-9">
-                <div class="row">
-                    <div class="col-md-3 px-4">
-                        <h3>나의 소셜</h3>
-                    </div>
-                    <div class="col-md-9">
-                        <nav class="navbar navbar-expand-md">
-                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                                <li><a th:href="@{/user/my/so/review}" class="nav-link px-2" style="color: #000;">좋아요한
-                                    리뷰</a>
-                                </li>
-                                <li><a th:href="@{/user/my/so/diary}" class="nav-link px-2">내가 남긴 다이어리 댓글</a></li>
-                            </ul>
-                        </nav>
+<div class="content-wrapper">
+    <style>
+        .jumbotron {
+        position : relative;
+        background-color : #EEEEEE;
+        }
+        .jumbotron .row {
+        position : absolute;
+        width : 100%;
+        bottom: 0%;
+        }
+        .nav-link {
+                color: #828282;
+            }
+        ul {
+      list-style: none;
+      padding-left : 0px;
+      }
+    </style>
+    <div class="jumbotron">
+        <div class="container">
+            <div class="row">
+                <div class="col-9">
+                    <div class="row">
+                        <div class="col-md-3 px-4">
+                            <h3>나의 소셜</h3>
+                        </div>
+                        <div class="col-md-9">
+                            <nav class="navbar navbar-expand-md">
+                                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                    <li><a th:href="@{/user/my/so/review}" class="nav-link px-2" style="color: #000;">좋아요한
+                                        리뷰</a>
+                                    </li>
+                                    <li><a th:href="@{/user/my/so/diary}" class="nav-link px-2">내가 남긴 다이어리 댓글</a></li>
+                                </ul>
+                            </nav>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
-<div class="container" style="padding:0;">
-    <div class="row">
-        <aside class="col-md-3 px-4">
-            <div class="row">
-                <div class="col-1"></div>
-                <div class="col-8">
-                    <div class="panel">
-                        <ul class="list-group">
-                            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
-                            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2" style="color: #03C75A;">나의
-                                소셜</a></li>
-                            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
-                            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-                        </ul>
+    <div class="container" style="padding:0;">
+        <div class="row">
+            <aside class="col-md-3 px-4">
+                <div class="row">
+                    <div class="col-1"></div>
+                    <div class="col-8">
+                        <div class="panel">
+                            <ul class="list-group">
+                                <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>
+                                <li><a th:href="@{/user/my/so/review}" class="nav-link px-2" style="color: #03C75A;">나의
+                                    소셜</a></li>
+                                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
+                                <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                                <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                                <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </aside>
-        <style>
-            .form-select {
-            background-color : #FCFCFC;
-            border : none;
-            width : 100%;
-            height : 50px;
-            }
-            select {
-            color : #828282;
-            }
-            .form-control {
-            background-color : #FCFCFC;
-            border : none;
-            width : 100%;
-            height : 50px;
-            }
-
-
-            .form-control::placeholder {
-            color : #BBBBBB;
-            }
-
-            .date-container {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        background-color: #8E4B6E;
-        color: white;
-        border-radius: 10px;
-        text-align:center;
-        font-family: "Work Sans", sans-serif;
-    }
-
-    .platform-1 {
-        background-color: #03C75A;
-    }
-
-    .platform-2 {
-        background-color: #F5BF41;
-    }
-
-    .month {
-        font-size: 1.1rem; /* M의 크기를 설정 */
-        font-weight: 550;
-        line-height: 1;
-    }
-
-    .year {
-        font-size: 0.65rem; /* yyyy의 크기를 설정 */
-        font-weight: 400;
-    }
-    :root {
-        --background-color-light: #FFFFFF;
-        --text-color-light: #000000;
-        --toggle-background-light: #CCCCCC;
-        --toggle-ball-light: #FFFFFF;
-
-        --background-color-dark: #333333;
-        --text-color-dark: #FFFFFF;
-        --toggle-background-dark: #03C75A;
-        --toggle-ball-dark: #FFFFFF;
-
-        --font-size-base: 32px; /* 기본 텍스트 크기 */
-        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
-    }
-
-
-
-    .toggle-switch {
-        position: relative;
-        display: inline-block;
-        width: 62px; /* 너비 조정 */
-        height: 38px; /* 높이 조정 */
-    }
-
-    .toggle-switch .checkbox {
-        opacity: 0;
-        width: 0;
-        height: 0;
-    }
-    #isToggledCheckbox {
-         opacity: 0;
-            width: 0;
-            height: 0;
-    }
-
-    .toggle-switch .label {
-        position: absolute;
-        cursor: pointer;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background-color: var(--toggle-background-light);
-        transition: background-color 0.4s;
-        border-radius: 38px; /* 둥근 모서리 반경 조정 */
-    }
-
-    .toggle-switch .label:before {
-        position: absolute;
-        content: "";
-        height: 30px; /* 내부 원 높이 조정 */
-        width: 30px; /* 내부 원 너비 조정 */
-        left: 2px;
-        bottom: 0px;
-        background-color: var(--toggle-ball-light);
-        transition: transform 0.4s;
-        border-radius: 50%;
-    }
-
-    .toggle-switch input:checked + .label {
-        background-color: var(--toggle-background-dark);
-    }
-
-    .toggle-switch input:checked + .label:before {
-        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
-    }
-
-             #absdiv {
-                position: relative;
-                top: 60px; /* Move down by 20px from its current position */
-                z-index : 1000;
-            }
-
-            #searchbutton {
-                background-color: #828282;
-            }
-
-            .card-img-top {
-                    width: 100%;
-                    height: 100px;
-                    object-fit: cover;
+            </aside>
+            <style>
+                .form-select {
+                background-color : #FCFCFC;
+                border : none;
+                width : 100%;
+                height : 50px;
+                }
+                select {
+                color : #828282;
+                }
+                .form-control {
+                background-color : #FCFCFC;
+                border : none;
+                width : 100%;
+                height : 50px;
                 }
 
-        </style>
-        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
-              rel="stylesheet">
-        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
-              rel="stylesheet">
+
+                .form-control::placeholder {
+                color : #BBBBBB;
+                }
+
+                .date-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            background-color: #8E4B6E;
+            color: white;
+            border-radius: 10px;
+            text-align:center;
+            font-family: "Work Sans", sans-serif;
+        }
+
+        .platform-1 {
+            background-color: #03C75A;
+        }
+
+        .platform-2 {
+            background-color: #F5BF41;
+        }
+
+        .month {
+            font-size: 1.1rem; /* M의 크기를 설정 */
+            font-weight: 550;
+            line-height: 1;
+        }
+
+        .year {
+            font-size: 0.65rem; /* yyyy의 크기를 설정 */
+            font-weight: 400;
+        }
+        :root {
+            --background-color-light: #FFFFFF;
+            --text-color-light: #000000;
+            --toggle-background-light: #CCCCCC;
+            --toggle-ball-light: #FFFFFF;
+
+            --background-color-dark: #333333;
+            --text-color-dark: #FFFFFF;
+            --toggle-background-dark: #03C75A;
+            --toggle-ball-dark: #FFFFFF;
+
+            --font-size-base: 32px; /* 기본 텍스트 크기 */
+            --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+        }
 
 
-        <div class="col-md-9">
-            <div class="row" style="color: #828282;">
-                <div class="col-11">
-                    <div class="row mb-4">
-                        <div class="col-12 p-0">
-                            <style>
-                                .col-4 select {
-                                    border-radius: 50px;
-                                    text-align: center;
-                                }
-                                /* 검색창 스타일 */
-                                .search-container {
-                                    width: 300px;
-                                }
 
-                                .search-container select {
-                                    position: absolute;
-                                    left: 0%;
-                                    width: 30%;
-                                    height: 50px;
-                                    color: #828282;
-                                    font-size: 1rem;
-                                    border-radius: 50px 0 0 50px;
-                                    outline: none;
-                                }
-                                .search-container input[type="text"] {
-                                    position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
-                                    left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
-                                    width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
-                                    height: 50px;
-                                    padding: 10px 40px 10px 15px;
-                                    font-size: 1rem;
-                                    outline: none;
-                                    border-radius: 0 50px 50px 0;
-                                    transition: border-color 0.3s, background-color 0.3s;
-                                    color: #828282; /* 입력 텍스트 색상 변경 */
-                                }
+        .toggle-switch {
+            position: relative;
+            display: inline-block;
+            width: 62px; /* 너비 조정 */
+            height: 38px; /* 높이 조정 */
+        }
 
-                                .search-container input[type="text"]::placeholder {
-                                    color: #BBBBBB; /* placeholder 색상 변경 */
-                                }
+        .toggle-switch .checkbox {
+            opacity: 0;
+            width: 0;
+            height: 0;
+        }
+        #isToggledCheckbox {
+             opacity: 0;
+                width: 0;
+                height: 0;
+        }
+
+        .toggle-switch .label {
+            position: absolute;
+            cursor: pointer;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: var(--toggle-background-light);
+            transition: background-color 0.4s;
+            border-radius: 38px; /* 둥근 모서리 반경 조정 */
+        }
+
+        .toggle-switch .label:before {
+            position: absolute;
+            content: "";
+            height: 30px; /* 내부 원 높이 조정 */
+            width: 30px; /* 내부 원 너비 조정 */
+            left: 2px;
+            bottom: 0px;
+            background-color: var(--toggle-ball-light);
+            transition: transform 0.4s;
+            border-radius: 50%;
+        }
+
+        .toggle-switch input:checked + .label {
+            background-color: var(--toggle-background-dark);
+        }
+
+        .toggle-switch input:checked + .label:before {
+            transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+        }
+
+                 #absdiv {
+                    position: relative;
+                    top: 60px; /* Move down by 20px from its current position */
+                    z-index : 1000;
+                }
+
+                #searchbutton {
+                    background-color: #828282;
+                }
+
+                .card-img-top {
+                        width: 100%;
+                        height: 100px;
+                        object-fit: cover;
+                    }
+
+            </style>
+            <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+                  rel="stylesheet">
+            <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+                  rel="stylesheet">
 
 
-                                .search-container button {
-                                    position: absolute;
-                                    right: 1rem;
-                                    top: 25px;
-                                    background: none;
-                                    transform: translateY(-50%);
-                                    border: none;
-                                    cursor: pointer;
-                                }
+            <div class="col-md-9">
+                <div class="row" style="color: #828282;">
+                    <div class="col-11">
+                        <div class="row mb-4">
+                            <div class="col-12 p-0">
+                                <style>
+                                    .col-4 select {
+                                        border-radius: 50px;
+                                        text-align: center;
+                                    }
+                                    /* 검색창 스타일 */
+                                    .search-container {
+                                        width: 300px;
+                                    }
 
-                                .search-container button i {
-                                    color: #A6AAB5;
-                                }
+                                    .search-container select {
+                                        position: absolute;
+                                        left: 0%;
+                                        width: 30%;
+                                        height: 50px;
+                                        color: #828282;
+                                        font-size: 1rem;
+                                        border-radius: 50px 0 0 50px;
+                                        outline: none;
+                                    }
+                                    .search-container input[type="text"] {
+                                        position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
+                                        left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
+                                        width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
+                                        height: 50px;
+                                        padding: 10px 40px 10px 15px;
+                                        font-size: 1rem;
+                                        outline: none;
+                                        border-radius: 0 50px 50px 0;
+                                        transition: border-color 0.3s, background-color 0.3s;
+                                        color: #828282; /* 입력 텍스트 색상 변경 */
+                                    }
 
-                                .search-container button:hover i {
-                                    color: #03C75A;
-                                }
-                            </style>
-                            <form id="sort-form" th:action="@{/user/my/so/review}" method="get">
-                                <div class="row m-0">
-                                    <div class="col-7 p-0">
-                                        <div class="row justify-content-start m-0">
-                                            <div class="col-12 p-0">
-                                                <div class="search-container">
-                                                    <select class="form-select px-3" name="searchBy">
-                                                        <option value="rTitle" th:selected="${searchBy == 'rTitle'}">
-                                                            리뷰제목
-                                                        </option>
-                                                        <option value="rContent"
-                                                                th:selected="${searchBy == 'rContent'}">리뷰내용
-                                                        </option>
-                                                    </select>
-                                                    <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
-                                                    <!-- 검색 버튼 -->
-                                                    <button type="submit">
-                                                        <i class="fas fa-search"></i>
-                                                    </button>
+                                    .search-container input[type="text"]::placeholder {
+                                        color: #BBBBBB; /* placeholder 색상 변경 */
+                                    }
+
+
+                                    .search-container button {
+                                        position: absolute;
+                                        right: 1rem;
+                                        top: 25px;
+                                        background: none;
+                                        transform: translateY(-50%);
+                                        border: none;
+                                        cursor: pointer;
+                                    }
+
+                                    .search-container button i {
+                                        color: #A6AAB5;
+                                    }
+
+                                    .search-container button:hover i {
+                                        color: #03C75A;
+                                    }
+                                </style>
+                                <form id="sort-form" th:action="@{/user/my/so/review}" method="get">
+                                    <div class="row m-0">
+                                        <div class="col-7 p-0">
+                                            <div class="row justify-content-start m-0">
+                                                <div class="col-12 p-0">
+                                                    <div class="search-container">
+                                                        <select class="form-select px-3" name="searchBy">
+                                                            <option value="rTitle"
+                                                                    th:selected="${searchBy == 'rTitle'}">
+                                                                리뷰제목
+                                                            </option>
+                                                            <option value="rContent"
+                                                                    th:selected="${searchBy == 'rContent'}">리뷰내용
+                                                            </option>
+                                                        </select>
+                                                        <input class="form-control px-3" type="text" name="searchTerm"
+                                                               placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
+                                                        <!-- 검색 버튼 -->
+                                                        <button type="submit">
+                                                            <i class="fas fa-search"></i>
+                                                        </button>
+                                                    </div>
                                                 </div>
                                             </div>
                                         </div>
-                                    </div>
-                                    <div class="col-1" style=""></div>
-                                    <div class="col-4">
-                                        <div class="row justify-content-end">
-                                            <!-- 정렬 또는 토글2 -->
-                                            <label>
-                                                <select class="form-select px-3" name="orderBy"
-                                                        onchange="this.form.submit()">
-                                                    <option value="recentliked"
-                                                            th:selected="${orderBy == 'recentliked'}">최근좋아요순
-                                                    </option>
-                                                    <option value="oldestliked"
-                                                            th:selected="${orderBy == 'oldestliked'}">오래된좋아요순
-                                                    </option>
+                                        <div class="col-1" style=""></div>
+                                        <div class="col-4">
+                                            <div class="row justify-content-end">
+                                                <!-- 정렬 또는 토글2 -->
+                                                <label>
+                                                    <select class="form-select px-3" name="orderBy"
+                                                            onchange="this.form.submit()">
+                                                        <option value="recentliked"
+                                                                th:selected="${orderBy == 'recentliked'}">최근좋아요순
+                                                        </option>
+                                                        <option value="oldestliked"
+                                                                th:selected="${orderBy == 'oldestliked'}">오래된좋아요순
+                                                        </option>
 
-                                                    <option value="recentadded"
-                                                            th:selected="${orderBy == 'recentadded'}">최근작성순
-                                                    </option>
-                                                    <option value="oldestadded"
-                                                            th:selected="${orderBy == 'oldestadded'}">오래된작성순
-                                                    </option>
+                                                        <option value="recentadded"
+                                                                th:selected="${orderBy == 'recentadded'}">최근작성순
+                                                        </option>
+                                                        <option value="oldestadded"
+                                                                th:selected="${orderBy == 'oldestadded'}">오래된작성순
+                                                        </option>
 
-                                                    <option value="highrated" th:selected="${orderBy == 'highrated'}">
-                                                        별점높은순
-                                                    </option>
-                                                    <option value="lowrated" th:selected="${orderBy == 'lowrated'}">
-                                                        별점낮은순
-                                                    </option>
+                                                        <option value="highrated"
+                                                                th:selected="${orderBy == 'highrated'}">
+                                                            별점높은순
+                                                        </option>
+                                                        <option value="lowrated" th:selected="${orderBy == 'lowrated'}">
+                                                            별점낮은순
+                                                        </option>
 
-                                                    <option value="views" th:selected="${orderBy == 'views'}">조회수높은순
-                                                    </option>
-                                                    <option value="title" th:selected="${orderBy == 'title'}">제목가나다순
-                                                    </option>
-                                                </select>
-                                            </label>
-                                        </div>
-                                    </div>
-                                </div> <!--검색, 소팅 (토글X)-->
-                                <div class="row justify-content-around">
-                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                    <div class="col-3" style="padding: 0 1.2rem;">
-                                        <div id="absdiv" class="row justify-content-end">
-                                            <!--                                        <div class="col-3">-->
-                                            <!--                                            <div class="toggle-switch">-->
-                                            <!--                                                &lt;!&ndash; 정렬 또는 토글1 &ndash;&gt;-->
-                                            <!--                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">-->
-                                            <!--                                                <label for="isToggledCheckbox" class="label">-->
-                                            <!--                                                    <div class="ball"></div>-->
-                                            <!--                                                </label>-->
-                                            <!--                                            </div>-->
-                                            <!--                                        </div>-->
-                                            <!--                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">진행중인 행사</div>-->
-                                        </div>
-                                    </div>
-                                </div> <!--토글-->
-                            </form>
-                        </div>
-                    </div>
-                    <div class="row justify-content-around mt-4">
-                        <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
-                            <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
-                                <div class="col-3 clickable-row"
-                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
-                                     th:each="mySoReview, iterStat : ${mySoReviews}"
-                                     th:attr="data-href=@{/social/users/{userId}/reviews/{reviewNo}(userId=${mySoReview.writerUserId},reviewNo=${mySoReview.reviewNo})}"
-                                     th:if="${iterStat.index < 3}">
-                                    <div class="row justify-content-center">
-                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
-                                             style="aspect-ratio: 1; border-radius: 5px;">
-                                            <div class="date-container px-2 py-1">
-                                                <div class="month"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(mySoReview.likedDate)}"></div>
-                                                <div class="year"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(mySoReview.likedDate)}"></div>
+                                                        <option value="views" th:selected="${orderBy == 'views'}">조회수높은순
+                                                        </option>
+                                                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순
+                                                        </option>
+                                                    </select>
+                                                </label>
                                             </div>
                                         </div>
-                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                        <!--                                    </div>-->
-                                        <div class="col-5" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
-                                             th:text="${mySoReview.writerNickname}">닉네임
-                                        </div>
-
-                                        <div class="col-3"
-                                             style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
-                                             th:text="${mySoReview.formattedLikedDate}">시간
-                                        </div>
-                                    </div>
-                                    <div class="row justify-content-center">
-                                        <div class="col-12 my-3" style="">
-                                            <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                            <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                            <!-- 썸네일 이미지 있을때  -->
-                                            <img th:if="${mySoReview.thumbnailUrl != null}"
-                                                 th:src="${mySoReview.thumbnailUrl}" class="card-img-top" alt="썸네일 이미지">
-                                        </div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
-                                             th:text="${mySoReview.title}">이름
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
-                                             th:text="${mySoReview.content}">내용
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                    </div>
-
-                                </div>
-                                <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
-                                <div class="col-3" th:if="${mySoReviews.size() == 0}"></div>
-                                <div class="col-3" th:if="${mySoReviews.size() == 0 || mySoReviews.size() == 1}"></div>
-                                <div class="col-3"
-                                     th:if="${mySoReviews.size() == 0 || mySoReviews.size() == 1 || mySoReviews.size() == 2}"></div>
-                            </div>
-                            <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
-                                <div class="col-3 clickable-row"
-                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
-                                     th:each="mySoReview, iterStat : ${mySoReviews}"
-                                     th:attr="data-href=@{/social/users/{userId}/reviews/{reviewNo}(userId=${mySoReview.writerUserId},reviewNo=${mySoReview.reviewNo})}"
-                                     th:if="${iterStat.index >= 3}">
-                                    <div class="row justify-content-center">
-                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
-                                             style="aspect-ratio: 1; border-radius: 5px;">
-                                            <div class="date-container px-2 py-1">
-                                                <div class="month"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(mySoReview.likedDate)}"></div>
-                                                <div class="year"
-                                                     th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(mySoReview.likedDate)}"></div>
+                                    </div> <!--검색, 소팅 (토글X)-->
+                                    <div class="row justify-content-around">
+                                        <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                        <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                        <div class="col-3" style="padding: 0 1.2rem;">
+                                            <div id="absdiv" class="row justify-content-end">
+                                                <!--                                        <div class="col-3">-->
+                                                <!--                                            <div class="toggle-switch">-->
+                                                <!--                                                &lt;!&ndash; 정렬 또는 토글1 &ndash;&gt;-->
+                                                <!--                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">-->
+                                                <!--                                                <label for="isToggledCheckbox" class="label">-->
+                                                <!--                                                    <div class="ball"></div>-->
+                                                <!--                                                </label>-->
+                                                <!--                                            </div>-->
+                                                <!--                                        </div>-->
+                                                <!--                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">진행중인 행사</div>-->
                                             </div>
                                         </div>
-                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                        <!--                                    </div>-->
-                                        <div class="col-5" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
-                                             th:text="${mySoReview.writerNickname}">닉네임
-                                        </div>
-
-                                        <div class="col-3"
-                                             style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
-                                             th:text="${mySoReview.formattedLikedDate}">시간
-                                        </div>
-                                    </div>
-                                    <div class="row justify-content-center">
-                                        <div class="col-12 my-3" style="">
-                                            <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                            <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                            <!-- 썸네일 이미지 있을때  -->
-                                            <img th:if="${mySoReview.thumbnailUrl != null}"
-                                                 th:src="${mySoReview.thumbnailUrl}" class="card-img-top" alt="썸네일 이미지">
-                                        </div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
-                                             th:text="${mySoReview.title}">이름
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
-                                             th:text="${mySoReview.content}">내용
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                    </div>
-
-                                </div>
-
-                                <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
-                                <div class="col-3" th:if="${mySoReviews.size() <= 3}"></div>
-                                <div class="col-3" th:if="${mySoReviews.size() <= 3 || mySoReviews.size() == 4}"></div>
-                                <div class="col-3"
-                                     th:if="${mySoReviews.size() <= 3 || mySoReviews.size() == 4 || mySoReviews.size() == 5}"></div>
+                                    </div> <!--토글-->
+                                </form>
                             </div>
                         </div>
-                    </div>
-                    <div class="row justify-content-center">
-                        <!-- 페이징 -->
-                        <th:block th:if="${pages != null}">
-                            <div class="d-flex justify-content-center">
-                                <div class="btn-group">
-                                    <button type="button" class="btn btn-sm previous"
-                                            th:onclick="|location.href='@{/user/my/so/review(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
-                                            th:disabled="${currentPage == 1}">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                             fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-                                            <path fill-rule="evenodd"
-                                                  d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                                        </svg>
-                                    </button>
-                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">
-                                        <button type="button" class="btn btn-sm me-2 pages"
-                                                th:text="${p}"
-                                                th:onclick="|location.href='@{/user/my/so/review(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
-                                    </th:block>
-                                    <button type="button" class="btn btn-sm  next"
-                                            th:onclick="|location.href='@{/user/my/so/review(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
-                                            th:disabled="${currentPage == pages}">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                             fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-                                            <path fill-rule="evenodd"
-                                                  d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
-                                        </svg>
-                                    </button>
+                        <div class="row justify-content-around mt-4">
+                            <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
+                                <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
+                                    <div class="col-3 clickable-row"
+                                         style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                         th:each="mySoReview, iterStat : ${mySoReviews}"
+                                         th:attr="data-href=@{/social/users/{userId}/reviews/{reviewNo}(userId=${mySoReview.writerUserId},reviewNo=${mySoReview.reviewNo})}"
+                                         th:if="${iterStat.index < 3}">
+                                        <div class="row justify-content-center">
+                                            <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                                 style="aspect-ratio: 1; border-radius: 5px;">
+                                                <div class="date-container px-2 py-1">
+                                                    <div class="month"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(mySoReview.likedDate)}"></div>
+                                                    <div class="year"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(mySoReview.likedDate)}"></div>
+                                                </div>
+                                            </div>
+                                            <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                            <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                            <!--                                    </div>-->
+                                            <div class="col-5"
+                                                 style="color: #333333; font-size: 0.8rem; font-weight: 530;"
+                                                 th:text="${mySoReview.writerNickname}">닉네임
+                                            </div>
+
+                                            <div class="col-3"
+                                                 style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
+                                                 th:text="${mySoReview.formattedLikedDate}">시간
+                                            </div>
+                                        </div>
+                                        <div class="row justify-content-center">
+                                            <div class="col-12 my-3" style="">
+                                                <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                                <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                                <!-- 썸네일 이미지 있을때  -->
+                                                <img th:if="${mySoReview.thumbnailUrl != null}"
+                                                     th:src="${mySoReview.thumbnailUrl}" class="card-img-top"
+                                                     alt="썸네일 이미지">
+                                            </div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                                 th:text="${mySoReview.title}">이름
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                                 th:text="${mySoReview.content}">내용
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                        </div>
+
+                                    </div>
+                                    <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
+                                    <div class="col-3" th:if="${mySoReviews.size() == 0}"></div>
+                                    <div class="col-3"
+                                         th:if="${mySoReviews.size() == 0 || mySoReviews.size() == 1}"></div>
+                                    <div class="col-3"
+                                         th:if="${mySoReviews.size() == 0 || mySoReviews.size() == 1 || mySoReviews.size() == 2}"></div>
+                                </div>
+                                <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
+                                    <div class="col-3 clickable-row"
+                                         style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                         th:each="mySoReview, iterStat : ${mySoReviews}"
+                                         th:attr="data-href=@{/social/users/{userId}/reviews/{reviewNo}(userId=${mySoReview.writerUserId},reviewNo=${mySoReview.reviewNo})}"
+                                         th:if="${iterStat.index >= 3}">
+                                        <div class="row justify-content-center">
+                                            <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                                 style="aspect-ratio: 1; border-radius: 5px;">
+                                                <div class="date-container px-2 py-1">
+                                                    <div class="month"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M').format(mySoReview.likedDate)}"></div>
+                                                    <div class="year"
+                                                         th:text="${T(java.time.format.DateTimeFormatter).ofPattern('yyyy').format(mySoReview.likedDate)}"></div>
+                                                </div>
+                                            </div>
+                                            <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                            <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                            <!--                                    </div>-->
+                                            <div class="col-5"
+                                                 style="color: #333333; font-size: 0.8rem; font-weight: 530;"
+                                                 th:text="${mySoReview.writerNickname}">닉네임
+                                            </div>
+
+                                            <div class="col-3"
+                                                 style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
+                                                 th:text="${mySoReview.formattedLikedDate}">시간
+                                            </div>
+                                        </div>
+                                        <div class="row justify-content-center">
+                                            <div class="col-12 my-3" style="">
+                                                <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                                <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                                <!-- 썸네일 이미지 있을때  -->
+                                                <img th:if="${mySoReview.thumbnailUrl != null}"
+                                                     th:src="${mySoReview.thumbnailUrl}" class="card-img-top"
+                                                     alt="썸네일 이미지">
+                                            </div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                                 th:text="${mySoReview.title}">이름
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                                 th:text="${mySoReview.content}">내용
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                        </div>
+
+                                    </div>
+
+                                    <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
+                                    <div class="col-3" th:if="${mySoReviews.size() <= 3}"></div>
+                                    <div class="col-3"
+                                         th:if="${mySoReviews.size() <= 3 || mySoReviews.size() == 4}"></div>
+                                    <div class="col-3"
+                                         th:if="${mySoReviews.size() <= 3 || mySoReviews.size() == 4 || mySoReviews.size() == 5}"></div>
                                 </div>
                             </div>
-                        </th:block>
-                    </div>
-                </div><!--테이블 및 페이징 포함-->
+                        </div>
+                        <div class="row justify-content-center">
+                            <!-- 페이징 -->
+                            <th:block th:if="${pages != null}">
+                                <div class="d-flex justify-content-center">
+                                    <div class="btn-group">
+                                        <button type="button" class="btn btn-sm previous"
+                                                th:onclick="|location.href='@{/user/my/so/review(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
+                                                th:disabled="${currentPage == 1}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                                 fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+                                                <path fill-rule="evenodd"
+                                                      d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                                            </svg>
+                                        </button>
+                                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">
+                                            <button type="button" class="btn btn-sm me-2 pages"
+                                                    th:text="${p}"
+                                                    th:onclick="|location.href='@{/user/my/so/review(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
+                                        </th:block>
+                                        <button type="button" class="btn btn-sm  next"
+                                                th:onclick="|location.href='@{/user/my/so/review(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
+                                                th:disabled="${currentPage == pages}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                                 fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+                                                <path fill-rule="evenodd"
+                                                      d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                                            </svg>
+                                        </button>
+                                    </div>
+                                </div>
+                            </th:block>
+                        </div>
+                    </div><!--테이블 및 페이징 포함-->
+                </div> <!--본화면-->
             </div> <!--본화면-->
-        </div> <!--본화면-->
 
-        <!--수정전-->
-        <!--    <div class="col-md-9">-->
-        <!--        <div class="review-list">-->
-        <!--            <h2>좋아요한 리뷰</h2>-->
-        <!--            <form id="sort-form" th:action="@{/user/my/so/review}" method="get">-->
-        <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
-        <!--                <label>-->
-        <!--                    <select name="searchBy">-->
-        <!--                        <option value="rTitle" th:selected="${searchBy == 'rTitle'}">리뷰제목</option>-->
-        <!--                        <option value="rContent" th:selected="${searchBy == 'rContent'}">리뷰내용</option>-->
-        <!--&lt;!&ndash;                        <option value="title" th:selected="${searchBy == 'title'}">웹툰제목</option>&ndash;&gt;-->
-        <!--&lt;!&ndash;                        <option value="author" th:selected="${searchBy == 'author'}">작가</option>&ndash;&gt;-->
-        <!--&lt;!&ndash;                        <option value="genre" th:selected="${searchBy == 'genre'}">장르</option>&ndash;&gt;-->
-        <!--&lt;!&ndash;                        <option value="tag" th:selected="${searchBy == 'tag'}">태그</option>&ndash;&gt;-->
-        <!--                    </select>-->
-        <!--                </label>-->
-        <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
+            <!--수정전-->
+            <!--    <div class="col-md-9">-->
+            <!--        <div class="review-list">-->
+            <!--            <h2>좋아요한 리뷰</h2>-->
+            <!--            <form id="sort-form" th:action="@{/user/my/so/review}" method="get">-->
+            <!--                &lt;!&ndash; 검색 조건 &ndash;&gt;-->
+            <!--                <label>-->
+            <!--                    <select name="searchBy">-->
+            <!--                        <option value="rTitle" th:selected="${searchBy == 'rTitle'}">리뷰제목</option>-->
+            <!--                        <option value="rContent" th:selected="${searchBy == 'rContent'}">리뷰내용</option>-->
+            <!--&lt;!&ndash;                        <option value="title" th:selected="${searchBy == 'title'}">웹툰제목</option>&ndash;&gt;-->
+            <!--&lt;!&ndash;                        <option value="author" th:selected="${searchBy == 'author'}">작가</option>&ndash;&gt;-->
+            <!--&lt;!&ndash;                        <option value="genre" th:selected="${searchBy == 'genre'}">장르</option>&ndash;&gt;-->
+            <!--&lt;!&ndash;                        <option value="tag" th:selected="${searchBy == 'tag'}">태그</option>&ndash;&gt;-->
+            <!--                    </select>-->
+            <!--                </label>-->
+            <!--                <input type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
 
-        <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
-        <!--                <button type="submit">검색</button>-->
+            <!--                &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
+            <!--                <button type="submit">검색</button>-->
 
-        <!--                &lt;!&ndash; 정렬 조건 &ndash;&gt;-->
-        <!--                <label>-->
-        <!--                    <select name="orderBy" onchange="this.form.submit()">-->
-        <!--                        <option value="recentliked" th:selected="${orderBy == 'recentliked'}">최근좋아요순</option>-->
-        <!--                        <option value="oldestliked" th:selected="${orderBy == 'oldestliked'}">오래된좋아요순</option>-->
+            <!--                &lt;!&ndash; 정렬 조건 &ndash;&gt;-->
+            <!--                <label>-->
+            <!--                    <select name="orderBy" onchange="this.form.submit()">-->
+            <!--                        <option value="recentliked" th:selected="${orderBy == 'recentliked'}">최근좋아요순</option>-->
+            <!--                        <option value="oldestliked" th:selected="${orderBy == 'oldestliked'}">오래된좋아요순</option>-->
 
-        <!--                        <option value="recentadded" th:selected="${orderBy == 'recentadded'}">최근작성순</option>-->
-        <!--                        <option value="oldestadded" th:selected="${orderBy == 'oldestadded'}">오래된작성순</option>-->
+            <!--                        <option value="recentadded" th:selected="${orderBy == 'recentadded'}">최근작성순</option>-->
+            <!--                        <option value="oldestadded" th:selected="${orderBy == 'oldestadded'}">오래된작성순</option>-->
 
-        <!--                        <option value="highrated" th:selected="${orderBy == 'highrated'}">별점높은순</option>-->
-        <!--                        <option value="lowrated" th:selected="${orderBy == 'lowrated'}">별점낮은순</option>-->
+            <!--                        <option value="highrated" th:selected="${orderBy == 'highrated'}">별점높은순</option>-->
+            <!--                        <option value="lowrated" th:selected="${orderBy == 'lowrated'}">별점낮은순</option>-->
 
-        <!--                        <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>-->
-        <!--                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
-        <!--                    </select>-->
-        <!--                </label>-->
-        <!--            </form>-->
+            <!--                        <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>-->
+            <!--                        <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
+            <!--                    </select>-->
+            <!--                </label>-->
+            <!--            </form>-->
 
-        <!--            <table>-->
-        <!--                <thead>-->
-        <!--                <tr>-->
-        <!--                    <th>좋아요 번호</th>-->
-        <!--                    <th>리뷰 번호</th>-->
-        <!--                    <th>좋아요 한 회원</th>-->
-        <!--                    <th>좋아요 일시</th>-->
-        <!--                    <th>웹툰 번호</th>-->
-        <!--                    <th>제목</th>-->
-        <!--                    <th>내용</th>-->
-        <!--                    <th>별점 평가</th>-->
-        <!--                    <th>작성일시</th>-->
-        <!--                    <th>수정일시</th>-->
-        <!--                    <th>조회수</th>-->
-        <!--                    <th>*리뷰작성자ID</th>-->
-        <!--                    <th>*리뷰작성자닉네임</th>-->
-        <!--                    <th>*썸네일URL</th>-->
-        <!--                </tr>-->
-        <!--                </thead>-->
-        <!--                <tbody>-->
-        <!--                <tr th:each="mySoReview : ${mySoReviews}" class="clickable-row" th:attr="data-href=@{/social/users/{userId}/reviews/{reviewNo}(userId=${mySoReview.writerUserId},reviewNo=${mySoReview.reviewNo})}">-->
-        <!--                    <td th:text="${mySoReview.likeNo}">좋아요 번호</td>-->
-        <!--                    <td th:text="${mySoReview.reviewNo}">리뷰 번호</td>-->
-        <!--                    <td th:text="${mySoReview.likedUser}">좋아요 한 회원</td>-->
-        <!--                    <td th:text="${mySoReview.likedDate}">좋아요 일시</td>-->
-        <!--                    <td th:text="${mySoReview.webtoonNo}">웹툰 번호</td>-->
-        <!--                    <td th:text="${mySoReview.title}">제목</td>-->
-        <!--                    <td th:text="${mySoReview.content}">내용</td>-->
-        <!--                    <td th:text="${mySoReview.starRating}">별점 평가</td>-->
-        <!--                    <td th:text="${mySoReview.createdDate}">작성일시</td>-->
-        <!--                    <td th:text="${mySoReview.modifiedDate}">수정일시</td>-->
-        <!--                    <td th:text="${mySoReview.viewCnt}">조회수</td>-->
-        <!--                    <td th:text="${mySoReview.writerUserId}">*리뷰작성자ID</td>-->
-        <!--                    <td th:text="${mySoReview.writerNickname}">*리뷰작성자닉네임</td>-->
-        <!--                    <td th:text="${mySoReview.thumbnailUrl}">*썸네일URL</td>-->
-        <!--                </tr>-->
-        <!--                </tbody>-->
-        <!--            </table>-->
-        <!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
-        <!--            <th:block th:if="${pages != null}">-->
-        <!--                <div class="d-flex justify-content-center">-->
-        <!--                    <div class="btn-group">-->
-        <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/so/review(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
-        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
-        <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
-        <!--                            </svg>-->
-        <!--                        </button>-->
-        <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
-        <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
-        <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/so/review(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
-        <!--                        </th:block>-->
-        <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/so/review(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
-        <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
-        <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
-        <!--                            </svg>-->
-        <!--                        </button>-->
-        <!--                    </div>-->
-        <!--                </div>-->
-        <!--            </th:block>-->
-        <!--        </div>-->
-        <!--    </div>-->
+            <!--            <table>-->
+            <!--                <thead>-->
+            <!--                <tr>-->
+            <!--                    <th>좋아요 번호</th>-->
+            <!--                    <th>리뷰 번호</th>-->
+            <!--                    <th>좋아요 한 회원</th>-->
+            <!--                    <th>좋아요 일시</th>-->
+            <!--                    <th>웹툰 번호</th>-->
+            <!--                    <th>제목</th>-->
+            <!--                    <th>내용</th>-->
+            <!--                    <th>별점 평가</th>-->
+            <!--                    <th>작성일시</th>-->
+            <!--                    <th>수정일시</th>-->
+            <!--                    <th>조회수</th>-->
+            <!--                    <th>*리뷰작성자ID</th>-->
+            <!--                    <th>*리뷰작성자닉네임</th>-->
+            <!--                    <th>*썸네일URL</th>-->
+            <!--                </tr>-->
+            <!--                </thead>-->
+            <!--                <tbody>-->
+            <!--                <tr th:each="mySoReview : ${mySoReviews}" class="clickable-row" th:attr="data-href=@{/social/users/{userId}/reviews/{reviewNo}(userId=${mySoReview.writerUserId},reviewNo=${mySoReview.reviewNo})}">-->
+            <!--                    <td th:text="${mySoReview.likeNo}">좋아요 번호</td>-->
+            <!--                    <td th:text="${mySoReview.reviewNo}">리뷰 번호</td>-->
+            <!--                    <td th:text="${mySoReview.likedUser}">좋아요 한 회원</td>-->
+            <!--                    <td th:text="${mySoReview.likedDate}">좋아요 일시</td>-->
+            <!--                    <td th:text="${mySoReview.webtoonNo}">웹툰 번호</td>-->
+            <!--                    <td th:text="${mySoReview.title}">제목</td>-->
+            <!--                    <td th:text="${mySoReview.content}">내용</td>-->
+            <!--                    <td th:text="${mySoReview.starRating}">별점 평가</td>-->
+            <!--                    <td th:text="${mySoReview.createdDate}">작성일시</td>-->
+            <!--                    <td th:text="${mySoReview.modifiedDate}">수정일시</td>-->
+            <!--                    <td th:text="${mySoReview.viewCnt}">조회수</td>-->
+            <!--                    <td th:text="${mySoReview.writerUserId}">*리뷰작성자ID</td>-->
+            <!--                    <td th:text="${mySoReview.writerNickname}">*리뷰작성자닉네임</td>-->
+            <!--                    <td th:text="${mySoReview.thumbnailUrl}">*썸네일URL</td>-->
+            <!--                </tr>-->
+            <!--                </tbody>-->
+            <!--            </table>-->
+            <!--            &lt;!&ndash; 페이징 &ndash;&gt;-->
+            <!--            <th:block th:if="${pages != null}">-->
+            <!--                <div class="d-flex justify-content-center">-->
+            <!--                    <div class="btn-group">-->
+            <!--                        <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/so/review(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
+            <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
+            <!--                                <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
+            <!--                            </svg>-->
+            <!--                        </button>-->
+            <!--                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
+            <!--                            <button type="button" class="btn btn-sm me-2 pages"-->
+            <!--                                    th:text="${p}" th:onclick="|location.href='@{/user/my/so/review(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
+            <!--                        </th:block>-->
+            <!--                        <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/so/review(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
+            <!--                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
+            <!--                                <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
+            <!--                            </svg>-->
+            <!--                        </button>-->
+            <!--                    </div>-->
+            <!--                </div>-->
+            <!--            </th:block>-->
+            <!--        </div>-->
+            <!--    </div>-->
+        </div>
     </div>
 </div>
 <div th:replace="common/footer.html"></div>

--- a/src/main/resources/templates/user/mypage_so_review.html
+++ b/src/main/resources/templates/user/mypage_so_review.html
@@ -132,7 +132,7 @@
         <aside class="col-md-3 px-4">
             <div class="row">
                 <div class="col-1"></div>
-                <div class="col-6">
+                <div class="col-8">
                     <div class="panel">
                         <ul class="list-group">
                             <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">나의 웹툰</a></li>

--- a/src/main/resources/templates/user/mypage_so_review.html
+++ b/src/main/resources/templates/user/mypage_so_review.html
@@ -293,14 +293,69 @@
             <div class="row" style="color: #828282;">
                 <div class="col-11">
                     <div class="row mb-4">
-                        <div class="col-12">
+                        <div class="col-12 p-0">
+                            <style>
+                                .col-4 select {
+                                    border-radius: 50px;
+                                    text-align: center;
+                                }
+                                /* 검색창 스타일 */
+                                .search-container {
+                                    width: 300px;
+                                }
+
+                                .search-container select {
+                                    position: absolute;
+                                    left: 0%;
+                                    width: 30%;
+                                    height: 50px;
+                                    color: #828282;
+                                    font-size: 1rem;
+                                    border-radius: 50px 0 0 50px;
+                                    outline: none;
+                                }
+                                .search-container input[type="text"] {
+                                    position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
+                                    left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
+                                    width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
+                                    height: 50px;
+                                    padding: 10px 40px 10px 15px;
+                                    font-size: 1rem;
+                                    outline: none;
+                                    border-radius: 0 50px 50px 0;
+                                    transition: border-color 0.3s, background-color 0.3s;
+                                    color: #828282; /* 입력 텍스트 색상 변경 */
+                                }
+
+                                .search-container input[type="text"]::placeholder {
+                                    color: #BBBBBB; /* placeholder 색상 변경 */
+                                }
+
+
+                                .search-container button {
+                                    position: absolute;
+                                    right: 1rem;
+                                    top: 25px;
+                                    background: none;
+                                    transform: translateY(-50%);
+                                    border: none;
+                                    cursor: pointer;
+                                }
+
+                                .search-container button i {
+                                    color: #666;
+                                }
+
+                                .search-container button:hover i {
+                                    color: #03C75A;
+                                }
+                            </style>
                             <form id="sort-form" th:action="@{/user/my/so/review}" method="get">
-                                <div class="row">
-                                    <div class="col-7">
+                                <div class="row m-0">
+                                    <div class="col-7 p-0">
                                         <div class="row justify-content-start m-0">
-                                            <div class="col-4">
-                                                <!-- 검색 조건 -->
-                                                <label>
+                                            <div class="col-12 p-0">
+                                                <div class="search-container">
                                                     <select class="form-select px-3" name="searchBy">
                                                         <option value="rTitle" th:selected="${searchBy == 'rTitle'}">
                                                             리뷰제목
@@ -308,21 +363,13 @@
                                                         <option value="rContent"
                                                                 th:selected="${searchBy == 'rContent'}">리뷰내용
                                                         </option>
-                                                        <!--                        <option value="title" th:selected="${searchBy == 'title'}">웹툰제목</option>-->
-                                                        <!--                        <option value="author" th:selected="${searchBy == 'author'}">작가</option>-->
-                                                        <!--                        <option value="genre" th:selected="${searchBy == 'genre'}">장르</option>-->
-                                                        <!--                        <option value="tag" th:selected="${searchBy == 'tag'}">태그</option>-->
                                                     </select>
-                                                </label>
-                                            </div>
-                                            <div class="col-6">
-                                                <input class="form-control px-3" type="text" name="searchTerm"
-                                                       placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
-                                            </div>
-                                            <div class="col-2">
-                                                <!-- 검색 버튼 -->
-                                                <button id="searchbutton" type="submit" class="btn btn-primary">검색
-                                                </button>
+                                                    <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
+                                                    <!-- 검색 버튼 -->
+                                                    <button type="submit">
+                                                        <i class="fas fa-search"></i>
+                                                    </button>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>

--- a/src/main/resources/templates/user/mypage_so_review.html
+++ b/src/main/resources/templates/user/mypage_so_review.html
@@ -131,7 +131,7 @@
     <div class="row">
         <aside class="col-md-3 px-4">
             <div class="row">
-                <div class="col-3"></div>
+                <div class="col-1"></div>
                 <div class="col-6">
                     <div class="panel">
                         <ul class="list-group">

--- a/src/main/resources/templates/user/mypage_wt_comment.html
+++ b/src/main/resources/templates/user/mypage_wt_comment.html
@@ -105,469 +105,530 @@
         </div>
     </div>
 </div>
-<div class="row">
-    <aside class="col-md-3 px-4">
-        <div class="row">
-            <div class="col-3"></div>
-            <div class="col-6">
-                <div class="panel">
-                    <ul class="list-group">
-                        <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2" style="color: #03C75A;">나의 웹툰</a></li>
-                        <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-                        <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
-                        <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-                        <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                        <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-                    </ul>
+<div class="container" style="padding:0;">
+    <div class="row">
+        <aside class="col-md-3 px-4">
+            <div class="row">
+                <div class="col-3"></div>
+                <div class="col-6">
+                    <div class="panel">
+                        <ul class="list-group">
+                            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2" style="color: #03C75A;">나의
+                                웹툰</a></li>
+                            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
+                            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+                        </ul>
+                    </div>
                 </div>
             </div>
-        </div>
-    </aside>
-    <style>
-        .form-select {
-        background-color : #FCFCFC;
-        border : none;
-        width : 100%;
-        height : 50px;
-        }
-        select {
-        color : #828282;
-        }
-        .form-control {
-        background-color : #FCFCFC;
-        border : none;
-        width : 100%;
-        height : 50px;
-        }
-
-
-        .form-control::placeholder {
-        color : #BBBBBB;
-        }
-
-        .date-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    background-color: #8E4B6E;
-    color: white;
-    border-radius: 10px;
-    text-align:center;
-    font-family: "Work Sans", sans-serif;
-}
-
-.month {
-    font-size: 1.1rem; /* M의 크기를 설정 */
-    font-weight: 550;
-    line-height: 1;
-}
-
-.year {
-    font-size: 0.65rem; /* yyyy의 크기를 설정 */
-    font-weight: 400;
-}
-:root {
-    --background-color-light: #FFFFFF;
-    --text-color-light: #000000;
-    --toggle-background-light: #CCCCCC;
-    --toggle-ball-light: #FFFFFF;
-
-    --background-color-dark: #333333;
-    --text-color-dark: #FFFFFF;
-    --toggle-background-dark: #03C75A;
-    --toggle-ball-dark: #FFFFFF;
-
-    --font-size-base: 32px; /* 기본 텍스트 크기 */
-    --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
-}
-
-
-
-.toggle-switch {
-    position: relative;
-    display: inline-block;
-    width: 62px; /* 너비 조정 */
-    height: 38px; /* 높이 조정 */
-}
-
-.toggle-switch .checkbox {
-    opacity: 0;
-    width: 0;
-    height: 0;
-}
-#isToggledCheckbox {
-     opacity: 0;
-        width: 0;
-        height: 0;
-}
-
-.toggle-switch .label {
-    position: absolute;
-    cursor: pointer;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: var(--toggle-background-light);
-    transition: background-color 0.4s;
-    border-radius: 38px; /* 둥근 모서리 반경 조정 */
-}
-
-.toggle-switch .label:before {
-    position: absolute;
-    content: "";
-    height: 30px; /* 내부 원 높이 조정 */
-    width: 30px; /* 내부 원 너비 조정 */
-    left: 2px;
-    bottom: 0px;
-    background-color: var(--toggle-ball-light);
-    transition: transform 0.4s;
-    border-radius: 50%;
-}
-
-.toggle-switch input:checked + .label {
-    background-color: var(--toggle-background-dark);
-}
-
-.toggle-switch input:checked + .label:before {
-    transform: translateX(28px); /* 내부 원 이동 거리 조정 */
-}
-
-         #absdiv {
-            position: relative;
-            top: 60px; /* Move down by 20px from its current position */
-            z-index : 1000;
-        }
-
-        #searchbutton {
-            background-color: #828282;
-        }
-
-        .card-img-top {
-                width: 100%;
-                height: 100px;
-                object-fit: cover;
+        </aside>
+        <style>
+            .form-select {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
+            }
+            select {
+            color : #828282;
+            }
+            .form-control {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
             }
 
-    </style>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
 
-    <div class="col-md-9">
-        <div class="row" style="color: #828282;">
-            <div class="col-11">
-                <div class="row mb-4">
-                    <div class="col-12">
-                        <form id="sort-form" th:action="@{/user/my/wt/comment}" method="get">
-                            <div class="row">
-                                <div class="col-7">
-                                    <div class="row justify-content-start m-0">
-                                        <div class="col-4">
-                                            <!-- 검색 조건 -->
+            .form-control::placeholder {
+            color : #BBBBBB;
+            }
+
+            .date-container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        background-color: #8E4B6E;
+        color: white;
+        border-radius: 10px;
+        text-align:center;
+        font-family: "Work Sans", sans-serif;
+    }
+
+    .month {
+        font-size: 1.1rem; /* M의 크기를 설정 */
+        font-weight: 550;
+        line-height: 1;
+    }
+
+    .year {
+        font-size: 0.65rem; /* yyyy의 크기를 설정 */
+        font-weight: 400;
+    }
+    :root {
+        --background-color-light: #FFFFFF;
+        --text-color-light: #000000;
+        --toggle-background-light: #CCCCCC;
+        --toggle-ball-light: #FFFFFF;
+
+        --background-color-dark: #333333;
+        --text-color-dark: #FFFFFF;
+        --toggle-background-dark: #03C75A;
+        --toggle-ball-dark: #FFFFFF;
+
+        --font-size-base: 32px; /* 기본 텍스트 크기 */
+        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+    }
+
+
+
+    .toggle-switch {
+        position: relative;
+        display: inline-block;
+        width: 62px; /* 너비 조정 */
+        height: 38px; /* 높이 조정 */
+    }
+
+    .toggle-switch .checkbox {
+        opacity: 0;
+        width: 0;
+        height: 0;
+    }
+    #isToggledCheckbox {
+         opacity: 0;
+            width: 0;
+            height: 0;
+    }
+
+    .toggle-switch .label {
+        position: absolute;
+        cursor: pointer;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: var(--toggle-background-light);
+        transition: background-color 0.4s;
+        border-radius: 38px; /* 둥근 모서리 반경 조정 */
+    }
+
+    .toggle-switch .label:before {
+        position: absolute;
+        content: "";
+        height: 30px; /* 내부 원 높이 조정 */
+        width: 30px; /* 내부 원 너비 조정 */
+        left: 2px;
+        bottom: 0px;
+        background-color: var(--toggle-ball-light);
+        transition: transform 0.4s;
+        border-radius: 50%;
+    }
+
+    .toggle-switch input:checked + .label {
+        background-color: var(--toggle-background-dark);
+    }
+
+    .toggle-switch input:checked + .label:before {
+        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+    }
+
+             #absdiv {
+                position: relative;
+                top: 60px; /* Move down by 20px from its current position */
+                z-index : 1000;
+            }
+
+            #searchbutton {
+                background-color: #828282;
+            }
+
+            .card-img-top {
+                    width: 100%;
+                    height: 100px;
+                    object-fit: cover;
+                }
+
+        </style>
+        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+              rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+              rel="stylesheet">
+
+        <div class="col-md-9">
+            <div class="row" style="color: #828282;">
+                <div class="col-11">
+                    <div class="row mb-4">
+                        <div class="col-12">
+                            <form id="sort-form" th:action="@{/user/my/wt/comment}" method="get">
+                                <div class="row">
+                                    <div class="col-7">
+                                        <div class="row justify-content-start m-0">
+                                            <div class="col-4">
+                                                <!-- 검색 조건 -->
+                                                <label>
+                                                    <select class="form-select px-3" name="searchBy">
+                                                        <option value="comment" th:selected="${searchBy == 'comment'}">
+                                                            코멘트내용
+                                                        </option>
+                                                        <option value="title" th:selected="${searchBy == 'title'}">제목
+                                                        </option>
+                                                        <option value="author" th:selected="${searchBy == 'author'}">
+                                                            작가
+                                                        </option>
+                                                        <option value="genre" th:selected="${searchBy == 'genre'}">장르
+                                                        </option>
+                                                        <option value="tag" th:selected="${searchBy == 'tag'}">태그
+                                                        </option>
+                                                    </select>
+                                                </label>
+                                            </div>
+                                            <div class="col-6">
+                                                <input class="form-control px-3" type="text" name="searchTerm"
+                                                       placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
+                                            </div>
+                                            <div class="col-2">
+                                                <!-- 검색 버튼 -->
+                                                <button id="searchbutton" type="submit" class="btn btn-primary">검색
+                                                </button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-1" style=""></div>
+                                    <div class="col-4">
+                                        <div class="row justify-content-end">
+                                            <!-- 정렬 또는 토글2 -->
                                             <label>
-                                                <select class="form-select px-3" name="searchBy">
-                                                    <option value="comment" th:selected="${searchBy == 'comment'}">코멘트내용</option>
-                                                    <option value="title" th:selected="${searchBy == 'title'}">제목</option>
-                                                    <option value="author" th:selected="${searchBy == 'author'}">작가</option>
-                                                    <option value="genre" th:selected="${searchBy == 'genre'}">장르</option>
-                                                    <option value="tag" th:selected="${searchBy == 'tag'}">태그</option>
+                                                <select class="form-select px-3" name="orderBy"
+                                                        onchange="this.form.submit()">
+                                                    <option value="recent" th:selected="${orderBy == 'recent'}">최근남긴순
+                                                    </option>
+                                                    <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순
+                                                    </option>
+                                                    <option value="views" th:selected="${orderBy == 'views'}">조회수높은순
+                                                    </option>
+                                                    <option value="likes" th:selected="${orderBy == 'likes'}">댓글좋아요많은순
+                                                    </option>
                                                 </select>
                                             </label>
                                         </div>
-                                        <div class="col-6">
-                                            <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
+                                    </div>
+                                </div> <!--검색, 소팅 (토글X)-->
+                                <div class="row justify-content-around">
+                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                    <div class="col-3" style="padding: 0 1.2rem;">
+                                        <div id="absdiv" class="row justify-content-end">
+                                            <!--                                        <div class="col-3">-->
+                                            <!--                                            <div class="toggle-switch">-->
+                                            <!--                                                &lt;!&ndash; 정렬 또는 토글1 &ndash;&gt;-->
+                                            <!--                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">-->
+                                            <!--                                                <label for="isToggledCheckbox" class="label">-->
+                                            <!--                                                    <div class="ball"></div>-->
+                                            <!--                                                </label>-->
+                                            <!--                                            </div>-->
+                                            <!--                                        </div>-->
+                                            <!--                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">진행중인 행사</div>-->
                                         </div>
-                                        <div class="col-2">
-                                            <!-- 검색 버튼 -->
-                                            <button id="searchbutton" type="submit" class="btn btn-primary">검색</button>
-                                        </div>
                                     </div>
-                                </div>
-                                <div class="col-1" style=""></div>
-                                <div class="col-4">
-                                    <div class="row justify-content-end">
-                                        <!-- 정렬 또는 토글2 -->
-                                        <label>
-                                            <select class="form-select px-3" name="orderBy" onchange="this.form.submit()">
-                                                <option value="recent" th:selected="${orderBy == 'recent'}">최근남긴순</option>
-                                                <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>
-                                                <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>
-                                                <option value="likes" th:selected="${orderBy == 'likes'}">댓글좋아요많은순</option>
-                                            </select>
-                                        </label>
-                                    </div>
-                                </div>
-                            </div> <!--검색, 소팅 (토글X)-->
-                            <div class="row justify-content-around">
-                                <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                <div class="col-3" style="padding: 0 1.2rem;">
-                                    <div id="absdiv" class="row justify-content-end">
-                                        <!--                                        <div class="col-3">-->
-                                        <!--                                            <div class="toggle-switch">-->
-                                        <!--                                                &lt;!&ndash; 정렬 또는 토글1 &ndash;&gt;-->
-                                        <!--                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">-->
-                                        <!--                                                <label for="isToggledCheckbox" class="label">-->
-                                        <!--                                                    <div class="ball"></div>-->
-                                        <!--                                                </label>-->
-                                        <!--                                            </div>-->
-                                        <!--                                        </div>-->
-                                        <!--                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">진행중인 행사</div>-->
-                                    </div>
-                                </div>
-                            </div> <!--토글-->
-                        </form>
+                                </div> <!--토글-->
+                            </form>
+                        </div>
                     </div>
-                </div>
-                <div class="row justify-content-around mt-4">
-                    <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
-                        <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
-                            <div class="col-3 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:each="myWtComment, iterStat : ${myWtComments}" th:attr="data-href=@{/webtoon/one(
+                    <div class="row justify-content-around mt-4">
+                        <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
+                            <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
+                                <div class="col-3 clickable-row"
+                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                     th:each="myWtComment, iterStat : ${myWtComments}" th:attr="data-href=@{/webtoon/one(
                 webtoon_id=${(myWtComment.platform == 1 ? 'naver_' : myWtComment.platform == 2 ? 'kakao_' : '') + myWtComment.webtoonId},
                 webtoon_name=${myWtComment.webtoonName},
                 author=${myWtComment.author}
                 )}" th:if="${iterStat.index < 3}">
-                                <div class="row justify-content-center">
-                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                        <div class="date-container px-3 py-2">
-                                            <div class="month"
-                                                 th:text="${myWtComment.platform == 1 ? 'N' : (myWtComment.platform == 2 ? 'K' : '')}"></div>
+                                    <div class="row justify-content-center">
+                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                             style="aspect-ratio: 1; border-radius: 5px;">
+                                            <div class="date-container px-3 py-2">
+                                                <div class="month"
+                                                     th:text="${myWtComment.platform == 1 ? 'N' : (myWtComment.platform == 2 ? 'K' : '')}"></div>
+                                            </div>
+                                        </div>
+                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                        <!--                                    </div>-->
+                                        <div class="col-5" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
+                                             th:text="${myWtComment.platform == 1 ? '네이버웹툰' : (myWtComment.platform == 2 ? '카카오웹툰' : '')}">
+                                            닉네임
+                                        </div>
+
+                                        <div class="col-3"
+                                             style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
+                                             th:text="${myWtComment.formattedCreatedAt}">시간
                                         </div>
                                     </div>
-                                    <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                    <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                    <!--                                    </div>-->
-                                    <div class="col-5" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
-                                         th:text="${myWtComment.platform == 1 ? '네이버웹툰' : (myWtComment.platform == 2 ? '카카오웹툰' : '')}">닉네임
+                                    <div class="row justify-content-center">
+                                        <div class="col-12 my-3" style="">
+                                            <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                            <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                            <!-- 썸네일 이미지 있을때  -->
+                                            <img th:if="${myWtComment.thumbnailUrl != null}"
+                                                 th:src="${myWtComment.thumbnailUrl}" class="card-img-top"
+                                                 alt="썸네일 이미지">
+                                        </div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                             th:text="${myWtComment.webtoonName}">이름
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                             th:text="${myWtComment.content}">내용
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
                                     </div>
 
-                                    <div class="col-3" style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;" th:text="${myWtComment.formattedCreatedAt}">시간</div>
                                 </div>
-                                <div class="row justify-content-center">
-                                    <div class="col-12 my-3" style="">
-                                        <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                        <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                        <!-- 썸네일 이미지 있을때  -->
-                                        <img th:if="${myWtComment.thumbnailUrl != null}" th:src="${myWtComment.thumbnailUrl}" class="card-img-top" alt="썸네일 이미지">
-                                    </div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" th:text="${myWtComment.webtoonName}">이름</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${myWtComment.content}">내용</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                </div>
-
+                                <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
+                                <div class="col-3" th:if="${myWtComments.size() == 0}"></div>
+                                <div class="col-3"
+                                     th:if="${myWtComments.size() == 0 || myWtComments.size() == 1}"></div>
+                                <div class="col-3"
+                                     th:if="${myWtComments.size() == 0 || myWtComments.size() == 1 || myWtComments.size() == 2}"></div>
                             </div>
-                            <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
-                            <div class="col-3" th:if="${myWtComments.size() == 0}"></div>
-                            <div class="col-3" th:if="${myWtComments.size() == 0 || myWtComments.size() == 1}"></div>
-                            <div class="col-3" th:if="${myWtComments.size() == 0 || myWtComments.size() == 1 || myWtComments.size() == 2}"></div>
-                        </div>
-                        <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
-                            <div class="col-3 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:each="myWtComment, iterStat : ${myWtComments}" th:attr="data-href=@{/webtoon/one(
+                            <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
+                                <div class="col-3 clickable-row"
+                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                     th:each="myWtComment, iterStat : ${myWtComments}" th:attr="data-href=@{/webtoon/one(
                 webtoon_id=${(myWtComment.platform == 1 ? 'naver_' : myWtComment.platform == 2 ? 'kakao_' : '') + myWtComment.webtoonId},
                 webtoon_name=${myWtComment.webtoonName},
                 author=${myWtComment.author}
                 )}" th:if="${iterStat.index >= 3}">
-                                <div class="row justify-content-center">
-                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                        <div class="date-container px-3 py-2">
-                                            <div class="month"
-                                                 th:text="${myWtComment.platform == 1 ? 'N' : (myWtComment.platform == 2 ? 'K' : '')}"></div>
+                                    <div class="row justify-content-center">
+                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                             style="aspect-ratio: 1; border-radius: 5px;">
+                                            <div class="date-container px-3 py-2">
+                                                <div class="month"
+                                                     th:text="${myWtComment.platform == 1 ? 'N' : (myWtComment.platform == 2 ? 'K' : '')}"></div>
+                                            </div>
+                                        </div>
+                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                        <!--                                    </div>-->
+                                        <div class="col-5" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
+                                             th:text="${myWtComment.platform == 1 ? '네이버웹툰' : (myWtComment.platform == 2 ? '카카오웹툰' : '')}">
+                                            닉네임
+                                        </div>
+
+                                        <div class="col-3"
+                                             style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
+                                             th:text="${myWtComment.formattedCreatedAt}">시간
                                         </div>
                                     </div>
-                                    <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                    <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                    <!--                                    </div>-->
-                                    <div class="col-5" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
-                                         th:text="${myWtComment.platform == 1 ? '네이버웹툰' : (myWtComment.platform == 2 ? '카카오웹툰' : '')}">닉네임
+                                    <div class="row justify-content-center">
+                                        <div class="col-12 my-3" style="">
+                                            <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                            <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                            <!-- 썸네일 이미지 있을때  -->
+                                            <img th:if="${myWtComment.thumbnailUrl != null}"
+                                                 th:src="${myWtComment.thumbnailUrl}" class="card-img-top"
+                                                 alt="썸네일 이미지">
+                                        </div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                             th:text="${myWtComment.webtoonName}">이름
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9"
+                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                             th:text="${myWtComment.content}">내용
+                                        </div>
+                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
                                     </div>
 
-                                    <div class="col-3" style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;" th:text="${myWtComment.formattedCreatedAt}">시간</div>
-                                </div>
-                                <div class="row justify-content-center">
-                                    <div class="col-12 my-3" style="">
-                                        <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                        <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                        <!-- 썸네일 이미지 있을때  -->
-                                        <img th:if="${myWtComment.thumbnailUrl != null}" th:src="${myWtComment.thumbnailUrl}" class="card-img-top" alt="썸네일 이미지">
-                                    </div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" th:text="${myWtComment.webtoonName}">이름</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${myWtComment.content}">내용</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;">→</div>
                                 </div>
 
+                                <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
+                                <div class="col-3" th:if="${myWtComments.size() <= 3}"></div>
+                                <div class="col-3"
+                                     th:if="${myWtComments.size() <= 3 || myWtComments.size() == 4}"></div>
+                                <div class="col-3"
+                                     th:if="${myWtComments.size() <= 3 || myWtComments.size() == 4 || myWtComments.size() == 5}"></div>
                             </div>
-
-                            <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
-                            <div class="col-3" th:if="${myWtComments.size() <= 3}"></div>
-                            <div class="col-3" th:if="${myWtComments.size() <= 3 || myWtComments.size() == 4}"></div>
-                            <div class="col-3" th:if="${myWtComments.size() <= 3 || myWtComments.size() == 4 || myWtComments.size() == 5}"></div>
                         </div>
                     </div>
-                </div>
-                <div class="row justify-content-center">
-                    <!-- 페이징 -->
-                    <th:block th:if="${pages != null}">
-                        <div class="d-flex justify-content-center">
-                            <div class="btn-group">
-                                <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/wt/comment(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-                                        <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                                    </svg>
-                                </button>
-                                <th:block th:each="p : ${#numbers.sequence(1, pages)}">
-                                    <button type="button" class="btn btn-sm me-2 pages"
-                                            th:text="${p}" th:onclick="|location.href='@{/user/my/wt/comment(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
-                                </th:block>
-                                <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/wt/comment(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-                                        <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
-                                    </svg>
-                                </button>
+                    <div class="row justify-content-center">
+                        <!-- 페이징 -->
+                        <th:block th:if="${pages != null}">
+                            <div class="d-flex justify-content-center">
+                                <div class="btn-group">
+                                    <button type="button" class="btn btn-sm previous"
+                                            th:onclick="|location.href='@{/user/my/wt/comment(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
+                                            th:disabled="${currentPage == 1}">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                             fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+                                            <path fill-rule="evenodd"
+                                                  d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                                        </svg>
+                                    </button>
+                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">
+                                        <button type="button" class="btn btn-sm me-2 pages"
+                                                th:text="${p}"
+                                                th:onclick="|location.href='@{/user/my/wt/comment(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
+                                    </th:block>
+                                    <button type="button" class="btn btn-sm  next"
+                                            th:onclick="|location.href='@{/user/my/wt/comment(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
+                                            th:disabled="${currentPage == pages}">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                             fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+                                            <path fill-rule="evenodd"
+                                                  d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                                        </svg>
+                                    </button>
+                                </div>
                             </div>
-                        </div>
-                    </th:block>
-                </div>
-            </div><!--테이블 및 페이징 포함-->
+                        </th:block>
+                    </div>
+                </div><!--테이블 및 페이징 포함-->
+            </div> <!--본화면-->
         </div> <!--본화면-->
-    </div> <!--본화면-->
 
-    <!--수정전-->
-<!--    <div class="col-md-9">-->
-<!--        <div class="row" style="color: #828282;">-->
-<!--            <div class="col-11">-->
-<!--                <div class="row">-->
-<!--                    <div class="col-12">-->
-<!--                        <form id="sort-form" th:action="@{/user/my/wt/comment}" method="get">-->
-<!--                            <div class="row">-->
-<!--                                <div class="col-6">-->
-<!--                                    <div class="row">-->
-<!--                                        <div class="col-4">-->
-<!--                                            &lt;!&ndash; 검색 조건 &ndash;&gt;-->
-<!--                                            <label>-->
-<!--                                                <select class="form-select px-3" name="searchBy">-->
-<!--                                                    <option value="comment" th:selected="${searchBy == 'comment'}">코멘트내용</option>-->
-<!--                                                    <option value="title" th:selected="${searchBy == 'title'}">제목</option>-->
-<!--                                                    <option value="author" th:selected="${searchBy == 'author'}">작가</option>-->
-<!--                                                    <option value="genre" th:selected="${searchBy == 'genre'}">장르</option>-->
-<!--                                                    <option value="tag" th:selected="${searchBy == 'tag'}">태그</option>-->
-<!--                                                </select>-->
-<!--                                            </label>-->
-<!--                                        </div>-->
-<!--                                        <div class="col-6">-->
-<!--                                            <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
-<!--                                        </div>-->
-<!--                                        <div class="col-2">-->
-<!--                                            &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
-<!--                                            <button type="submit">검색</button>-->
-<!--                                        </div>-->
-<!--                                    </div>-->
-<!--                                </div>-->
-<!--                                <div class="col-2" style="background-color: red;"></div>-->
-<!--                                <div class="col-4">-->
-<!--                                    <div class="row justify-content-end">-->
-<!--                                        &lt;!&ndash; 정렬 조건 &ndash;&gt;-->
-<!--                                        <label>-->
-<!--                                            <select class="form-select px-3" name="orderBy" onchange="this.form.submit()">-->
-<!--                                                <option value="recent" th:selected="${orderBy == 'recent'}">최근남긴순</option>-->
-<!--                                                <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
-<!--                                                <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>-->
-<!--                                                <option value="likes" th:selected="${orderBy == 'likes'}">댓글좋아요많은순</option>-->
-<!--                                            </select>-->
-<!--                                        </label>-->
-<!--                                    </div>-->
-<!--                                </div>-->
-<!--                            </div> &lt;!&ndash;검색, 소팅 (토글X)&ndash;&gt;-->
-<!--                        </form>-->
-<!--                    </div>-->
-<!--                </div>-->
-<!--                <div class="row">-->
-<!--                    <div class="review-list">-->
-<!--                        <table>-->
-<!--                            <thead>-->
-<!--                            <tr>-->
-<!--                                <th>댓글 번호</th>-->
-<!--                                <th>웹툰 번호</th>-->
-<!--                                <th>유저 번호</th>-->
-<!--                                <th>내용</th>-->
-<!--                                <th>좋아요</th>-->
-<!--                                <th>싫어요</th>-->
-<!--                                <th>생성일시*</th>-->
-<!--                                <th>수정일시*</th>-->
-<!--                                <th>웹툰아이디</th>-->
-<!--                                <th>플렛폼</th>-->
-<!--                                <th>제목</th>-->
-<!--                                <th>작가</th>-->
-<!--                                <th>이미지URL</th>-->
-<!--                                <th>장르</th>-->
-<!--                                <th>태그</th>-->
-<!--                                <th>조회수</th>-->
-<!--                            </tr>-->
-<!--                            </thead>-->
-<!--                            <tbody>-->
-<!--                            <tr th:each="myWtComment : ${myWtComments}" class="clickable-row"-->
-<!--                                th:attr="data-href=@{/webtoon/one(-->
-<!--                webtoon_id=${(myWtComment.platform == 1 ? 'naver_' : myWtComment.platform == 2 ? 'kakao_' : '') + myWtComment.webtoonId},-->
-<!--                webtoon_name=${myWtComment.webtoonName},-->
-<!--                author=${myWtComment.author}-->
-<!--                )}">-->
-<!--                                <td th:text="${myWtComment.commentNo}">댓글 번호</td>-->
-<!--                                <td th:text="${myWtComment.webtoonNo}">웹툰 번호</td>-->
-<!--                                <td th:text="${myWtComment.userNo}">유저 번호</td>-->
-<!--                                <td th:text="${myWtComment.content}">내용</td>-->
-<!--                                <td th:text="${myWtComment.liked}">좋아요</td>-->
-<!--                                <td th:text="${myWtComment.dislike}">싫어요</td>-->
-<!--                                <td th:text="${myWtComment.createdAt}">생성일시*</td>-->
-<!--                                <td th:text="${myWtComment.updatedAt}">수정일시*</td>-->
-<!--                                <td th:text="${myWtComment.webtoonId}">웹툰아이디</td>-->
-<!--                                <td th:text="${myWtComment.platform}">플렛폼</td>-->
-<!--                                <td th:text="${myWtComment.webtoonName}">제목</td>-->
-<!--                                <td th:text="${myWtComment.author}">작가</td>-->
-<!--                                <td th:text="${myWtComment.thumbnailUrl}">이미지URL</td>-->
-<!--                                <td th:text="${myWtComment.genre}">장르</td>-->
-<!--                                <td th:text="${myWtComment.tags}">태그</td>-->
-<!--                                <td th:text="${myWtComment.count}">조회수</td>-->
-<!--                            </tr>-->
-<!--                            </tbody>-->
-<!--                        </table>-->
-<!--                        &lt;!&ndash; 페이징 &ndash;&gt;-->
-<!--                        <th:block th:if="${pages != null}">-->
-<!--                            <div class="d-flex justify-content-center">-->
-<!--                                <div class="btn-group">-->
-<!--                                    <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/wt/comment(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
-<!--                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
-<!--                                            <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
-<!--                                        </svg>-->
-<!--                                    </button>-->
-<!--                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
-<!--                                        <button type="button" class="btn btn-sm me-2 pages"-->
-<!--                                                th:text="${p}" th:onclick="|location.href='@{/user/my/wt/comment(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
-<!--                                    </th:block>-->
-<!--                                    <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/wt/comment(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
-<!--                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
-<!--                                            <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
-<!--                                        </svg>-->
-<!--                                    </button>-->
-<!--                                </div>-->
-<!--                            </div>-->
-<!--                        </th:block>-->
-<!--                    </div>-->
-<!--                </div> &lt;!&ndash;테이블과 페이징&ndash;&gt;-->
-<!--            </div>&lt;!&ndash;테이블 및 페이징 포함&ndash;&gt;-->
-<!--        </div>-->
+        <!--수정전-->
+        <!--    <div class="col-md-9">-->
+        <!--        <div class="row" style="color: #828282;">-->
+        <!--            <div class="col-11">-->
+        <!--                <div class="row">-->
+        <!--                    <div class="col-12">-->
+        <!--                        <form id="sort-form" th:action="@{/user/my/wt/comment}" method="get">-->
+        <!--                            <div class="row">-->
+        <!--                                <div class="col-6">-->
+        <!--                                    <div class="row">-->
+        <!--                                        <div class="col-4">-->
+        <!--                                            &lt;!&ndash; 검색 조건 &ndash;&gt;-->
+        <!--                                            <label>-->
+        <!--                                                <select class="form-select px-3" name="searchBy">-->
+        <!--                                                    <option value="comment" th:selected="${searchBy == 'comment'}">코멘트내용</option>-->
+        <!--                                                    <option value="title" th:selected="${searchBy == 'title'}">제목</option>-->
+        <!--                                                    <option value="author" th:selected="${searchBy == 'author'}">작가</option>-->
+        <!--                                                    <option value="genre" th:selected="${searchBy == 'genre'}">장르</option>-->
+        <!--                                                    <option value="tag" th:selected="${searchBy == 'tag'}">태그</option>-->
+        <!--                                                </select>-->
+        <!--                                            </label>-->
+        <!--                                        </div>-->
+        <!--                                        <div class="col-6">-->
+        <!--                                            <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
+        <!--                                        </div>-->
+        <!--                                        <div class="col-2">-->
+        <!--                                            &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
+        <!--                                            <button type="submit">검색</button>-->
+        <!--                                        </div>-->
+        <!--                                    </div>-->
+        <!--                                </div>-->
+        <!--                                <div class="col-2" style="background-color: red;"></div>-->
+        <!--                                <div class="col-4">-->
+        <!--                                    <div class="row justify-content-end">-->
+        <!--                                        &lt;!&ndash; 정렬 조건 &ndash;&gt;-->
+        <!--                                        <label>-->
+        <!--                                            <select class="form-select px-3" name="orderBy" onchange="this.form.submit()">-->
+        <!--                                                <option value="recent" th:selected="${orderBy == 'recent'}">최근남긴순</option>-->
+        <!--                                                <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
+        <!--                                                <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>-->
+        <!--                                                <option value="likes" th:selected="${orderBy == 'likes'}">댓글좋아요많은순</option>-->
+        <!--                                            </select>-->
+        <!--                                        </label>-->
+        <!--                                    </div>-->
+        <!--                                </div>-->
+        <!--                            </div> &lt;!&ndash;검색, 소팅 (토글X)&ndash;&gt;-->
+        <!--                        </form>-->
+        <!--                    </div>-->
+        <!--                </div>-->
+        <!--                <div class="row">-->
+        <!--                    <div class="review-list">-->
+        <!--                        <table>-->
+        <!--                            <thead>-->
+        <!--                            <tr>-->
+        <!--                                <th>댓글 번호</th>-->
+        <!--                                <th>웹툰 번호</th>-->
+        <!--                                <th>유저 번호</th>-->
+        <!--                                <th>내용</th>-->
+        <!--                                <th>좋아요</th>-->
+        <!--                                <th>싫어요</th>-->
+        <!--                                <th>생성일시*</th>-->
+        <!--                                <th>수정일시*</th>-->
+        <!--                                <th>웹툰아이디</th>-->
+        <!--                                <th>플렛폼</th>-->
+        <!--                                <th>제목</th>-->
+        <!--                                <th>작가</th>-->
+        <!--                                <th>이미지URL</th>-->
+        <!--                                <th>장르</th>-->
+        <!--                                <th>태그</th>-->
+        <!--                                <th>조회수</th>-->
+        <!--                            </tr>-->
+        <!--                            </thead>-->
+        <!--                            <tbody>-->
+        <!--                            <tr th:each="myWtComment : ${myWtComments}" class="clickable-row"-->
+        <!--                                th:attr="data-href=@{/webtoon/one(-->
+        <!--                webtoon_id=${(myWtComment.platform == 1 ? 'naver_' : myWtComment.platform == 2 ? 'kakao_' : '') + myWtComment.webtoonId},-->
+        <!--                webtoon_name=${myWtComment.webtoonName},-->
+        <!--                author=${myWtComment.author}-->
+        <!--                )}">-->
+        <!--                                <td th:text="${myWtComment.commentNo}">댓글 번호</td>-->
+        <!--                                <td th:text="${myWtComment.webtoonNo}">웹툰 번호</td>-->
+        <!--                                <td th:text="${myWtComment.userNo}">유저 번호</td>-->
+        <!--                                <td th:text="${myWtComment.content}">내용</td>-->
+        <!--                                <td th:text="${myWtComment.liked}">좋아요</td>-->
+        <!--                                <td th:text="${myWtComment.dislike}">싫어요</td>-->
+        <!--                                <td th:text="${myWtComment.createdAt}">생성일시*</td>-->
+        <!--                                <td th:text="${myWtComment.updatedAt}">수정일시*</td>-->
+        <!--                                <td th:text="${myWtComment.webtoonId}">웹툰아이디</td>-->
+        <!--                                <td th:text="${myWtComment.platform}">플렛폼</td>-->
+        <!--                                <td th:text="${myWtComment.webtoonName}">제목</td>-->
+        <!--                                <td th:text="${myWtComment.author}">작가</td>-->
+        <!--                                <td th:text="${myWtComment.thumbnailUrl}">이미지URL</td>-->
+        <!--                                <td th:text="${myWtComment.genre}">장르</td>-->
+        <!--                                <td th:text="${myWtComment.tags}">태그</td>-->
+        <!--                                <td th:text="${myWtComment.count}">조회수</td>-->
+        <!--                            </tr>-->
+        <!--                            </tbody>-->
+        <!--                        </table>-->
+        <!--                        &lt;!&ndash; 페이징 &ndash;&gt;-->
+        <!--                        <th:block th:if="${pages != null}">-->
+        <!--                            <div class="d-flex justify-content-center">-->
+        <!--                                <div class="btn-group">-->
+        <!--                                    <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/wt/comment(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
+        <!--                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
+        <!--                                            <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
+        <!--                                        </svg>-->
+        <!--                                    </button>-->
+        <!--                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
+        <!--                                        <button type="button" class="btn btn-sm me-2 pages"-->
+        <!--                                                th:text="${p}" th:onclick="|location.href='@{/user/my/wt/comment(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
+        <!--                                    </th:block>-->
+        <!--                                    <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/wt/comment(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
+        <!--                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
+        <!--                                            <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
+        <!--                                        </svg>-->
+        <!--                                    </button>-->
+        <!--                                </div>-->
+        <!--                            </div>-->
+        <!--                        </th:block>-->
+        <!--                    </div>-->
+        <!--                </div> &lt;!&ndash;테이블과 페이징&ndash;&gt;-->
+        <!--            </div>&lt;!&ndash;테이블 및 페이징 포함&ndash;&gt;-->
+        <!--        </div>-->
 
-<!--    </div> &lt;!&ndash;본화면&ndash;&gt;-->
-</div> <!--aside와 본화면-->
+        <!--    </div> &lt;!&ndash;본화면&ndash;&gt;-->
+    </div> <!--aside와 본화면--></div>
 <div th:replace="common/footer.html"></div>
 </body>
 </html>

--- a/src/main/resources/templates/user/mypage_wt_comment.html
+++ b/src/main/resources/templates/user/mypage_wt_comment.html
@@ -321,7 +321,7 @@
                                 }
 
                                 .search-container button i {
-                                    color: #666;
+                                    color: #A6AAB5;
                                 }
 
                                 .search-container button:hover i {

--- a/src/main/resources/templates/user/mypage_wt_comment.html
+++ b/src/main/resources/templates/user/mypage_wt_comment.html
@@ -114,7 +114,7 @@
     <div class="row">
         <aside class="col-md-3 px-4">
             <div class="row">
-                <div class="col-3"></div>
+                <div class="col-1"></div>
                 <div class="col-6">
                     <div class="panel">
                         <ul class="list-group">

--- a/src/main/resources/templates/user/mypage_wt_comment.html
+++ b/src/main/resources/templates/user/mypage_wt_comment.html
@@ -90,17 +90,22 @@
 <div class="jumbotron">
     <div class="container">
         <div class="row">
-            <div class="col-md-3 px-4">
-                <h3>나의 웹툰</h3>
-            </div>
-            <div class="col-md-9">
-                <nav class="navbar navbar-expand-md">
-                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                        <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">북마크한 웹툰</a></li>
-                        <li><a th:href="@{/user/my/wt/comment}" class="nav-link px-2" style="color: #000;">내가 남긴 코멘트</a>
-                        </li>
-                    </ul>
-                </nav>
+            <div class="col-9">
+                <div class="row">
+                    <div class="col-md-3 px-4">
+                        <h3>나의 웹툰</h3>
+                    </div>
+                    <div class="col-md-9">
+                        <nav class="navbar navbar-expand-md">
+                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">북마크한 웹툰</a></li>
+                                <li><a th:href="@{/user/my/wt/comment}" class="nav-link px-2" style="color: #000;">내가 남긴
+                                    코멘트</a>
+                                </li>
+                            </ul>
+                        </nav>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/user/mypage_wt_comment.html
+++ b/src/main/resources/templates/user/mypage_wt_comment.html
@@ -28,6 +28,11 @@
         });
     </script>
     <style>
+        .container {
+            max-width: 1000px;
+            margin: 0 auto;
+            padding: 20px;
+        }
         .review-list {
             background-color: #fff;
             border-radius: 8px;
@@ -99,8 +104,7 @@
                         <nav class="navbar navbar-expand-md">
                             <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
                                 <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">북마크한 웹툰</a></li>
-                                <li><a th:href="@{/user/my/wt/comment}" class="nav-link px-2" style="color: #000;">내가 남긴
-                                    코멘트</a>
+                                <li><a th:href="@{/user/my/wt/comment}" class="nav-link px-2" style="color: #000;">내가 남긴 코멘트</a>
                                 </li>
                             </ul>
                         </nav>

--- a/src/main/resources/templates/user/mypage_wt_comment.html
+++ b/src/main/resources/templates/user/mypage_wt_comment.html
@@ -267,14 +267,69 @@
             <div class="row" style="color: #828282;">
                 <div class="col-11">
                     <div class="row mb-4">
-                        <div class="col-12">
+                        <div class="col-12 p-0">
+                            <style>
+                                .col-4 select {
+                                    border-radius: 50px;
+                                    text-align: center;
+                                }
+                                /* 검색창 스타일 */
+                                .search-container {
+                                    width: 300px;
+                                }
+
+                                .search-container select {
+                                    position: absolute;
+                                    left: 0%;
+                                    width: 30%;
+                                    height: 50px;
+                                    color: #828282;
+                                    font-size: 1rem;
+                                    border-radius: 50px 0 0 50px;
+                                    outline: none;
+                                }
+                                .search-container input[type="text"] {
+                                    position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
+                                    left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
+                                    width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
+                                    height: 50px;
+                                    padding: 10px 40px 10px 15px;
+                                    font-size: 1rem;
+                                    outline: none;
+                                    border-radius: 0 50px 50px 0;
+                                    transition: border-color 0.3s, background-color 0.3s;
+                                    color: #828282; /* 입력 텍스트 색상 변경 */
+                                }
+
+                                .search-container input[type="text"]::placeholder {
+                                    color: #BBBBBB; /* placeholder 색상 변경 */
+                                }
+
+
+                                .search-container button {
+                                    position: absolute;
+                                    right: 1rem;
+                                    top: 25px;
+                                    background: none;
+                                    transform: translateY(-50%);
+                                    border: none;
+                                    cursor: pointer;
+                                }
+
+                                .search-container button i {
+                                    color: #666;
+                                }
+
+                                .search-container button:hover i {
+                                    color: #03C75A;
+                                }
+                            </style>
                             <form id="sort-form" th:action="@{/user/my/wt/comment}" method="get">
-                                <div class="row">
-                                    <div class="col-7">
+                                <div class="row m-0">
+                                    <div class="col-7 p-0">
                                         <div class="row justify-content-start m-0">
-                                            <div class="col-4">
-                                                <!-- 검색 조건 -->
-                                                <label>
+                                            <div class="col-12 p-0">
+                                                <div class="search-container">
                                                     <select class="form-select px-3" name="searchBy">
                                                         <option value="comment" th:selected="${searchBy == 'comment'}">
                                                             코멘트내용
@@ -289,16 +344,12 @@
                                                         <option value="tag" th:selected="${searchBy == 'tag'}">태그
                                                         </option>
                                                     </select>
-                                                </label>
-                                            </div>
-                                            <div class="col-6">
-                                                <input class="form-control px-3" type="text" name="searchTerm"
-                                                       placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
-                                            </div>
-                                            <div class="col-2">
-                                                <!-- 검색 버튼 -->
-                                                <button id="searchbutton" type="submit" class="btn btn-primary">검색
-                                                </button>
+                                                    <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
+                                                    <!-- 검색 버튼 -->
+                                                    <button type="submit">
+                                                        <i class="fas fa-search"></i>
+                                                    </button>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>

--- a/src/main/resources/templates/user/mypage_wt_comment.html
+++ b/src/main/resources/templates/user/mypage_wt_comment.html
@@ -88,17 +88,20 @@
   }
 </style>
 <div class="jumbotron">
-    <div class="row">
-        <div class="col-md-3 px-4">
-            <h3>나의 웹툰</h3>
-        </div>
-        <div class="col-md-9">
-            <nav class="navbar navbar-expand-md">
-                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                    <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">북마크한 웹툰</a></li>
-                    <li><a th:href="@{/user/my/wt/comment}" class="nav-link px-2" style="color: #000;">내가 남긴 코멘트</a></li>
-                </ul>
-            </nav>
+    <div class="container">
+        <div class="row">
+            <div class="col-md-3 px-4">
+                <h3>나의 웹툰</h3>
+            </div>
+            <div class="col-md-9">
+                <nav class="navbar navbar-expand-md">
+                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                        <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">북마크한 웹툰</a></li>
+                        <li><a th:href="@{/user/my/wt/comment}" class="nav-link px-2" style="color: #000;">내가 남긴 코멘트</a>
+                        </li>
+                    </ul>
+                </nav>
+            </div>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/user/mypage_wt_comment.html
+++ b/src/main/resources/templates/user/mypage_wt_comment.html
@@ -115,7 +115,7 @@
         <aside class="col-md-3 px-4">
             <div class="row">
                 <div class="col-1"></div>
-                <div class="col-6">
+                <div class="col-8">
                     <div class="panel">
                         <ul class="list-group">
                             <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2" style="color: #03C75A;">나의

--- a/src/main/resources/templates/user/mypage_wt_comment.html
+++ b/src/main/resources/templates/user/mypage_wt_comment.html
@@ -74,621 +74,650 @@
 
 <div th:replace="~{common/menubar}"></div>
 <style>
-    .jumbotron {
-    position : relative;
-    background-color : #EEEEEE;
+    html, body {
+        height: 100%;
+        margin: 0;
     }
-    .jumbotron .row {
-    position : absolute;
-    width : 100%;
-    bottom: 0%;
+    body {
+        display: flex;
+        flex-direction: column;
+    }
+    .content-wrapper {
+        flex: 1 0 auto;
+    }
+    footer {
+        flex-shrink: 0;
     }
 
-    .nav-link {
-            color: #828282;
-    }
-    ul {
-  list-style: none;
-  padding-left : 0px;
-  }
 </style>
-<div class="jumbotron">
-    <div class="container">
-        <div class="row">
-            <div class="col-9">
-                <div class="row">
-                    <div class="col-md-3 px-4">
-                        <h3>나의 웹툰</h3>
-                    </div>
-                    <div class="col-md-9">
-                        <nav class="navbar navbar-expand-md">
-                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                                <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">북마크한 웹툰</a></li>
-                                <li><a th:href="@{/user/my/wt/comment}" class="nav-link px-2" style="color: #000;">내가 남긴 코멘트</a>
-                                </li>
-                            </ul>
-                        </nav>
+<div class="content-wrapper">
+    <style>
+        .jumbotron {
+        position : relative;
+        background-color : #EEEEEE;
+        }
+        .jumbotron .row {
+        position : absolute;
+        width : 100%;
+        bottom: 0%;
+        }
+
+        .nav-link {
+                color: #828282;
+        }
+        ul {
+      list-style: none;
+      padding-left : 0px;
+      }
+    </style>
+    <div class="jumbotron">
+        <div class="container">
+            <div class="row">
+                <div class="col-9">
+                    <div class="row">
+                        <div class="col-md-3 px-4">
+                            <h3>나의 웹툰</h3>
+                        </div>
+                        <div class="col-md-9">
+                            <nav class="navbar navbar-expand-md">
+                                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                    <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2">북마크한 웹툰</a></li>
+                                    <li><a th:href="@{/user/my/wt/comment}" class="nav-link px-2" style="color: #000;">내가
+                                        남긴 코멘트</a>
+                                    </li>
+                                </ul>
+                            </nav>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
-<div class="container" style="padding:0;">
-    <div class="row">
-        <aside class="col-md-3 px-4">
-            <div class="row">
-                <div class="col-1"></div>
-                <div class="col-8">
-                    <div class="panel">
-                        <ul class="list-group">
-                            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2" style="color: #03C75A;">나의
-                                웹툰</a></li>
-                            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-                            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
-                            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-                        </ul>
+    <div class="container" style="padding:0;">
+        <div class="row">
+            <aside class="col-md-3 px-4">
+                <div class="row">
+                    <div class="col-1"></div>
+                    <div class="col-8">
+                        <div class="panel">
+                            <ul class="list-group">
+                                <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2" style="color: #03C75A;">나의
+                                    웹툰</a></li>
+                                <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
+                                <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                                <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                                <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </aside>
-        <style>
-            .form-select {
-            background-color : #FCFCFC;
-            border : none;
-            width : 100%;
-            height : 50px;
-            }
-            select {
-            color : #828282;
-            }
-            .form-control {
-            background-color : #FCFCFC;
-            border : none;
-            width : 100%;
-            height : 50px;
-            }
-
-
-            .form-control::placeholder {
-            color : #BBBBBB;
-            }
-
-            .date-container {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        background-color: #8E4B6E;
-        color: white;
-        border-radius: 10px;
-        text-align:center;
-        font-family: "Work Sans", sans-serif;
-    }
-
-    .month {
-        font-size: 1.1rem; /* M의 크기를 설정 */
-        font-weight: 550;
-        line-height: 1;
-    }
-
-    .year {
-        font-size: 0.65rem; /* yyyy의 크기를 설정 */
-        font-weight: 400;
-    }
-    :root {
-        --background-color-light: #FFFFFF;
-        --text-color-light: #000000;
-        --toggle-background-light: #CCCCCC;
-        --toggle-ball-light: #FFFFFF;
-
-        --background-color-dark: #333333;
-        --text-color-dark: #FFFFFF;
-        --toggle-background-dark: #03C75A;
-        --toggle-ball-dark: #FFFFFF;
-
-        --font-size-base: 32px; /* 기본 텍스트 크기 */
-        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
-    }
-
-
-
-    .toggle-switch {
-        position: relative;
-        display: inline-block;
-        width: 62px; /* 너비 조정 */
-        height: 38px; /* 높이 조정 */
-    }
-
-    .toggle-switch .checkbox {
-        opacity: 0;
-        width: 0;
-        height: 0;
-    }
-    #isToggledCheckbox {
-         opacity: 0;
-            width: 0;
-            height: 0;
-    }
-
-    .toggle-switch .label {
-        position: absolute;
-        cursor: pointer;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background-color: var(--toggle-background-light);
-        transition: background-color 0.4s;
-        border-radius: 38px; /* 둥근 모서리 반경 조정 */
-    }
-
-    .toggle-switch .label:before {
-        position: absolute;
-        content: "";
-        height: 30px; /* 내부 원 높이 조정 */
-        width: 30px; /* 내부 원 너비 조정 */
-        left: 2px;
-        bottom: 0px;
-        background-color: var(--toggle-ball-light);
-        transition: transform 0.4s;
-        border-radius: 50%;
-    }
-
-    .toggle-switch input:checked + .label {
-        background-color: var(--toggle-background-dark);
-    }
-
-    .toggle-switch input:checked + .label:before {
-        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
-    }
-
-             #absdiv {
-                position: relative;
-                top: 60px; /* Move down by 20px from its current position */
-                z-index : 1000;
-            }
-
-            #searchbutton {
-                background-color: #828282;
-            }
-
-            .card-img-top {
-                    width: 100%;
-                    height: 100px;
-                    object-fit: cover;
+            </aside>
+            <style>
+                .form-select {
+                background-color : #FCFCFC;
+                border : none;
+                width : 100%;
+                height : 50px;
+                }
+                select {
+                color : #828282;
+                }
+                .form-control {
+                background-color : #FCFCFC;
+                border : none;
+                width : 100%;
+                height : 50px;
                 }
 
-        </style>
-        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
-              rel="stylesheet">
-        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
-              rel="stylesheet">
 
-        <div class="col-md-9">
-            <div class="row" style="color: #828282;">
-                <div class="col-11">
-                    <div class="row mb-4">
-                        <div class="col-12 p-0">
-                            <style>
-                                .col-4 select {
-                                    border-radius: 50px;
-                                    text-align: center;
-                                }
-                                /* 검색창 스타일 */
-                                .search-container {
-                                    width: 300px;
-                                }
+                .form-control::placeholder {
+                color : #BBBBBB;
+                }
 
-                                .search-container select {
-                                    position: absolute;
-                                    left: 0%;
-                                    width: 30%;
-                                    height: 50px;
-                                    color: #828282;
-                                    font-size: 1rem;
-                                    border-radius: 50px 0 0 50px;
-                                    outline: none;
-                                }
-                                .search-container input[type="text"] {
-                                    position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
-                                    left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
-                                    width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
-                                    height: 50px;
-                                    padding: 10px 40px 10px 15px;
-                                    font-size: 1rem;
-                                    outline: none;
-                                    border-radius: 0 50px 50px 0;
-                                    transition: border-color 0.3s, background-color 0.3s;
-                                    color: #828282; /* 입력 텍스트 색상 변경 */
-                                }
+                .date-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            background-color: #8E4B6E;
+            color: white;
+            border-radius: 10px;
+            text-align:center;
+            font-family: "Work Sans", sans-serif;
+        }
 
-                                .search-container input[type="text"]::placeholder {
-                                    color: #BBBBBB; /* placeholder 색상 변경 */
-                                }
+        .month {
+            font-size: 1.1rem; /* M의 크기를 설정 */
+            font-weight: 550;
+            line-height: 1;
+        }
+
+        .year {
+            font-size: 0.65rem; /* yyyy의 크기를 설정 */
+            font-weight: 400;
+        }
+        :root {
+            --background-color-light: #FFFFFF;
+            --text-color-light: #000000;
+            --toggle-background-light: #CCCCCC;
+            --toggle-ball-light: #FFFFFF;
+
+            --background-color-dark: #333333;
+            --text-color-dark: #FFFFFF;
+            --toggle-background-dark: #03C75A;
+            --toggle-ball-dark: #FFFFFF;
+
+            --font-size-base: 32px; /* 기본 텍스트 크기 */
+            --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+        }
 
 
-                                .search-container button {
-                                    position: absolute;
-                                    right: 1rem;
-                                    top: 25px;
-                                    background: none;
-                                    transform: translateY(-50%);
-                                    border: none;
-                                    cursor: pointer;
-                                }
 
-                                .search-container button i {
-                                    color: #A6AAB5;
-                                }
+        .toggle-switch {
+            position: relative;
+            display: inline-block;
+            width: 62px; /* 너비 조정 */
+            height: 38px; /* 높이 조정 */
+        }
 
-                                .search-container button:hover i {
-                                    color: #03C75A;
-                                }
-                            </style>
-                            <form id="sort-form" th:action="@{/user/my/wt/comment}" method="get">
-                                <div class="row m-0">
-                                    <div class="col-7 p-0">
-                                        <div class="row justify-content-start m-0">
-                                            <div class="col-12 p-0">
-                                                <div class="search-container">
-                                                    <select class="form-select px-3" name="searchBy">
-                                                        <option value="comment" th:selected="${searchBy == 'comment'}">
-                                                            코멘트내용
-                                                        </option>
-                                                        <option value="title" th:selected="${searchBy == 'title'}">제목
-                                                        </option>
-                                                        <option value="author" th:selected="${searchBy == 'author'}">
-                                                            작가
-                                                        </option>
-                                                        <option value="genre" th:selected="${searchBy == 'genre'}">장르
-                                                        </option>
-                                                        <option value="tag" th:selected="${searchBy == 'tag'}">태그
-                                                        </option>
-                                                    </select>
-                                                    <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
-                                                    <!-- 검색 버튼 -->
-                                                    <button type="submit">
-                                                        <i class="fas fa-search"></i>
-                                                    </button>
+        .toggle-switch .checkbox {
+            opacity: 0;
+            width: 0;
+            height: 0;
+        }
+        #isToggledCheckbox {
+             opacity: 0;
+                width: 0;
+                height: 0;
+        }
+
+        .toggle-switch .label {
+            position: absolute;
+            cursor: pointer;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: var(--toggle-background-light);
+            transition: background-color 0.4s;
+            border-radius: 38px; /* 둥근 모서리 반경 조정 */
+        }
+
+        .toggle-switch .label:before {
+            position: absolute;
+            content: "";
+            height: 30px; /* 내부 원 높이 조정 */
+            width: 30px; /* 내부 원 너비 조정 */
+            left: 2px;
+            bottom: 0px;
+            background-color: var(--toggle-ball-light);
+            transition: transform 0.4s;
+            border-radius: 50%;
+        }
+
+        .toggle-switch input:checked + .label {
+            background-color: var(--toggle-background-dark);
+        }
+
+        .toggle-switch input:checked + .label:before {
+            transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+        }
+
+                 #absdiv {
+                    position: relative;
+                    top: 60px; /* Move down by 20px from its current position */
+                    z-index : 1000;
+                }
+
+                #searchbutton {
+                    background-color: #828282;
+                }
+
+                .card-img-top {
+                        width: 100%;
+                        height: 100px;
+                        object-fit: cover;
+                    }
+
+            </style>
+            <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+                  rel="stylesheet">
+            <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+                  rel="stylesheet">
+
+            <div class="col-md-9">
+                <div class="row" style="color: #828282;">
+                    <div class="col-11">
+                        <div class="row mb-4">
+                            <div class="col-12 p-0">
+                                <style>
+                                    .col-4 select {
+                                        border-radius: 50px;
+                                        text-align: center;
+                                    }
+                                    /* 검색창 스타일 */
+                                    .search-container {
+                                        width: 300px;
+                                    }
+
+                                    .search-container select {
+                                        position: absolute;
+                                        left: 0%;
+                                        width: 30%;
+                                        height: 50px;
+                                        color: #828282;
+                                        font-size: 1rem;
+                                        border-radius: 50px 0 0 50px;
+                                        outline: none;
+                                    }
+                                    .search-container input[type="text"] {
+                                        position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
+                                        left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
+                                        width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
+                                        height: 50px;
+                                        padding: 10px 40px 10px 15px;
+                                        font-size: 1rem;
+                                        outline: none;
+                                        border-radius: 0 50px 50px 0;
+                                        transition: border-color 0.3s, background-color 0.3s;
+                                        color: #828282; /* 입력 텍스트 색상 변경 */
+                                    }
+
+                                    .search-container input[type="text"]::placeholder {
+                                        color: #BBBBBB; /* placeholder 색상 변경 */
+                                    }
+
+
+                                    .search-container button {
+                                        position: absolute;
+                                        right: 1rem;
+                                        top: 25px;
+                                        background: none;
+                                        transform: translateY(-50%);
+                                        border: none;
+                                        cursor: pointer;
+                                    }
+
+                                    .search-container button i {
+                                        color: #A6AAB5;
+                                    }
+
+                                    .search-container button:hover i {
+                                        color: #03C75A;
+                                    }
+                                </style>
+                                <form id="sort-form" th:action="@{/user/my/wt/comment}" method="get">
+                                    <div class="row m-0">
+                                        <div class="col-7 p-0">
+                                            <div class="row justify-content-start m-0">
+                                                <div class="col-12 p-0">
+                                                    <div class="search-container">
+                                                        <select class="form-select px-3" name="searchBy">
+                                                            <option value="comment"
+                                                                    th:selected="${searchBy == 'comment'}">
+                                                                코멘트내용
+                                                            </option>
+                                                            <option value="title" th:selected="${searchBy == 'title'}">
+                                                                제목
+                                                            </option>
+                                                            <option value="author"
+                                                                    th:selected="${searchBy == 'author'}">
+                                                                작가
+                                                            </option>
+                                                            <option value="genre" th:selected="${searchBy == 'genre'}">
+                                                                장르
+                                                            </option>
+                                                            <option value="tag" th:selected="${searchBy == 'tag'}">태그
+                                                            </option>
+                                                        </select>
+                                                        <input class="form-control px-3" type="text" name="searchTerm"
+                                                               placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
+                                                        <!-- 검색 버튼 -->
+                                                        <button type="submit">
+                                                            <i class="fas fa-search"></i>
+                                                        </button>
+                                                    </div>
                                                 </div>
                                             </div>
                                         </div>
-                                    </div>
-                                    <div class="col-1" style=""></div>
-                                    <div class="col-4">
-                                        <div class="row justify-content-end">
-                                            <!-- 정렬 또는 토글2 -->
-                                            <label>
-                                                <select class="form-select px-3" name="orderBy"
-                                                        onchange="this.form.submit()">
-                                                    <option value="recent" th:selected="${orderBy == 'recent'}">최근남긴순
-                                                    </option>
-                                                    <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순
-                                                    </option>
-                                                    <option value="views" th:selected="${orderBy == 'views'}">조회수높은순
-                                                    </option>
-                                                    <option value="likes" th:selected="${orderBy == 'likes'}">댓글좋아요많은순
-                                                    </option>
-                                                </select>
-                                            </label>
-                                        </div>
-                                    </div>
-                                </div> <!--검색, 소팅 (토글X)-->
-                                <div class="row justify-content-around">
-                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                    <div class="col-3" style="padding: 0 1.2rem;">
-                                        <div id="absdiv" class="row justify-content-end">
-                                            <!--                                        <div class="col-3">-->
-                                            <!--                                            <div class="toggle-switch">-->
-                                            <!--                                                &lt;!&ndash; 정렬 또는 토글1 &ndash;&gt;-->
-                                            <!--                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">-->
-                                            <!--                                                <label for="isToggledCheckbox" class="label">-->
-                                            <!--                                                    <div class="ball"></div>-->
-                                            <!--                                                </label>-->
-                                            <!--                                            </div>-->
-                                            <!--                                        </div>-->
-                                            <!--                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">진행중인 행사</div>-->
-                                        </div>
-                                    </div>
-                                </div> <!--토글-->
-                            </form>
-                        </div>
-                    </div>
-                    <div class="row justify-content-around mt-4">
-                        <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
-                            <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
-                                <div class="col-3 clickable-row"
-                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
-                                     th:each="myWtComment, iterStat : ${myWtComments}" th:attr="data-href=@{/webtoon/one(
-                webtoon_id=${(myWtComment.platform == 1 ? 'naver_' : myWtComment.platform == 2 ? 'kakao_' : '') + myWtComment.webtoonId},
-                webtoon_name=${myWtComment.webtoonName},
-                author=${myWtComment.author}
-                )}" th:if="${iterStat.index < 3}">
-                                    <div class="row justify-content-center">
-                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
-                                             style="aspect-ratio: 1; border-radius: 5px;">
-                                            <div class="date-container px-3 py-2">
-                                                <div class="month"
-                                                     th:text="${myWtComment.platform == 1 ? 'N' : (myWtComment.platform == 2 ? 'K' : '')}"></div>
+                                        <div class="col-1" style=""></div>
+                                        <div class="col-4">
+                                            <div class="row justify-content-end">
+                                                <!-- 정렬 또는 토글2 -->
+                                                <label>
+                                                    <select class="form-select px-3" name="orderBy"
+                                                            onchange="this.form.submit()">
+                                                        <option value="recent" th:selected="${orderBy == 'recent'}">
+                                                            최근남긴순
+                                                        </option>
+                                                        <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순
+                                                        </option>
+                                                        <option value="views" th:selected="${orderBy == 'views'}">조회수높은순
+                                                        </option>
+                                                        <option value="likes" th:selected="${orderBy == 'likes'}">
+                                                            댓글좋아요많은순
+                                                        </option>
+                                                    </select>
+                                                </label>
                                             </div>
                                         </div>
-                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                        <!--                                    </div>-->
-                                        <div class="col-5" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
-                                             th:text="${myWtComment.platform == 1 ? '네이버웹툰' : (myWtComment.platform == 2 ? '카카오웹툰' : '')}">
-                                            닉네임
-                                        </div>
-
-                                        <div class="col-3"
-                                             style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
-                                             th:text="${myWtComment.formattedCreatedAt}">시간
-                                        </div>
-                                    </div>
-                                    <div class="row justify-content-center">
-                                        <div class="col-12 my-3" style="">
-                                            <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                            <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                            <!-- 썸네일 이미지 있을때  -->
-                                            <img th:if="${myWtComment.thumbnailUrl != null}"
-                                                 th:src="${myWtComment.thumbnailUrl}" class="card-img-top"
-                                                 alt="썸네일 이미지">
-                                        </div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
-                                             th:text="${myWtComment.webtoonName}">이름
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
-                                             th:text="${myWtComment.content}">내용
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                    </div>
-
-                                </div>
-                                <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
-                                <div class="col-3" th:if="${myWtComments.size() == 0}"></div>
-                                <div class="col-3"
-                                     th:if="${myWtComments.size() == 0 || myWtComments.size() == 1}"></div>
-                                <div class="col-3"
-                                     th:if="${myWtComments.size() == 0 || myWtComments.size() == 1 || myWtComments.size() == 2}"></div>
-                            </div>
-                            <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
-                                <div class="col-3 clickable-row"
-                                     style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
-                                     th:each="myWtComment, iterStat : ${myWtComments}" th:attr="data-href=@{/webtoon/one(
-                webtoon_id=${(myWtComment.platform == 1 ? 'naver_' : myWtComment.platform == 2 ? 'kakao_' : '') + myWtComment.webtoonId},
-                webtoon_name=${myWtComment.webtoonName},
-                author=${myWtComment.author}
-                )}" th:if="${iterStat.index >= 3}">
-                                    <div class="row justify-content-center">
-                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center"
-                                             style="aspect-ratio: 1; border-radius: 5px;">
-                                            <div class="date-container px-3 py-2">
-                                                <div class="month"
-                                                     th:text="${myWtComment.platform == 1 ? 'N' : (myWtComment.platform == 2 ? 'K' : '')}"></div>
+                                    </div> <!--검색, 소팅 (토글X)-->
+                                    <div class="row justify-content-around">
+                                        <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                        <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                        <div class="col-3" style="padding: 0 1.2rem;">
+                                            <div id="absdiv" class="row justify-content-end">
+                                                <!--                                        <div class="col-3">-->
+                                                <!--                                            <div class="toggle-switch">-->
+                                                <!--                                                &lt;!&ndash; 정렬 또는 토글1 &ndash;&gt;-->
+                                                <!--                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">-->
+                                                <!--                                                <label for="isToggledCheckbox" class="label">-->
+                                                <!--                                                    <div class="ball"></div>-->
+                                                <!--                                                </label>-->
+                                                <!--                                            </div>-->
+                                                <!--                                        </div>-->
+                                                <!--                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">진행중인 행사</div>-->
                                             </div>
                                         </div>
-                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                        <!--                                    </div>-->
-                                        <div class="col-5" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
-                                             th:text="${myWtComment.platform == 1 ? '네이버웹툰' : (myWtComment.platform == 2 ? '카카오웹툰' : '')}">
-                                            닉네임
-                                        </div>
-
-                                        <div class="col-3"
-                                             style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
-                                             th:text="${myWtComment.formattedCreatedAt}">시간
-                                        </div>
-                                    </div>
-                                    <div class="row justify-content-center">
-                                        <div class="col-12 my-3" style="">
-                                            <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                            <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                            <!-- 썸네일 이미지 있을때  -->
-                                            <img th:if="${myWtComment.thumbnailUrl != null}"
-                                                 th:src="${myWtComment.thumbnailUrl}" class="card-img-top"
-                                                 alt="썸네일 이미지">
-                                        </div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
-                                             th:text="${myWtComment.webtoonName}">이름
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9"
-                                             style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
-                                             th:text="${myWtComment.content}">내용
-                                        </div>
-                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                    </div>
-
-                                </div>
-
-                                <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
-                                <div class="col-3" th:if="${myWtComments.size() <= 3}"></div>
-                                <div class="col-3"
-                                     th:if="${myWtComments.size() <= 3 || myWtComments.size() == 4}"></div>
-                                <div class="col-3"
-                                     th:if="${myWtComments.size() <= 3 || myWtComments.size() == 4 || myWtComments.size() == 5}"></div>
+                                    </div> <!--토글-->
+                                </form>
                             </div>
                         </div>
-                    </div>
-                    <div class="row justify-content-center">
-                        <!-- 페이징 -->
-                        <th:block th:if="${pages != null}">
-                            <div class="d-flex justify-content-center">
-                                <div class="btn-group">
-                                    <button type="button" class="btn btn-sm previous"
-                                            th:onclick="|location.href='@{/user/my/wt/comment(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
-                                            th:disabled="${currentPage == 1}">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                             fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-                                            <path fill-rule="evenodd"
-                                                  d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                                        </svg>
-                                    </button>
-                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">
-                                        <button type="button" class="btn btn-sm me-2 pages"
-                                                th:text="${p}"
-                                                th:onclick="|location.href='@{/user/my/wt/comment(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
-                                    </th:block>
-                                    <button type="button" class="btn btn-sm  next"
-                                            th:onclick="|location.href='@{/user/my/wt/comment(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
-                                            th:disabled="${currentPage == pages}">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
-                                             fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-                                            <path fill-rule="evenodd"
-                                                  d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
-                                        </svg>
-                                    </button>
+                        <div class="row justify-content-around mt-4">
+                            <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
+                                <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
+                                    <div class="col-3 clickable-row"
+                                         style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                         th:each="myWtComment, iterStat : ${myWtComments}" th:attr="data-href=@{/webtoon/one(
+                    webtoon_id=${(myWtComment.platform == 1 ? 'naver_' : myWtComment.platform == 2 ? 'kakao_' : '') + myWtComment.webtoonId},
+                    webtoon_name=${myWtComment.webtoonName},
+                    author=${myWtComment.author}
+                    )}" th:if="${iterStat.index < 3}">
+                                        <div class="row justify-content-center">
+                                            <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                                 style="aspect-ratio: 1; border-radius: 5px;">
+                                                <div class="date-container px-3 py-2">
+                                                    <div class="month"
+                                                         th:text="${myWtComment.platform == 1 ? 'N' : (myWtComment.platform == 2 ? 'K' : '')}"></div>
+                                                </div>
+                                            </div>
+                                            <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                            <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                            <!--                                    </div>-->
+                                            <div class="col-5"
+                                                 style="color: #333333; font-size: 0.8rem; font-weight: 530;"
+                                                 th:text="${myWtComment.platform == 1 ? '네이버웹툰' : (myWtComment.platform == 2 ? '카카오웹툰' : '')}">
+                                                닉네임
+                                            </div>
+
+                                            <div class="col-3"
+                                                 style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
+                                                 th:text="${myWtComment.formattedCreatedAt}">시간
+                                            </div>
+                                        </div>
+                                        <div class="row justify-content-center">
+                                            <div class="col-12 my-3" style="">
+                                                <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                                <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                                <!-- 썸네일 이미지 있을때  -->
+                                                <img th:if="${myWtComment.thumbnailUrl != null}"
+                                                     th:src="${myWtComment.thumbnailUrl}" class="card-img-top"
+                                                     alt="썸네일 이미지">
+                                            </div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                                 th:text="${myWtComment.webtoonName}">이름
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                                 th:text="${myWtComment.content}">내용
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                        </div>
+
+                                    </div>
+                                    <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
+                                    <div class="col-3" th:if="${myWtComments.size() == 0}"></div>
+                                    <div class="col-3"
+                                         th:if="${myWtComments.size() == 0 || myWtComments.size() == 1}"></div>
+                                    <div class="col-3"
+                                         th:if="${myWtComments.size() == 0 || myWtComments.size() == 1 || myWtComments.size() == 2}"></div>
+                                </div>
+                                <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
+                                    <div class="col-3 clickable-row"
+                                         style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                         th:each="myWtComment, iterStat : ${myWtComments}" th:attr="data-href=@{/webtoon/one(
+                    webtoon_id=${(myWtComment.platform == 1 ? 'naver_' : myWtComment.platform == 2 ? 'kakao_' : '') + myWtComment.webtoonId},
+                    webtoon_name=${myWtComment.webtoonName},
+                    author=${myWtComment.author}
+                    )}" th:if="${iterStat.index >= 3}">
+                                        <div class="row justify-content-center">
+                                            <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                                 style="aspect-ratio: 1; border-radius: 5px;">
+                                                <div class="date-container px-3 py-2">
+                                                    <div class="month"
+                                                         th:text="${myWtComment.platform == 1 ? 'N' : (myWtComment.platform == 2 ? 'K' : '')}"></div>
+                                                </div>
+                                            </div>
+                                            <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                            <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                            <!--                                    </div>-->
+                                            <div class="col-5"
+                                                 style="color: #333333; font-size: 0.8rem; font-weight: 530;"
+                                                 th:text="${myWtComment.platform == 1 ? '네이버웹툰' : (myWtComment.platform == 2 ? '카카오웹툰' : '')}">
+                                                닉네임
+                                            </div>
+
+                                            <div class="col-3"
+                                                 style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD;"
+                                                 th:text="${myWtComment.formattedCreatedAt}">시간
+                                            </div>
+                                        </div>
+                                        <div class="row justify-content-center">
+                                            <div class="col-12 my-3" style="">
+                                                <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                                <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                                <!-- 썸네일 이미지 있을때  -->
+                                                <img th:if="${myWtComment.thumbnailUrl != null}"
+                                                     th:src="${myWtComment.thumbnailUrl}" class="card-img-top"
+                                                     alt="썸네일 이미지">
+                                            </div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                                 th:text="${myWtComment.webtoonName}">이름
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                                 th:text="${myWtComment.content}">내용
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                        </div>
+
+                                    </div>
+
+                                    <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
+                                    <div class="col-3" th:if="${myWtComments.size() <= 3}"></div>
+                                    <div class="col-3"
+                                         th:if="${myWtComments.size() <= 3 || myWtComments.size() == 4}"></div>
+                                    <div class="col-3"
+                                         th:if="${myWtComments.size() <= 3 || myWtComments.size() == 4 || myWtComments.size() == 5}"></div>
                                 </div>
                             </div>
-                        </th:block>
-                    </div>
-                </div><!--테이블 및 페이징 포함-->
+                        </div>
+                        <div class="row justify-content-center">
+                            <!-- 페이징 -->
+                            <th:block th:if="${pages != null}">
+                                <div class="d-flex justify-content-center">
+                                    <div class="btn-group">
+                                        <button type="button" class="btn btn-sm previous"
+                                                th:onclick="|location.href='@{/user/my/wt/comment(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
+                                                th:disabled="${currentPage == 1}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                                 fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+                                                <path fill-rule="evenodd"
+                                                      d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                                            </svg>
+                                        </button>
+                                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">
+                                            <button type="button" class="btn btn-sm me-2 pages"
+                                                    th:text="${p}"
+                                                    th:onclick="|location.href='@{/user/my/wt/comment(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
+                                        </th:block>
+                                        <button type="button" class="btn btn-sm  next"
+                                                th:onclick="|location.href='@{/user/my/wt/comment(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
+                                                th:disabled="${currentPage == pages}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                                 fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+                                                <path fill-rule="evenodd"
+                                                      d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                                            </svg>
+                                        </button>
+                                    </div>
+                                </div>
+                            </th:block>
+                        </div>
+                    </div><!--테이블 및 페이징 포함-->
+                </div> <!--본화면-->
             </div> <!--본화면-->
-        </div> <!--본화면-->
 
-        <!--수정전-->
-        <!--    <div class="col-md-9">-->
-        <!--        <div class="row" style="color: #828282;">-->
-        <!--            <div class="col-11">-->
-        <!--                <div class="row">-->
-        <!--                    <div class="col-12">-->
-        <!--                        <form id="sort-form" th:action="@{/user/my/wt/comment}" method="get">-->
-        <!--                            <div class="row">-->
-        <!--                                <div class="col-6">-->
-        <!--                                    <div class="row">-->
-        <!--                                        <div class="col-4">-->
-        <!--                                            &lt;!&ndash; 검색 조건 &ndash;&gt;-->
-        <!--                                            <label>-->
-        <!--                                                <select class="form-select px-3" name="searchBy">-->
-        <!--                                                    <option value="comment" th:selected="${searchBy == 'comment'}">코멘트내용</option>-->
-        <!--                                                    <option value="title" th:selected="${searchBy == 'title'}">제목</option>-->
-        <!--                                                    <option value="author" th:selected="${searchBy == 'author'}">작가</option>-->
-        <!--                                                    <option value="genre" th:selected="${searchBy == 'genre'}">장르</option>-->
-        <!--                                                    <option value="tag" th:selected="${searchBy == 'tag'}">태그</option>-->
-        <!--                                                </select>-->
-        <!--                                            </label>-->
-        <!--                                        </div>-->
-        <!--                                        <div class="col-6">-->
-        <!--                                            <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
-        <!--                                        </div>-->
-        <!--                                        <div class="col-2">-->
-        <!--                                            &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
-        <!--                                            <button type="submit">검색</button>-->
-        <!--                                        </div>-->
-        <!--                                    </div>-->
-        <!--                                </div>-->
-        <!--                                <div class="col-2" style="background-color: red;"></div>-->
-        <!--                                <div class="col-4">-->
-        <!--                                    <div class="row justify-content-end">-->
-        <!--                                        &lt;!&ndash; 정렬 조건 &ndash;&gt;-->
-        <!--                                        <label>-->
-        <!--                                            <select class="form-select px-3" name="orderBy" onchange="this.form.submit()">-->
-        <!--                                                <option value="recent" th:selected="${orderBy == 'recent'}">최근남긴순</option>-->
-        <!--                                                <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
-        <!--                                                <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>-->
-        <!--                                                <option value="likes" th:selected="${orderBy == 'likes'}">댓글좋아요많은순</option>-->
-        <!--                                            </select>-->
-        <!--                                        </label>-->
-        <!--                                    </div>-->
-        <!--                                </div>-->
-        <!--                            </div> &lt;!&ndash;검색, 소팅 (토글X)&ndash;&gt;-->
-        <!--                        </form>-->
-        <!--                    </div>-->
-        <!--                </div>-->
-        <!--                <div class="row">-->
-        <!--                    <div class="review-list">-->
-        <!--                        <table>-->
-        <!--                            <thead>-->
-        <!--                            <tr>-->
-        <!--                                <th>댓글 번호</th>-->
-        <!--                                <th>웹툰 번호</th>-->
-        <!--                                <th>유저 번호</th>-->
-        <!--                                <th>내용</th>-->
-        <!--                                <th>좋아요</th>-->
-        <!--                                <th>싫어요</th>-->
-        <!--                                <th>생성일시*</th>-->
-        <!--                                <th>수정일시*</th>-->
-        <!--                                <th>웹툰아이디</th>-->
-        <!--                                <th>플렛폼</th>-->
-        <!--                                <th>제목</th>-->
-        <!--                                <th>작가</th>-->
-        <!--                                <th>이미지URL</th>-->
-        <!--                                <th>장르</th>-->
-        <!--                                <th>태그</th>-->
-        <!--                                <th>조회수</th>-->
-        <!--                            </tr>-->
-        <!--                            </thead>-->
-        <!--                            <tbody>-->
-        <!--                            <tr th:each="myWtComment : ${myWtComments}" class="clickable-row"-->
-        <!--                                th:attr="data-href=@{/webtoon/one(-->
-        <!--                webtoon_id=${(myWtComment.platform == 1 ? 'naver_' : myWtComment.platform == 2 ? 'kakao_' : '') + myWtComment.webtoonId},-->
-        <!--                webtoon_name=${myWtComment.webtoonName},-->
-        <!--                author=${myWtComment.author}-->
-        <!--                )}">-->
-        <!--                                <td th:text="${myWtComment.commentNo}">댓글 번호</td>-->
-        <!--                                <td th:text="${myWtComment.webtoonNo}">웹툰 번호</td>-->
-        <!--                                <td th:text="${myWtComment.userNo}">유저 번호</td>-->
-        <!--                                <td th:text="${myWtComment.content}">내용</td>-->
-        <!--                                <td th:text="${myWtComment.liked}">좋아요</td>-->
-        <!--                                <td th:text="${myWtComment.dislike}">싫어요</td>-->
-        <!--                                <td th:text="${myWtComment.createdAt}">생성일시*</td>-->
-        <!--                                <td th:text="${myWtComment.updatedAt}">수정일시*</td>-->
-        <!--                                <td th:text="${myWtComment.webtoonId}">웹툰아이디</td>-->
-        <!--                                <td th:text="${myWtComment.platform}">플렛폼</td>-->
-        <!--                                <td th:text="${myWtComment.webtoonName}">제목</td>-->
-        <!--                                <td th:text="${myWtComment.author}">작가</td>-->
-        <!--                                <td th:text="${myWtComment.thumbnailUrl}">이미지URL</td>-->
-        <!--                                <td th:text="${myWtComment.genre}">장르</td>-->
-        <!--                                <td th:text="${myWtComment.tags}">태그</td>-->
-        <!--                                <td th:text="${myWtComment.count}">조회수</td>-->
-        <!--                            </tr>-->
-        <!--                            </tbody>-->
-        <!--                        </table>-->
-        <!--                        &lt;!&ndash; 페이징 &ndash;&gt;-->
-        <!--                        <th:block th:if="${pages != null}">-->
-        <!--                            <div class="d-flex justify-content-center">-->
-        <!--                                <div class="btn-group">-->
-        <!--                                    <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/wt/comment(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
-        <!--                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
-        <!--                                            <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
-        <!--                                        </svg>-->
-        <!--                                    </button>-->
-        <!--                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
-        <!--                                        <button type="button" class="btn btn-sm me-2 pages"-->
-        <!--                                                th:text="${p}" th:onclick="|location.href='@{/user/my/wt/comment(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
-        <!--                                    </th:block>-->
-        <!--                                    <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/wt/comment(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
-        <!--                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
-        <!--                                            <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
-        <!--                                        </svg>-->
-        <!--                                    </button>-->
-        <!--                                </div>-->
-        <!--                            </div>-->
-        <!--                        </th:block>-->
-        <!--                    </div>-->
-        <!--                </div> &lt;!&ndash;테이블과 페이징&ndash;&gt;-->
-        <!--            </div>&lt;!&ndash;테이블 및 페이징 포함&ndash;&gt;-->
-        <!--        </div>-->
+            <!--수정전-->
+            <!--    <div class="col-md-9">-->
+            <!--        <div class="row" style="color: #828282;">-->
+            <!--            <div class="col-11">-->
+            <!--                <div class="row">-->
+            <!--                    <div class="col-12">-->
+            <!--                        <form id="sort-form" th:action="@{/user/my/wt/comment}" method="get">-->
+            <!--                            <div class="row">-->
+            <!--                                <div class="col-6">-->
+            <!--                                    <div class="row">-->
+            <!--                                        <div class="col-4">-->
+            <!--                                            &lt;!&ndash; 검색 조건 &ndash;&gt;-->
+            <!--                                            <label>-->
+            <!--                                                <select class="form-select px-3" name="searchBy">-->
+            <!--                                                    <option value="comment" th:selected="${searchBy == 'comment'}">코멘트내용</option>-->
+            <!--                                                    <option value="title" th:selected="${searchBy == 'title'}">제목</option>-->
+            <!--                                                    <option value="author" th:selected="${searchBy == 'author'}">작가</option>-->
+            <!--                                                    <option value="genre" th:selected="${searchBy == 'genre'}">장르</option>-->
+            <!--                                                    <option value="tag" th:selected="${searchBy == 'tag'}">태그</option>-->
+            <!--                                                </select>-->
+            <!--                                            </label>-->
+            <!--                                        </div>-->
+            <!--                                        <div class="col-6">-->
+            <!--                                            <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
+            <!--                                        </div>-->
+            <!--                                        <div class="col-2">-->
+            <!--                                            &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
+            <!--                                            <button type="submit">검색</button>-->
+            <!--                                        </div>-->
+            <!--                                    </div>-->
+            <!--                                </div>-->
+            <!--                                <div class="col-2" style="background-color: red;"></div>-->
+            <!--                                <div class="col-4">-->
+            <!--                                    <div class="row justify-content-end">-->
+            <!--                                        &lt;!&ndash; 정렬 조건 &ndash;&gt;-->
+            <!--                                        <label>-->
+            <!--                                            <select class="form-select px-3" name="orderBy" onchange="this.form.submit()">-->
+            <!--                                                <option value="recent" th:selected="${orderBy == 'recent'}">최근남긴순</option>-->
+            <!--                                                <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
+            <!--                                                <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>-->
+            <!--                                                <option value="likes" th:selected="${orderBy == 'likes'}">댓글좋아요많은순</option>-->
+            <!--                                            </select>-->
+            <!--                                        </label>-->
+            <!--                                    </div>-->
+            <!--                                </div>-->
+            <!--                            </div> &lt;!&ndash;검색, 소팅 (토글X)&ndash;&gt;-->
+            <!--                        </form>-->
+            <!--                    </div>-->
+            <!--                </div>-->
+            <!--                <div class="row">-->
+            <!--                    <div class="review-list">-->
+            <!--                        <table>-->
+            <!--                            <thead>-->
+            <!--                            <tr>-->
+            <!--                                <th>댓글 번호</th>-->
+            <!--                                <th>웹툰 번호</th>-->
+            <!--                                <th>유저 번호</th>-->
+            <!--                                <th>내용</th>-->
+            <!--                                <th>좋아요</th>-->
+            <!--                                <th>싫어요</th>-->
+            <!--                                <th>생성일시*</th>-->
+            <!--                                <th>수정일시*</th>-->
+            <!--                                <th>웹툰아이디</th>-->
+            <!--                                <th>플렛폼</th>-->
+            <!--                                <th>제목</th>-->
+            <!--                                <th>작가</th>-->
+            <!--                                <th>이미지URL</th>-->
+            <!--                                <th>장르</th>-->
+            <!--                                <th>태그</th>-->
+            <!--                                <th>조회수</th>-->
+            <!--                            </tr>-->
+            <!--                            </thead>-->
+            <!--                            <tbody>-->
+            <!--                            <tr th:each="myWtComment : ${myWtComments}" class="clickable-row"-->
+            <!--                                th:attr="data-href=@{/webtoon/one(-->
+            <!--                webtoon_id=${(myWtComment.platform == 1 ? 'naver_' : myWtComment.platform == 2 ? 'kakao_' : '') + myWtComment.webtoonId},-->
+            <!--                webtoon_name=${myWtComment.webtoonName},-->
+            <!--                author=${myWtComment.author}-->
+            <!--                )}">-->
+            <!--                                <td th:text="${myWtComment.commentNo}">댓글 번호</td>-->
+            <!--                                <td th:text="${myWtComment.webtoonNo}">웹툰 번호</td>-->
+            <!--                                <td th:text="${myWtComment.userNo}">유저 번호</td>-->
+            <!--                                <td th:text="${myWtComment.content}">내용</td>-->
+            <!--                                <td th:text="${myWtComment.liked}">좋아요</td>-->
+            <!--                                <td th:text="${myWtComment.dislike}">싫어요</td>-->
+            <!--                                <td th:text="${myWtComment.createdAt}">생성일시*</td>-->
+            <!--                                <td th:text="${myWtComment.updatedAt}">수정일시*</td>-->
+            <!--                                <td th:text="${myWtComment.webtoonId}">웹툰아이디</td>-->
+            <!--                                <td th:text="${myWtComment.platform}">플렛폼</td>-->
+            <!--                                <td th:text="${myWtComment.webtoonName}">제목</td>-->
+            <!--                                <td th:text="${myWtComment.author}">작가</td>-->
+            <!--                                <td th:text="${myWtComment.thumbnailUrl}">이미지URL</td>-->
+            <!--                                <td th:text="${myWtComment.genre}">장르</td>-->
+            <!--                                <td th:text="${myWtComment.tags}">태그</td>-->
+            <!--                                <td th:text="${myWtComment.count}">조회수</td>-->
+            <!--                            </tr>-->
+            <!--                            </tbody>-->
+            <!--                        </table>-->
+            <!--                        &lt;!&ndash; 페이징 &ndash;&gt;-->
+            <!--                        <th:block th:if="${pages != null}">-->
+            <!--                            <div class="d-flex justify-content-center">-->
+            <!--                                <div class="btn-group">-->
+            <!--                                    <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/wt/comment(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
+            <!--                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
+            <!--                                            <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
+            <!--                                        </svg>-->
+            <!--                                    </button>-->
+            <!--                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
+            <!--                                        <button type="button" class="btn btn-sm me-2 pages"-->
+            <!--                                                th:text="${p}" th:onclick="|location.href='@{/user/my/wt/comment(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
+            <!--                                    </th:block>-->
+            <!--                                    <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/wt/comment(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
+            <!--                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
+            <!--                                            <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
+            <!--                                        </svg>-->
+            <!--                                    </button>-->
+            <!--                                </div>-->
+            <!--                            </div>-->
+            <!--                        </th:block>-->
+            <!--                    </div>-->
+            <!--                </div> &lt;!&ndash;테이블과 페이징&ndash;&gt;-->
+            <!--            </div>&lt;!&ndash;테이블 및 페이징 포함&ndash;&gt;-->
+            <!--        </div>-->
 
-        <!--    </div> &lt;!&ndash;본화면&ndash;&gt;-->
-    </div> <!--aside와 본화면--></div>
+            <!--    </div> &lt;!&ndash;본화면&ndash;&gt;-->
+        </div> <!--aside와 본화면--></div>
+</div>
 <div th:replace="common/footer.html"></div>
 </body>
 </html>

--- a/src/main/resources/templates/user/mypage_wt_webtoon.html
+++ b/src/main/resources/templates/user/mypage_wt_webtoon.html
@@ -107,481 +107,486 @@
   }
 </style>
 <div class="jumbotron">
-    <div class="row">
-        <div class="col-md-3 px-4">
-            <h3>나의 웹툰</h3>
-        </div>
-        <div class="col-md-9">
-            <nav class="navbar navbar-expand-md">
-                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                    <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2" style="color: #000;">북마크한 웹툰</a></li>
-                    <li><a th:href="@{/user/my/wt/comment}" class="nav-link px-2">내가 남긴 코멘트</a></li>
-                </ul>
-            </nav>
+    <div class="container">
+        <div class="row">
+            <div class="col-md-3 px-4">
+                <h3>나의 웹툰</h3>
+            </div>
+            <div class="col-md-9">
+                <nav class="navbar navbar-expand-md">
+                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                        <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2" style="color: #000;">북마크한 웹툰</a></li>
+                        <li><a th:href="@{/user/my/wt/comment}" class="nav-link px-2">내가 남긴 코멘트</a></li>
+                    </ul>
+                </nav>
+            </div>
         </div>
     </div>
 </div>
-<div class="row">
-    <aside class="col-md-3 px-4">
-        <div class="row">
-            <div class="col-3"></div>
-            <div class="col-6">
-                <div class="panel">
-                    <ul class="list-group">
-                        <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2" style="color: #03C75A;">나의 웹툰</a></li>
-                        <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-                        <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
-                        <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-                        <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                        <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-                    </ul>
+<div class="container" style="padding:0;">
+    <div class="row">
+        <aside class="col-md-3 px-4">
+            <div class="row">
+                <div class="col-3"></div>
+                <div class="col-6">
+                    <div class="panel">
+                        <ul class="list-group">
+                            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2" style="color: #03C75A;">나의 웹툰</a></li>
+                            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
+                            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+                        </ul>
+                    </div>
                 </div>
             </div>
-        </div>
-    </aside>
-    <style>
-        .form-select {
-        background-color : #FCFCFC;
-        border : none;
-        width : 100%;
-        height : 50px;
-        }
-        select {
-        color : #828282;
-        }
-        .form-control {
-        background-color : #FCFCFC;
-        border : none;
-        width : 100%;
-        height : 50px;
-        }
-
-
-        .form-control::placeholder {
-        color : #BBBBBB;
-        }
-
-        .date-container {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    justify-content: center;
-    background-color: #8E4B6E;
-    color: white;
-    border-radius: 10px;
-    text-align:center;
-    font-family: "Work Sans", sans-serif;
-}
-
-.platform-1 {
-    background-color: #03C75A;
-}
-
-.platform-2 {
-    background-color: #F5BF41;
-}
-
-.month {
-    font-size: 1.1rem; /* M의 크기를 설정 */
-    font-weight: 550;
-    line-height: 1;
-}
-
-.year {
-    font-size: 0.65rem; /* yyyy의 크기를 설정 */
-    font-weight: 400;
-}
-:root {
-    --background-color-light: #FFFFFF;
-    --text-color-light: #000000;
-    --toggle-background-light: #CCCCCC;
-    --toggle-ball-light: #FFFFFF;
-
-    --background-color-dark: #333333;
-    --text-color-dark: #FFFFFF;
-    --toggle-background-dark: #03C75A;
-    --toggle-ball-dark: #FFFFFF;
-
-    --font-size-base: 32px; /* 기본 텍스트 크기 */
-    --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
-}
-
-
-
-.toggle-switch {
-    position: relative;
-    display: inline-block;
-    width: 62px; /* 너비 조정 */
-    height: 38px; /* 높이 조정 */
-}
-
-.toggle-switch .checkbox {
-    opacity: 0;
-    width: 0;
-    height: 0;
-}
-#isToggledCheckbox {
-     opacity: 0;
-        width: 0;
-        height: 0;
-}
-
-.toggle-switch .label {
-    position: absolute;
-    cursor: pointer;
-    top: 0;
-    left: 0;
-    right: 0;
-    bottom: 0;
-    background-color: var(--toggle-background-light);
-    transition: background-color 0.4s;
-    border-radius: 38px; /* 둥근 모서리 반경 조정 */
-}
-
-.toggle-switch .label:before {
-    position: absolute;
-    content: "";
-    height: 30px; /* 내부 원 높이 조정 */
-    width: 30px; /* 내부 원 너비 조정 */
-    left: 2px;
-    bottom: 0px;
-    background-color: var(--toggle-ball-light);
-    transition: transform 0.4s;
-    border-radius: 50%;
-}
-
-.toggle-switch input:checked + .label {
-    background-color: var(--toggle-background-dark);
-}
-
-.toggle-switch input:checked + .label:before {
-    transform: translateX(28px); /* 내부 원 이동 거리 조정 */
-}
-
-         #absdiv {
-            position: relative;
-            top: 60px; /* Move down by 20px from its current position */
-            z-index : 1000;
-        }
-
-        #searchbutton {
-            background-color: #828282;
-        }
-
-        .card-img-top {
-                width: 100%;
-                height: 100px;
-                object-fit: cover;
+        </aside>
+        <style>
+            .form-select {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
+            }
+            select {
+            color : #828282;
+            }
+            .form-control {
+            background-color : #FCFCFC;
+            border : none;
+            width : 100%;
+            height : 50px;
             }
 
-    </style>
-    <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
-    <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+
+            .form-control::placeholder {
+            color : #BBBBBB;
+            }
+
+            .date-container {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        justify-content: center;
+        background-color: #8E4B6E;
+        color: white;
+        border-radius: 10px;
+        text-align:center;
+        font-family: "Work Sans", sans-serif;
+    }
+
+    .platform-1 {
+        background-color: #03C75A;
+    }
+
+    .platform-2 {
+        background-color: #F5BF41;
+    }
+
+    .month {
+        font-size: 1.1rem; /* M의 크기를 설정 */
+        font-weight: 550;
+        line-height: 1;
+    }
+
+    .year {
+        font-size: 0.65rem; /* yyyy의 크기를 설정 */
+        font-weight: 400;
+    }
+    :root {
+        --background-color-light: #FFFFFF;
+        --text-color-light: #000000;
+        --toggle-background-light: #CCCCCC;
+        --toggle-ball-light: #FFFFFF;
+
+        --background-color-dark: #333333;
+        --text-color-dark: #FFFFFF;
+        --toggle-background-dark: #03C75A;
+        --toggle-ball-dark: #FFFFFF;
+
+        --font-size-base: 32px; /* 기본 텍스트 크기 */
+        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+    }
 
 
-    <div class="col-md-9">
-        <div class="row" style="color: #828282;">
-            <div class="col-11">
-                <div class="row mb-4">
-                    <div class="col-12">
-                        <form id="sort-form" th:action="@{/user/my/wt/webtoon}" method="get">
-                            <div class="row">
-                                <div class="col-7">
-                                    <div class="row justify-content-start m-0">
-                                        <div class="col-4">
-                                            <!-- 검색 조건 -->
+
+    .toggle-switch {
+        position: relative;
+        display: inline-block;
+        width: 62px; /* 너비 조정 */
+        height: 38px; /* 높이 조정 */
+    }
+
+    .toggle-switch .checkbox {
+        opacity: 0;
+        width: 0;
+        height: 0;
+    }
+    #isToggledCheckbox {
+         opacity: 0;
+            width: 0;
+            height: 0;
+    }
+
+    .toggle-switch .label {
+        position: absolute;
+        cursor: pointer;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: var(--toggle-background-light);
+        transition: background-color 0.4s;
+        border-radius: 38px; /* 둥근 모서리 반경 조정 */
+    }
+
+    .toggle-switch .label:before {
+        position: absolute;
+        content: "";
+        height: 30px; /* 내부 원 높이 조정 */
+        width: 30px; /* 내부 원 너비 조정 */
+        left: 2px;
+        bottom: 0px;
+        background-color: var(--toggle-ball-light);
+        transition: transform 0.4s;
+        border-radius: 50%;
+    }
+
+    .toggle-switch input:checked + .label {
+        background-color: var(--toggle-background-dark);
+    }
+
+    .toggle-switch input:checked + .label:before {
+        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+    }
+
+             #absdiv {
+                position: relative;
+                top: 60px; /* Move down by 20px from its current position */
+                z-index : 1000;
+            }
+
+            #searchbutton {
+                background-color: #828282;
+            }
+
+            .card-img-top {
+                    width: 100%;
+                    height: 100px;
+                    object-fit: cover;
+                }
+
+        </style>
+        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+
+
+        <div class="col-md-9">
+            <div class="row" style="color: #828282;">
+                <div class="col-11">
+                    <div class="row mb-4">
+                        <div class="col-12">
+                            <form id="sort-form" th:action="@{/user/my/wt/webtoon}" method="get">
+                                <div class="row">
+                                    <div class="col-7">
+                                        <div class="row justify-content-start m-0">
+                                            <div class="col-4">
+                                                <!-- 검색 조건 -->
+                                                <label>
+                                                    <select class="form-select px-3" name="searchBy">
+                                                        <option value="title" th:selected="${searchBy == 'title'}">제목</option>
+                                                        <option value="author" th:selected="${searchBy == 'author'}">작가</option>
+                                                        <option value="genre" th:selected="${searchBy == 'genre'}">장르</option>
+                                                        <option value="tag" th:selected="${searchBy == 'tag'}">태그</option>
+                                                    </select>
+                                                </label>
+                                            </div>
+                                            <div class="col-6">
+                                                <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
+                                            </div>
+                                            <div class="col-2">
+                                                <!-- 검색 버튼 -->
+                                                <button id="searchbutton" type="submit" class="btn btn-primary">검색</button>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-1" style=""></div>
+                                    <div class="col-4">
+                                        <div class="row justify-content-end">
+                                            <!-- 정렬 또는 토글2 -->
                                             <label>
-                                                <select class="form-select px-3" name="searchBy">
-                                                    <option value="title" th:selected="${searchBy == 'title'}">제목</option>
-                                                    <option value="author" th:selected="${searchBy == 'author'}">작가</option>
-                                                    <option value="genre" th:selected="${searchBy == 'genre'}">장르</option>
-                                                    <option value="tag" th:selected="${searchBy == 'tag'}">태그</option>
+                                                <select class="form-select px-3" name="orderBy" onchange="this.form.submit()">
+                                                    <option value="recent" th:selected="${orderBy == 'recent'}">최근저장순</option>
+                                                    <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>
+                                                    <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>
+                                                    <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>
                                                 </select>
                                             </label>
                                         </div>
-                                        <div class="col-6">
-                                            <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
+                                    </div>
+                                </div> <!--검색, 소팅 (토글X)-->
+                                <div class="row justify-content-around">
+                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                    <div class="col-3" style="padding: 0 1.2rem;">
+                                        <div id="absdiv" class="row justify-content-end">
+                                            <!--                                        <div class="col-3">-->
+                                            <!--                                            <div class="toggle-switch">-->
+                                            <!--                                                &lt;!&ndash; 정렬 또는 토글1 &ndash;&gt;-->
+                                            <!--                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">-->
+                                            <!--                                                <label for="isToggledCheckbox" class="label">-->
+                                            <!--                                                    <div class="ball"></div>-->
+                                            <!--                                                </label>-->
+                                            <!--                                            </div>-->
+                                            <!--                                        </div>-->
+                                            <!--                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">진행중인 행사</div>-->
                                         </div>
-                                        <div class="col-2">
-                                            <!-- 검색 버튼 -->
-                                            <button id="searchbutton" type="submit" class="btn btn-primary">검색</button>
-                                        </div>
                                     </div>
-                                </div>
-                                <div class="col-1" style=""></div>
-                                <div class="col-4">
-                                    <div class="row justify-content-end">
-                                        <!-- 정렬 또는 토글2 -->
-                                        <label>
-                                            <select class="form-select px-3" name="orderBy" onchange="this.form.submit()">
-                                                <option value="recent" th:selected="${orderBy == 'recent'}">최근저장순</option>
-                                                <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>
-                                                <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>
-                                                <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>
-                                            </select>
-                                        </label>
-                                    </div>
-                                </div>
-                            </div> <!--검색, 소팅 (토글X)-->
-                            <div class="row justify-content-around">
-                                <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                <div class="col-3" style="padding: 0 1.2rem;">
-                                    <div id="absdiv" class="row justify-content-end">
-                                        <!--                                        <div class="col-3">-->
-                                        <!--                                            <div class="toggle-switch">-->
-                                        <!--                                                &lt;!&ndash; 정렬 또는 토글1 &ndash;&gt;-->
-                                        <!--                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">-->
-                                        <!--                                                <label for="isToggledCheckbox" class="label">-->
-                                        <!--                                                    <div class="ball"></div>-->
-                                        <!--                                                </label>-->
-                                        <!--                                            </div>-->
-                                        <!--                                        </div>-->
-                                        <!--                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">진행중인 행사</div>-->
-                                    </div>
-                                </div>
-                            </div> <!--토글-->
-                        </form>
+                                </div> <!--토글-->
+                            </form>
+                        </div>
                     </div>
-                </div>
-                <div class="row justify-content-around mt-4">
-                    <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
-                        <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
-                            <div class="col-3 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:each="myWtWebtoon, iterStat : ${myWtWebtoons}" th:attr="data-href=@{/webtoon/one(
+                    <div class="row justify-content-around mt-4">
+                        <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
+                            <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
+                                <div class="col-3 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:each="myWtWebtoon, iterStat : ${myWtWebtoons}" th:attr="data-href=@{/webtoon/one(
                 webtoon_id=${(myWtWebtoon.platform == 1 ? 'naver_' : myWtWebtoon.platform == 2 ? 'kakao_' : '') + myWtWebtoon.webtoonId},
                 webtoon_name=${myWtWebtoon.webtoonName},
                 author=${myWtWebtoon.author}
                 )}" th:if="${iterStat.index < 3}">
-                                <div class="row justify-content-center">
-                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                        <div class="date-container px-3 py-2">
-                                            <div class="month"
+                                    <div class="row justify-content-center">
+                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
+                                            <div class="date-container px-3 py-2">
+                                                <div class="month"
                                                      th:text="${myWtWebtoon.platform == 1 ? 'N' : (myWtWebtoon.platform == 2 ? 'K' : '')}"></div>
+                                            </div>
+                                        </div>
+                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                        <!--                                    </div>-->
+                                        <div class="col-5" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
+                                             th:text="${myWtWebtoon.platform == 1 ? '네이버웹툰' : (myWtWebtoon.platform == 2 ? '카카오웹툰' : '')}">닉네임
+                                        </div>
+
+                                        <div class="col-3" style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD; font-family: 'Work Sans', sans-serif;" th:text="${myWtWebtoon.genre}">시간</div>
+                                    </div>
+                                    <div class="row justify-content-center">
+                                        <div class="col-12 my-3" style="">
+                                            <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                            <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                            <!-- 썸네일 이미지 있을때  -->
+                                            <img th:if="${myWtWebtoon.thumbnailUrl != null}" th:src="${myWtWebtoon.thumbnailUrl}" class="card-img-top" alt="썸네일 이미지">
                                         </div>
                                     </div>
-                                    <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                    <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                    <!--                                    </div>-->
-                                    <div class="col-5" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
-                                         th:text="${myWtWebtoon.platform == 1 ? '네이버웹툰' : (myWtWebtoon.platform == 2 ? '카카오웹툰' : '')}">닉네임
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" th:text="${myWtWebtoon.webtoonName}">이름</div>
+                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${myWtWebtoon.author}">내용</div>
+                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
                                     </div>
 
-                                    <div class="col-3" style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD; font-family: 'Work Sans', sans-serif;" th:text="${myWtWebtoon.genre}">시간</div>
                                 </div>
-                                <div class="row justify-content-center">
-                                    <div class="col-12 my-3" style="">
-                                        <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                        <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                        <!-- 썸네일 이미지 있을때  -->
-                                        <img th:if="${myWtWebtoon.thumbnailUrl != null}" th:src="${myWtWebtoon.thumbnailUrl}" class="card-img-top" alt="썸네일 이미지">
-                                    </div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" th:text="${myWtWebtoon.webtoonName}">이름</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${myWtWebtoon.author}">내용</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                </div>
-
+                                <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
+                                <div class="col-3" th:if="${myWtWebtoons.size() == 0}"></div>
+                                <div class="col-3" th:if="${myWtWebtoons.size() == 0 || myWtWebtoons.size() == 1}"></div>
+                                <div class="col-3" th:if="${myWtWebtoons.size() == 0 || myWtWebtoons.size() == 1 || myWtWebtoons.size() == 2}"></div>
                             </div>
-                            <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
-                            <div class="col-3" th:if="${myWtWebtoons.size() == 0}"></div>
-                            <div class="col-3" th:if="${myWtWebtoons.size() == 0 || myWtWebtoons.size() == 1}"></div>
-                            <div class="col-3" th:if="${myWtWebtoons.size() == 0 || myWtWebtoons.size() == 1 || myWtWebtoons.size() == 2}"></div>
-                        </div>
-                        <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
-                            <div class="col-3 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:each="myWtWebtoon, iterStat : ${myWtWebtoons}" th:attr="data-href=@{/webtoon/one(
+                            <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
+                                <div class="col-3 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:each="myWtWebtoon, iterStat : ${myWtWebtoons}" th:attr="data-href=@{/webtoon/one(
                 webtoon_id=${(myWtWebtoon.platform == 1 ? 'naver_' : myWtWebtoon.platform == 2 ? 'kakao_' : '') + myWtWebtoon.webtoonId},
                 webtoon_name=${myWtWebtoon.webtoonName},
                 author=${myWtWebtoon.author}
                 )}" th:if="${iterStat.index >= 3}">
-                                <div class="row justify-content-center">
-                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                        <div class="date-container px-3 py-2">
-                                            <div class="month"
-                                                 th:text="${myWtWebtoon.platform == 1 ? 'N' : (myWtWebtoon.platform == 2 ? 'K' : '')}"></div>
+                                    <div class="row justify-content-center">
+                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
+                                            <div class="date-container px-3 py-2">
+                                                <div class="month"
+                                                     th:text="${myWtWebtoon.platform == 1 ? 'N' : (myWtWebtoon.platform == 2 ? 'K' : '')}"></div>
+                                            </div>
+                                        </div>
+                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                        <!--                                    </div>-->
+                                        <div class="col-5" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
+                                             th:text="${myWtWebtoon.platform == 1 ? '네이버웹툰' : (myWtWebtoon.platform == 2 ? '카카오웹툰' : '')}">닉네임
+                                        </div>
+
+                                        <div class="col-3" style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD; font-family: 'Work Sans', sans-serif;" th:text="${myWtWebtoon.genre}">시간</div>
+                                    </div>
+                                    <div class="row justify-content-center">
+                                        <div class="col-12 my-3" style="">
+                                            <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                            <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                            <!-- 썸네일 이미지 있을때  -->
+                                            <img th:if="${myWtWebtoon.thumbnailUrl != null}" th:src="${myWtWebtoon.thumbnailUrl}" class="card-img-top" alt="썸네일 이미지">
                                         </div>
                                     </div>
-                                    <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                    <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                    <!--                                    </div>-->
-                                    <div class="col-5" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
-                                         th:text="${myWtWebtoon.platform == 1 ? '네이버웹툰' : (myWtWebtoon.platform == 2 ? '카카오웹툰' : '')}">닉네임
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" th:text="${myWtWebtoon.webtoonName}">이름</div>
+                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                    </div>
+                                    <div class="row" style="padding: 0; margin: 0;">
+                                        <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${myWtWebtoon.author}">내용</div>
+                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
                                     </div>
 
-                                    <div class="col-3" style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD; font-family: 'Work Sans', sans-serif;" th:text="${myWtWebtoon.genre}">시간</div>
-                                </div>
-                                <div class="row justify-content-center">
-                                    <div class="col-12 my-3" style="">
-                                        <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                        <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                        <!-- 썸네일 이미지 있을때  -->
-                                        <img th:if="${myWtWebtoon.thumbnailUrl != null}" th:src="${myWtWebtoon.thumbnailUrl}" class="card-img-top" alt="썸네일 이미지">
-                                    </div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" th:text="${myWtWebtoon.webtoonName}">이름</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                </div>
-                                <div class="row" style="padding: 0; margin: 0;">
-                                    <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${myWtWebtoon.author}">내용</div>
-                                    <div class="col-3" style="padding: 0; text-align: right;">→</div>
                                 </div>
 
+                                <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
+                                <div class="col-3" th:if="${myWtWebtoons.size() <= 3}"></div>
+                                <div class="col-3" th:if="${myWtWebtoons.size() <= 3 || myWtWebtoons.size() == 4}"></div>
+                                <div class="col-3" th:if="${myWtWebtoons.size() <= 3 || myWtWebtoons.size() == 4 || myWtWebtoons.size() == 5}"></div>
                             </div>
-
-                            <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
-                            <div class="col-3" th:if="${myWtWebtoons.size() <= 3}"></div>
-                            <div class="col-3" th:if="${myWtWebtoons.size() <= 3 || myWtWebtoons.size() == 4}"></div>
-                            <div class="col-3" th:if="${myWtWebtoons.size() <= 3 || myWtWebtoons.size() == 4 || myWtWebtoons.size() == 5}"></div>
                         </div>
                     </div>
-                </div>
-                <div class="row justify-content-center">
-                    <!-- 페이징 -->
-                    <th:block th:if="${pages != null}">
-                        <div class="d-flex justify-content-center">
-                            <div class="btn-group">
-                                <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/wt/webtoon(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-                                        <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                                    </svg>
-                                </button>
-                                <th:block th:each="p : ${#numbers.sequence(1, pages)}">
-                                    <button type="button" class="btn btn-sm me-2 pages"
-                                            th:text="${p}" th:onclick="|location.href='@{/user/my/wt/webtoon(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
-                                </th:block>
-                                <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/wt/webtoon(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">
-                                    <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-                                        <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
-                                    </svg>
-                                </button>
+                    <div class="row justify-content-center">
+                        <!-- 페이징 -->
+                        <th:block th:if="${pages != null}">
+                            <div class="d-flex justify-content-center">
+                                <div class="btn-group">
+                                    <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/wt/webtoon(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+                                            <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                                        </svg>
+                                    </button>
+                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">
+                                        <button type="button" class="btn btn-sm me-2 pages"
+                                                th:text="${p}" th:onclick="|location.href='@{/user/my/wt/webtoon(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
+                                    </th:block>
+                                    <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/wt/webtoon(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">
+                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+                                            <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                                        </svg>
+                                    </button>
+                                </div>
                             </div>
-                        </div>
-                    </th:block>
-                </div>
-            </div><!--테이블 및 페이징 포함-->
+                        </th:block>
+                    </div>
+                </div><!--테이블 및 페이징 포함-->
+            </div> <!--본화면-->
         </div> <!--본화면-->
-    </div> <!--본화면-->
 
 
-    <!--수정전-->
-<!--    <div class="col-md-9">-->
-<!--        <div class="row" style="color: #828282;">-->
-<!--            <div class="col-11">-->
-<!--                <div class="row">-->
-<!--                    <div class="col-12">-->
-<!--                        <form id="sort-form" th:action="@{/user/my/wt/webtoon}" method="get">-->
-<!--                            <div class="row">-->
-<!--                                <div class="col-6">-->
-<!--                                    <div class="row">-->
-<!--                                        <div class="col-4">-->
-<!--                                            &lt;!&ndash; 검색 조건 &ndash;&gt;-->
-<!--                                            <label>-->
-<!--                                                <select class="form-select px-3" name="searchBy">-->
-<!--                                                    <option value="title" th:selected="${searchBy == 'title'}">제목</option>-->
-<!--                                                    <option value="author" th:selected="${searchBy == 'author'}">작가</option>-->
-<!--                                                    <option value="genre" th:selected="${searchBy == 'genre'}">장르</option>-->
-<!--                                                    <option value="tag" th:selected="${searchBy == 'tag'}">태그</option>-->
-<!--                                                </select>-->
-<!--                                            </label>-->
-<!--                                        </div>-->
-<!--                                        <div class="col-6">-->
-<!--                                            <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
-<!--                                        </div>-->
-<!--                                        <div class="col-2">-->
-<!--                                            &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
-<!--                                            <button type="submit">검색</button>-->
-<!--                                        </div>-->
-<!--                                    </div>-->
-<!--                                </div>-->
-<!--                                <div class="col-2" style="background-color: red;"></div>-->
-<!--                                <div class="col-4">-->
-<!--                                    <div class="row justify-content-end">-->
-<!--                                        &lt;!&ndash; 정렬 조건 &ndash;&gt;-->
-<!--                                        <label>-->
-<!--                                            <select class="form-select px-3" name="orderBy" onchange="this.form.submit()">-->
-<!--                                                <option value="recent" th:selected="${orderBy == 'recent'}">최근저장순</option>-->
-<!--                                                <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
-<!--                                                <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>-->
-<!--                                                <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
-<!--                                            </select>-->
-<!--                                        </label>-->
-<!--                                    </div>-->
-<!--                                </div>-->
-<!--                            </div> &lt;!&ndash;검색, 소팅 (토글X)&ndash;&gt;-->
-<!--                        </form>-->
-<!--                    </div>-->
-<!--                </div>-->
-<!--                <div class="row">-->
-<!--                    <div class="review-list">-->
-<!--                        <table>-->
-<!--                            <thead>-->
-<!--                            <tr>-->
-<!--                                <th>저장번호</th>-->
-<!--                                <th>웹툰 번호</th>-->
-<!--                                <th>유저넘버</th>-->
-<!--                                <th>웹툰아이디</th>-->
-<!--                                <th>플렛폼</th>-->
-<!--                                <th>제목</th>-->
-<!--                                <th>작가</th>-->
-<!--                                <th>이미지URL</th>-->
-<!--                                <th>장르</th>-->
-<!--                                <th>태그</th>-->
-<!--                                <th>조회수</th>-->
-<!--                            </tr>-->
-<!--                            </thead>-->
-<!--                            <tbody>-->
-<!--                            <tr th:each="myWtWebtoon : ${myWtWebtoons}" class="clickable-row"-->
-<!--                                th:attr="data-href=@{/webtoon/one(-->
-<!--                webtoon_id=${(myWtWebtoon.platform == 1 ? 'naver_' : myWtWebtoon.platform == 2 ? 'kakao_' : '') + myWtWebtoon.webtoonId},-->
-<!--                webtoon_name=${myWtWebtoon.webtoonName},-->
-<!--                author=${myWtWebtoon.author}-->
-<!--                )}">-->
-<!--                                <td th:text="${myWtWebtoon.saveNo}">저장번호</td>-->
-<!--                                <td th:text="${myWtWebtoon.webtoonNo}">웹툰 번호</td>-->
-<!--                                <td th:text="${myWtWebtoon.userNo}">유저넘버</td>-->
-<!--                                <td th:text="${myWtWebtoon.webtoonId}">웹툰아이디</td>-->
-<!--                                <td th:text="${myWtWebtoon.platform}">플렛폼</td>-->
-<!--                                <td th:text="${myWtWebtoon.webtoonName}">제목</td>-->
-<!--                                <td th:text="${myWtWebtoon.author}">작가</td>-->
-<!--                                <td th:text="${myWtWebtoon.thumbnailUrl}">이미지URL</td>-->
-<!--                                <td th:text="${myWtWebtoon.genre}">장르</td>-->
-<!--                                <td th:text="${myWtWebtoon.tags}">태그</td>-->
-<!--                                <td th:text="${myWtWebtoon.count}">조회수</td>-->
-<!--                            </tr>-->
-<!--                            </tbody>-->
-<!--                        </table>-->
-<!--                        &lt;!&ndash; 페이징 &ndash;&gt;-->
-<!--                        <th:block th:if="${pages != null}">-->
-<!--                            <div class="d-flex justify-content-center">-->
-<!--                                <div class="btn-group">-->
-<!--                                    <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/wt/webtoon(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
-<!--                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
-<!--                                            <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
-<!--                                        </svg>-->
-<!--                                    </button>-->
-<!--                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
-<!--                                        <button type="button" class="btn btn-sm me-2 pages"-->
-<!--                                                th:text="${p}" th:onclick="|location.href='@{/user/my/wt/webtoon(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
-<!--                                    </th:block>-->
-<!--                                    <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/wt/webtoon(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
-<!--                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
-<!--                                            <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
-<!--                                        </svg>-->
-<!--                                    </button>-->
-<!--                                </div>-->
-<!--                            </div>-->
-<!--                        </th:block>-->
-<!--                    </div>-->
-<!--                </div> &lt;!&ndash;테이블과 페이징&ndash;&gt;-->
-<!--            </div>&lt;!&ndash;테이블 및 페이징 포함&ndash;&gt;-->
-<!--        </div>-->
+        <!--수정전-->
+        <!--    <div class="col-md-9">-->
+        <!--        <div class="row" style="color: #828282;">-->
+        <!--            <div class="col-11">-->
+        <!--                <div class="row">-->
+        <!--                    <div class="col-12">-->
+        <!--                        <form id="sort-form" th:action="@{/user/my/wt/webtoon}" method="get">-->
+        <!--                            <div class="row">-->
+        <!--                                <div class="col-6">-->
+        <!--                                    <div class="row">-->
+        <!--                                        <div class="col-4">-->
+        <!--                                            &lt;!&ndash; 검색 조건 &ndash;&gt;-->
+        <!--                                            <label>-->
+        <!--                                                <select class="form-select px-3" name="searchBy">-->
+        <!--                                                    <option value="title" th:selected="${searchBy == 'title'}">제목</option>-->
+        <!--                                                    <option value="author" th:selected="${searchBy == 'author'}">작가</option>-->
+        <!--                                                    <option value="genre" th:selected="${searchBy == 'genre'}">장르</option>-->
+        <!--                                                    <option value="tag" th:selected="${searchBy == 'tag'}">태그</option>-->
+        <!--                                                </select>-->
+        <!--                                            </label>-->
+        <!--                                        </div>-->
+        <!--                                        <div class="col-6">-->
+        <!--                                            <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
+        <!--                                        </div>-->
+        <!--                                        <div class="col-2">-->
+        <!--                                            &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
+        <!--                                            <button type="submit">검색</button>-->
+        <!--                                        </div>-->
+        <!--                                    </div>-->
+        <!--                                </div>-->
+        <!--                                <div class="col-2" style="background-color: red;"></div>-->
+        <!--                                <div class="col-4">-->
+        <!--                                    <div class="row justify-content-end">-->
+        <!--                                        &lt;!&ndash; 정렬 조건 &ndash;&gt;-->
+        <!--                                        <label>-->
+        <!--                                            <select class="form-select px-3" name="orderBy" onchange="this.form.submit()">-->
+        <!--                                                <option value="recent" th:selected="${orderBy == 'recent'}">최근저장순</option>-->
+        <!--                                                <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
+        <!--                                                <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>-->
+        <!--                                                <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
+        <!--                                            </select>-->
+        <!--                                        </label>-->
+        <!--                                    </div>-->
+        <!--                                </div>-->
+        <!--                            </div> &lt;!&ndash;검색, 소팅 (토글X)&ndash;&gt;-->
+        <!--                        </form>-->
+        <!--                    </div>-->
+        <!--                </div>-->
+        <!--                <div class="row">-->
+        <!--                    <div class="review-list">-->
+        <!--                        <table>-->
+        <!--                            <thead>-->
+        <!--                            <tr>-->
+        <!--                                <th>저장번호</th>-->
+        <!--                                <th>웹툰 번호</th>-->
+        <!--                                <th>유저넘버</th>-->
+        <!--                                <th>웹툰아이디</th>-->
+        <!--                                <th>플렛폼</th>-->
+        <!--                                <th>제목</th>-->
+        <!--                                <th>작가</th>-->
+        <!--                                <th>이미지URL</th>-->
+        <!--                                <th>장르</th>-->
+        <!--                                <th>태그</th>-->
+        <!--                                <th>조회수</th>-->
+        <!--                            </tr>-->
+        <!--                            </thead>-->
+        <!--                            <tbody>-->
+        <!--                            <tr th:each="myWtWebtoon : ${myWtWebtoons}" class="clickable-row"-->
+        <!--                                th:attr="data-href=@{/webtoon/one(-->
+        <!--                webtoon_id=${(myWtWebtoon.platform == 1 ? 'naver_' : myWtWebtoon.platform == 2 ? 'kakao_' : '') + myWtWebtoon.webtoonId},-->
+        <!--                webtoon_name=${myWtWebtoon.webtoonName},-->
+        <!--                author=${myWtWebtoon.author}-->
+        <!--                )}">-->
+        <!--                                <td th:text="${myWtWebtoon.saveNo}">저장번호</td>-->
+        <!--                                <td th:text="${myWtWebtoon.webtoonNo}">웹툰 번호</td>-->
+        <!--                                <td th:text="${myWtWebtoon.userNo}">유저넘버</td>-->
+        <!--                                <td th:text="${myWtWebtoon.webtoonId}">웹툰아이디</td>-->
+        <!--                                <td th:text="${myWtWebtoon.platform}">플렛폼</td>-->
+        <!--                                <td th:text="${myWtWebtoon.webtoonName}">제목</td>-->
+        <!--                                <td th:text="${myWtWebtoon.author}">작가</td>-->
+        <!--                                <td th:text="${myWtWebtoon.thumbnailUrl}">이미지URL</td>-->
+        <!--                                <td th:text="${myWtWebtoon.genre}">장르</td>-->
+        <!--                                <td th:text="${myWtWebtoon.tags}">태그</td>-->
+        <!--                                <td th:text="${myWtWebtoon.count}">조회수</td>-->
+        <!--                            </tr>-->
+        <!--                            </tbody>-->
+        <!--                        </table>-->
+        <!--                        &lt;!&ndash; 페이징 &ndash;&gt;-->
+        <!--                        <th:block th:if="${pages != null}">-->
+        <!--                            <div class="d-flex justify-content-center">-->
+        <!--                                <div class="btn-group">-->
+        <!--                                    <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/wt/webtoon(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
+        <!--                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
+        <!--                                            <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
+        <!--                                        </svg>-->
+        <!--                                    </button>-->
+        <!--                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
+        <!--                                        <button type="button" class="btn btn-sm me-2 pages"-->
+        <!--                                                th:text="${p}" th:onclick="|location.href='@{/user/my/wt/webtoon(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
+        <!--                                    </th:block>-->
+        <!--                                    <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/wt/webtoon(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
+        <!--                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
+        <!--                                            <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
+        <!--                                        </svg>-->
+        <!--                                    </button>-->
+        <!--                                </div>-->
+        <!--                            </div>-->
+        <!--                        </th:block>-->
+        <!--                    </div>-->
+        <!--                </div> &lt;!&ndash;테이블과 페이징&ndash;&gt;-->
+        <!--            </div>&lt;!&ndash;테이블 및 페이징 포함&ndash;&gt;-->
+        <!--        </div>-->
 
-<!--    </div> &lt;!&ndash;본화면&ndash;&gt;-->
-</div> <!--aside와 본화면-->
+        <!--    </div> &lt;!&ndash;본화면&ndash;&gt;-->
+    </div> <!--aside와 본화면-->
+</div>
+
 <div th:replace="common/footer.html"></div>
 </body>
 </html>

--- a/src/main/resources/templates/user/mypage_wt_webtoon.html
+++ b/src/main/resources/templates/user/mypage_wt_webtoon.html
@@ -123,6 +123,7 @@
         </div>
     </div>
 </div>
+
 <div class="container" style="padding:0;">
     <div class="row">
         <aside class="col-md-3 px-4">

--- a/src/main/resources/templates/user/mypage_wt_webtoon.html
+++ b/src/main/resources/templates/user/mypage_wt_webtoon.html
@@ -291,28 +291,81 @@
             <div class="row" style="color: #828282;">
                 <div class="col-11">
                     <div class="row mb-4">
-                        <div class="col-12">
+                        <div class="col-12 p-0">
+                            <style>
+                                .col-4 select {
+                                    border-radius: 50px;
+                                    text-align: center;
+                                }
+                                /* 검색창 스타일 */
+                                .search-container {
+                                    width: 300px;
+                                }
+
+                                .search-container select {
+                                    position: absolute;
+                                    left: 0%;
+                                    width: 30%;
+                                    height: 50px;
+                                    color: #828282;
+                                    font-size: 1rem;
+                                    border-radius: 50px 0 0 50px;
+                                    outline: none;
+                                }
+                                .search-container input[type="text"] {
+                                    position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
+                                    left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
+                                    width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
+                                    height: 50px;
+                                    padding: 10px 40px 10px 15px;
+                                    font-size: 1rem;
+                                    outline: none;
+                                    border-radius: 0 50px 50px 0;
+                                    transition: border-color 0.3s, background-color 0.3s;
+                                    color: #828282; /* 입력 텍스트 색상 변경 */
+                                }
+
+                                .search-container input[type="text"]::placeholder {
+                                    color: #BBBBBB; /* placeholder 색상 변경 */
+                                }
+
+
+                                .search-container button {
+                                    position: absolute;
+                                    right: 1rem;
+                                    top: 25px;
+                                    background: none;
+                                    transform: translateY(-50%);
+                                    border: none;
+                                    cursor: pointer;
+                                }
+
+                                .search-container button i {
+                                    color: #666;
+                                }
+
+                                .search-container button:hover i {
+                                    color: #03C75A;
+                                }
+                            </style>
                             <form id="sort-form" th:action="@{/user/my/wt/webtoon}" method="get">
-                                <div class="row">
-                                    <div class="col-7">
+                                <div class="row m-0">
+                                    <div class="col-7 p-0">
                                         <div class="row justify-content-start m-0">
-                                            <div class="col-4">
-                                                <!-- 검색 조건 -->
-                                                <label>
+                                            <div class="col-12 p-0">
+                                                <div class="search-container">
                                                     <select class="form-select px-3" name="searchBy">
                                                         <option value="title" th:selected="${searchBy == 'title'}">제목</option>
                                                         <option value="author" th:selected="${searchBy == 'author'}">작가</option>
                                                         <option value="genre" th:selected="${searchBy == 'genre'}">장르</option>
                                                         <option value="tag" th:selected="${searchBy == 'tag'}">태그</option>
                                                     </select>
-                                                </label>
-                                            </div>
-                                            <div class="col-6">
-                                                <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
-                                            </div>
-                                            <div class="col-2">
-                                                <!-- 검색 버튼 -->
-                                                <button id="searchbutton" type="submit" class="btn btn-primary">검색</button>
+                                                    <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
+                                                    <!-- 검색 버튼 -->
+                                                    <button type="submit">
+                                                        <i class="fas fa-search"></i>
+                                                    </button>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>

--- a/src/main/resources/templates/user/mypage_wt_webtoon.html
+++ b/src/main/resources/templates/user/mypage_wt_webtoon.html
@@ -109,16 +109,20 @@
 <div class="jumbotron">
     <div class="container">
         <div class="row">
-            <div class="col-md-3 px-4">
-                <h3>나의 웹툰</h3>
-            </div>
-            <div class="col-md-9">
-                <nav class="navbar navbar-expand-md">
-                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                        <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2" style="color: #000;">북마크한 웹툰</a></li>
-                        <li><a th:href="@{/user/my/wt/comment}" class="nav-link px-2">내가 남긴 코멘트</a></li>
-                    </ul>
-                </nav>
+            <div class="col-9">
+                <div class="row">
+                    <div class="col-md-3 px-4">
+                        <h3>나의 웹툰</h3>
+                    </div>
+                    <div class="col-md-9">
+                        <nav class="navbar navbar-expand-md">
+                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2" style="color: #000;">북마크한 웹툰</a></li>
+                                <li><a th:href="@{/user/my/wt/comment}" class="nav-link px-2">내가 남긴 코멘트</a></li>
+                            </ul>
+                        </nav>
+                    </div>
+                </div>
             </div>
         </div>
     </div>
@@ -128,8 +132,8 @@
     <div class="row">
         <aside class="col-md-3 px-4">
             <div class="row">
-                <div class="col-3"></div>
-                <div class="col-6">
+                <div class="col-1"></div>
+                <div class="col-8">
                     <div class="panel">
                         <ul class="list-group">
                             <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2" style="color: #03C75A;">나의 웹툰</a></li>

--- a/src/main/resources/templates/user/mypage_wt_webtoon.html
+++ b/src/main/resources/templates/user/mypage_wt_webtoon.html
@@ -374,7 +374,7 @@
                                              th:text="${myWtWebtoon.platform == 1 ? '네이버웹툰' : (myWtWebtoon.platform == 2 ? '카카오웹툰' : '')}">닉네임
                                         </div>
 
-                                        <div class="col-3" style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD; font-family: 'Work Sans', sans-serif;" th:text="${myWtWebtoon.genre}">시간</div>
+                                        <div class="col-3" style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD; font-family: 'Work Sans', sans-serif;" th:text="${myWtWebtoon.firstHashtag}">시간</div>
                                     </div>
                                     <div class="row justify-content-center">
                                         <div class="col-12 my-3" style="">
@@ -419,7 +419,7 @@
                                              th:text="${myWtWebtoon.platform == 1 ? '네이버웹툰' : (myWtWebtoon.platform == 2 ? '카카오웹툰' : '')}">닉네임
                                         </div>
 
-                                        <div class="col-3" style="padding: 0; font-size: 0.8rem; text-align: right; color: #BDBDBD; font-family: 'Work Sans', sans-serif;" th:text="${myWtWebtoon.genre}">시간</div>
+                                        <div class="col-3" style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD; font-family: 'Work Sans', sans-serif;" th:text="${myWtWebtoon.firstHashtag}">시간</div>
                                     </div>
                                     <div class="row justify-content-center">
                                         <div class="col-12 my-3" style="">

--- a/src/main/resources/templates/user/mypage_wt_webtoon.html
+++ b/src/main/resources/templates/user/mypage_wt_webtoon.html
@@ -341,7 +341,7 @@
                                 }
 
                                 .search-container button i {
-                                    color: #666;
+                                    color: #A6AAB5;
                                 }
 
                                 .search-container button:hover i {

--- a/src/main/resources/templates/user/mypage_wt_webtoon.html
+++ b/src/main/resources/templates/user/mypage_wt_webtoon.html
@@ -88,6 +88,24 @@
 
 <div th:replace="~{common/menubar}"></div>
 <style>
+    html, body {
+        height: 100%;
+        margin: 0;
+    }
+    body {
+        display: flex;
+        flex-direction: column;
+    }
+    .content-wrapper {
+        flex: 1 0 auto;
+    }
+    footer {
+        flex-shrink: 0;
+    }
+
+</style>
+<div class="content-wrapper">
+    <style>
         .jumbotron {
         position : relative;
         background-color : #EEEEEE;
@@ -105,544 +123,611 @@
   list-style: none;
   padding-left : 0px;
   }
-</style>
-<div class="jumbotron">
-    <div class="container">
-        <div class="row">
-            <div class="col-9">
-                <div class="row">
-                    <div class="col-md-3 px-4">
-                        <h3>나의 웹툰</h3>
-                    </div>
-                    <div class="col-md-9">
-                        <nav class="navbar navbar-expand-md">
-                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                                <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2" style="color: #000;">북마크한 웹툰</a></li>
-                                <li><a th:href="@{/user/my/wt/comment}" class="nav-link px-2">내가 남긴 코멘트</a></li>
-                            </ul>
-                        </nav>
+    </style>
+    <div class="jumbotron">
+        <div class="container">
+            <div class="row">
+                <div class="col-9">
+                    <div class="row">
+                        <div class="col-md-3 px-4">
+                            <h3>나의 웹툰</h3>
+                        </div>
+                        <div class="col-md-9">
+                            <nav class="navbar navbar-expand-md">
+                                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                    <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2" style="color: #000;">북마크한
+                                        웹툰</a></li>
+                                    <li><a th:href="@{/user/my/wt/comment}" class="nav-link px-2">내가 남긴 코멘트</a></li>
+                                </ul>
+                            </nav>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
 
-<div class="container" style="padding:0;">
-    <div class="row">
-        <aside class="col-md-3 px-4">
-            <div class="row">
-                <div class="col-1"></div>
-                <div class="col-8">
-                    <div class="panel">
-                        <ul class="list-group">
-                            <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2" style="color: #03C75A;">나의 웹툰</a></li>
-                            <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
-                            <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
-                            <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
-                            <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
-                            <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
-                        </ul>
+    <div class="container" style="padding:0;">
+        <div class="row">
+            <aside class="col-md-3 px-4">
+                <div class="row">
+                    <div class="col-1"></div>
+                    <div class="col-8">
+                        <div class="panel">
+                            <ul class="list-group">
+                                <li><a th:href="@{/user/my/wt/webtoon}" class="nav-link px-2" style="color: #03C75A;">나의
+                                    웹툰</a></li>
+                                <li><a th:href="@{/user/my/so/review}" class="nav-link px-2">나의 소셜</a></li>
+                                <li><a th:href="@{/user/my/rct/job}" class="nav-link px-2">나의 채용</a></li>
+                                <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">나의 소식</a></li>
+                                <li><a th:href="@{/user/my/editprofile}" class="nav-link px-2">프로필 수정</a></li>
+                                <li><a th:href="@{/user/my/cs}" class="nav-link px-2">나의 문의</a></li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </aside>
-        <style>
-            .form-select {
-            background-color : #FCFCFC;
-            border : none;
-            width : 100%;
-            height : 50px;
-            }
-            select {
-            color : #828282;
-            }
-            .form-control {
-            background-color : #FCFCFC;
-            border : none;
-            width : 100%;
-            height : 50px;
-            }
-
-
-            .form-control::placeholder {
-            color : #BBBBBB;
-            }
-
-            .date-container {
-        display: flex;
-        flex-direction: column;
-        align-items: center;
-        justify-content: center;
-        background-color: #8E4B6E;
-        color: white;
-        border-radius: 10px;
-        text-align:center;
-        font-family: "Work Sans", sans-serif;
-    }
-
-    .platform-1 {
-        background-color: #03C75A;
-    }
-
-    .platform-2 {
-        background-color: #F5BF41;
-    }
-
-    .month {
-        font-size: 1.1rem; /* M의 크기를 설정 */
-        font-weight: 550;
-        line-height: 1;
-    }
-
-    .year {
-        font-size: 0.65rem; /* yyyy의 크기를 설정 */
-        font-weight: 400;
-    }
-    :root {
-        --background-color-light: #FFFFFF;
-        --text-color-light: #000000;
-        --toggle-background-light: #CCCCCC;
-        --toggle-ball-light: #FFFFFF;
-
-        --background-color-dark: #333333;
-        --text-color-dark: #FFFFFF;
-        --toggle-background-dark: #03C75A;
-        --toggle-ball-dark: #FFFFFF;
-
-        --font-size-base: 32px; /* 기본 텍스트 크기 */
-        --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
-    }
-
-
-
-    .toggle-switch {
-        position: relative;
-        display: inline-block;
-        width: 62px; /* 너비 조정 */
-        height: 38px; /* 높이 조정 */
-    }
-
-    .toggle-switch .checkbox {
-        opacity: 0;
-        width: 0;
-        height: 0;
-    }
-    #isToggledCheckbox {
-         opacity: 0;
-            width: 0;
-            height: 0;
-    }
-
-    .toggle-switch .label {
-        position: absolute;
-        cursor: pointer;
-        top: 0;
-        left: 0;
-        right: 0;
-        bottom: 0;
-        background-color: var(--toggle-background-light);
-        transition: background-color 0.4s;
-        border-radius: 38px; /* 둥근 모서리 반경 조정 */
-    }
-
-    .toggle-switch .label:before {
-        position: absolute;
-        content: "";
-        height: 30px; /* 내부 원 높이 조정 */
-        width: 30px; /* 내부 원 너비 조정 */
-        left: 2px;
-        bottom: 0px;
-        background-color: var(--toggle-ball-light);
-        transition: transform 0.4s;
-        border-radius: 50%;
-    }
-
-    .toggle-switch input:checked + .label {
-        background-color: var(--toggle-background-dark);
-    }
-
-    .toggle-switch input:checked + .label:before {
-        transform: translateX(28px); /* 내부 원 이동 거리 조정 */
-    }
-
-             #absdiv {
-                position: relative;
-                top: 60px; /* Move down by 20px from its current position */
-                z-index : 1000;
-            }
-
-            #searchbutton {
-                background-color: #828282;
-            }
-
-            .card-img-top {
-                    width: 100%;
-                    height: 100px;
-                    object-fit: cover;
+            </aside>
+            <style>
+                .form-select {
+                background-color : #FCFCFC;
+                border : none;
+                width : 100%;
+                height : 50px;
+                }
+                select {
+                color : #828282;
+                }
+                .form-control {
+                background-color : #FCFCFC;
+                border : none;
+                width : 100%;
+                height : 50px;
                 }
 
-        </style>
-        <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
-        <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap" rel="stylesheet">
+
+                .form-control::placeholder {
+                color : #BBBBBB;
+                }
+
+                .date-container {
+            display: flex;
+            flex-direction: column;
+            align-items: center;
+            justify-content: center;
+            background-color: #8E4B6E;
+            color: white;
+            border-radius: 10px;
+            text-align:center;
+            font-family: "Work Sans", sans-serif;
+        }
+
+        .platform-1 {
+            background-color: #03C75A;
+        }
+
+        .platform-2 {
+            background-color: #F5BF41;
+        }
+
+        .month {
+            font-size: 1.1rem; /* M의 크기를 설정 */
+            font-weight: 550;
+            line-height: 1;
+        }
+
+        .year {
+            font-size: 0.65rem; /* yyyy의 크기를 설정 */
+            font-weight: 400;
+        }
+        :root {
+            --background-color-light: #FFFFFF;
+            --text-color-light: #000000;
+            --toggle-background-light: #CCCCCC;
+            --toggle-ball-light: #FFFFFF;
+
+            --background-color-dark: #333333;
+            --text-color-dark: #FFFFFF;
+            --toggle-background-dark: #03C75A;
+            --toggle-ball-dark: #FFFFFF;
+
+            --font-size-base: 32px; /* 기본 텍스트 크기 */
+            --font-size-large: 52px; /* 제목 등 큰 텍스트용 폰트 크기 */
+        }
 
 
-        <div class="col-md-9">
-            <div class="row" style="color: #828282;">
-                <div class="col-11">
-                    <div class="row mb-4">
-                        <div class="col-12 p-0">
-                            <style>
-                                .col-4 select {
-                                    border-radius: 50px;
-                                    text-align: center;
-                                }
-                                /* 검색창 스타일 */
-                                .search-container {
-                                    width: 300px;
-                                }
 
-                                .search-container select {
-                                    position: absolute;
-                                    left: 0%;
-                                    width: 30%;
-                                    height: 50px;
-                                    color: #828282;
-                                    font-size: 1rem;
-                                    border-radius: 50px 0 0 50px;
-                                    outline: none;
-                                }
-                                .search-container input[type="text"] {
-                                    position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
-                                    left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
-                                    width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
-                                    height: 50px;
-                                    padding: 10px 40px 10px 15px;
-                                    font-size: 1rem;
-                                    outline: none;
-                                    border-radius: 0 50px 50px 0;
-                                    transition: border-color 0.3s, background-color 0.3s;
-                                    color: #828282; /* 입력 텍스트 색상 변경 */
-                                }
+        .toggle-switch {
+            position: relative;
+            display: inline-block;
+            width: 62px; /* 너비 조정 */
+            height: 38px; /* 높이 조정 */
+        }
 
-                                .search-container input[type="text"]::placeholder {
-                                    color: #BBBBBB; /* placeholder 색상 변경 */
-                                }
+        .toggle-switch .checkbox {
+            opacity: 0;
+            width: 0;
+            height: 0;
+        }
+        #isToggledCheckbox {
+             opacity: 0;
+                width: 0;
+                height: 0;
+        }
+
+        .toggle-switch .label {
+            position: absolute;
+            cursor: pointer;
+            top: 0;
+            left: 0;
+            right: 0;
+            bottom: 0;
+            background-color: var(--toggle-background-light);
+            transition: background-color 0.4s;
+            border-radius: 38px; /* 둥근 모서리 반경 조정 */
+        }
+
+        .toggle-switch .label:before {
+            position: absolute;
+            content: "";
+            height: 30px; /* 내부 원 높이 조정 */
+            width: 30px; /* 내부 원 너비 조정 */
+            left: 2px;
+            bottom: 0px;
+            background-color: var(--toggle-ball-light);
+            transition: transform 0.4s;
+            border-radius: 50%;
+        }
+
+        .toggle-switch input:checked + .label {
+            background-color: var(--toggle-background-dark);
+        }
+
+        .toggle-switch input:checked + .label:before {
+            transform: translateX(28px); /* 내부 원 이동 거리 조정 */
+        }
+
+                 #absdiv {
+                    position: relative;
+                    top: 60px; /* Move down by 20px from its current position */
+                    z-index : 1000;
+                }
+
+                #searchbutton {
+                    background-color: #828282;
+                }
+
+                .card-img-top {
+                        width: 100%;
+                        height: 100px;
+                        object-fit: cover;
+                    }
+
+            </style>
+            <link href="https://fonts.googleapis.com/css2?family=Montserrat:ital,wght@0,100..900;1,100..900&display=swap"
+                  rel="stylesheet">
+            <link href="https://fonts.googleapis.com/css2?family=Work+Sans:ital,wght@0,100..900;1,100..900&display=swap"
+                  rel="stylesheet">
 
 
-                                .search-container button {
-                                    position: absolute;
-                                    right: 1rem;
-                                    top: 25px;
-                                    background: none;
-                                    transform: translateY(-50%);
-                                    border: none;
-                                    cursor: pointer;
-                                }
+            <div class="col-md-9">
+                <div class="row" style="color: #828282;">
+                    <div class="col-11">
+                        <div class="row mb-4">
+                            <div class="col-12 p-0">
+                                <style>
+                                    .col-4 select {
+                                        border-radius: 50px;
+                                        text-align: center;
+                                    }
+                                    /* 검색창 스타일 */
+                                    .search-container {
+                                        width: 300px;
+                                    }
 
-                                .search-container button i {
-                                    color: #A6AAB5;
-                                }
+                                    .search-container select {
+                                        position: absolute;
+                                        left: 0%;
+                                        width: 30%;
+                                        height: 50px;
+                                        color: #828282;
+                                        font-size: 1rem;
+                                        border-radius: 50px 0 0 50px;
+                                        outline: none;
+                                    }
+                                    .search-container input[type="text"] {
+                                        position: absolute; /* 변경된 부분: 위치를 절대적으로 설정 */
+                                        left: 30%; /* 변경된 부분: 전체 너비의 30% 위치로 이동 */
+                                        width: 70%; /* 변경된 부분: 너비를 조정하여 적절한 위치에 맞춤 */
+                                        height: 50px;
+                                        padding: 10px 40px 10px 15px;
+                                        font-size: 1rem;
+                                        outline: none;
+                                        border-radius: 0 50px 50px 0;
+                                        transition: border-color 0.3s, background-color 0.3s;
+                                        color: #828282; /* 입력 텍스트 색상 변경 */
+                                    }
 
-                                .search-container button:hover i {
-                                    color: #03C75A;
-                                }
-                            </style>
-                            <form id="sort-form" th:action="@{/user/my/wt/webtoon}" method="get">
-                                <div class="row m-0">
-                                    <div class="col-7 p-0">
-                                        <div class="row justify-content-start m-0">
-                                            <div class="col-12 p-0">
-                                                <div class="search-container">
-                                                    <select class="form-select px-3" name="searchBy">
-                                                        <option value="title" th:selected="${searchBy == 'title'}">제목</option>
-                                                        <option value="author" th:selected="${searchBy == 'author'}">작가</option>
-                                                        <option value="genre" th:selected="${searchBy == 'genre'}">장르</option>
-                                                        <option value="tag" th:selected="${searchBy == 'tag'}">태그</option>
-                                                    </select>
-                                                    <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />
-                                                    <!-- 검색 버튼 -->
-                                                    <button type="submit">
-                                                        <i class="fas fa-search"></i>
-                                                    </button>
+                                    .search-container input[type="text"]::placeholder {
+                                        color: #BBBBBB; /* placeholder 색상 변경 */
+                                    }
+
+
+                                    .search-container button {
+                                        position: absolute;
+                                        right: 1rem;
+                                        top: 25px;
+                                        background: none;
+                                        transform: translateY(-50%);
+                                        border: none;
+                                        cursor: pointer;
+                                    }
+
+                                    .search-container button i {
+                                        color: #A6AAB5;
+                                    }
+
+                                    .search-container button:hover i {
+                                        color: #03C75A;
+                                    }
+                                </style>
+                                <form id="sort-form" th:action="@{/user/my/wt/webtoon}" method="get">
+                                    <div class="row m-0">
+                                        <div class="col-7 p-0">
+                                            <div class="row justify-content-start m-0">
+                                                <div class="col-12 p-0">
+                                                    <div class="search-container">
+                                                        <select class="form-select px-3" name="searchBy">
+                                                            <option value="title" th:selected="${searchBy == 'title'}">
+                                                                제목
+                                                            </option>
+                                                            <option value="author"
+                                                                    th:selected="${searchBy == 'author'}">작가
+                                                            </option>
+                                                            <option value="genre" th:selected="${searchBy == 'genre'}">
+                                                                장르
+                                                            </option>
+                                                            <option value="tag" th:selected="${searchBy == 'tag'}">태그
+                                                            </option>
+                                                        </select>
+                                                        <input class="form-control px-3" type="text" name="searchTerm"
+                                                               placeholder="검색어를 입력하세요" th:value="${searchTerm}"/>
+                                                        <!-- 검색 버튼 -->
+                                                        <button type="submit">
+                                                            <i class="fas fa-search"></i>
+                                                        </button>
+                                                    </div>
                                                 </div>
                                             </div>
                                         </div>
-                                    </div>
-                                    <div class="col-1" style=""></div>
-                                    <div class="col-4">
-                                        <div class="row justify-content-end">
-                                            <!-- 정렬 또는 토글2 -->
-                                            <label>
-                                                <select class="form-select px-3" name="orderBy" onchange="this.form.submit()">
-                                                    <option value="recent" th:selected="${orderBy == 'recent'}">최근저장순</option>
-                                                    <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>
-                                                    <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>
-                                                    <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>
-                                                </select>
-                                            </label>
-                                        </div>
-                                    </div>
-                                </div> <!--검색, 소팅 (토글X)-->
-                                <div class="row justify-content-around">
-                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                    <div class="col-3" style="padding: 0 1.2rem;"></div>
-                                    <div class="col-3" style="padding: 0 1.2rem;">
-                                        <div id="absdiv" class="row justify-content-end">
-                                            <!--                                        <div class="col-3">-->
-                                            <!--                                            <div class="toggle-switch">-->
-                                            <!--                                                &lt;!&ndash; 정렬 또는 토글1 &ndash;&gt;-->
-                                            <!--                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">-->
-                                            <!--                                                <label for="isToggledCheckbox" class="label">-->
-                                            <!--                                                    <div class="ball"></div>-->
-                                            <!--                                                </label>-->
-                                            <!--                                            </div>-->
-                                            <!--                                        </div>-->
-                                            <!--                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">진행중인 행사</div>-->
-                                        </div>
-                                    </div>
-                                </div> <!--토글-->
-                            </form>
-                        </div>
-                    </div>
-                    <div class="row justify-content-around mt-4">
-                        <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
-                            <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
-                                <div class="col-3 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:each="myWtWebtoon, iterStat : ${myWtWebtoons}" th:attr="data-href=@{/webtoon/one(
-                webtoon_id=${(myWtWebtoon.platform == 1 ? 'naver_' : myWtWebtoon.platform == 2 ? 'kakao_' : '') + myWtWebtoon.webtoonId},
-                webtoon_name=${myWtWebtoon.webtoonName},
-                author=${myWtWebtoon.author}
-                )}" th:if="${iterStat.index < 3}">
-                                    <div class="row justify-content-center">
-                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                            <div class="date-container px-3 py-2">
-                                                <div class="month"
-                                                     th:text="${myWtWebtoon.platform == 1 ? 'N' : (myWtWebtoon.platform == 2 ? 'K' : '')}"></div>
+                                        <div class="col-1" style=""></div>
+                                        <div class="col-4">
+                                            <div class="row justify-content-end">
+                                                <!-- 정렬 또는 토글2 -->
+                                                <label>
+                                                    <select class="form-select px-3" name="orderBy"
+                                                            onchange="this.form.submit()">
+                                                        <option value="recent" th:selected="${orderBy == 'recent'}">
+                                                            최근저장순
+                                                        </option>
+                                                        <option value="oldest" th:selected="${orderBy == 'oldest'}">
+                                                            오래된순
+                                                        </option>
+                                                        <option value="views" th:selected="${orderBy == 'views'}">
+                                                            조회수높은순
+                                                        </option>
+                                                        <option value="title" th:selected="${orderBy == 'title'}">
+                                                            제목가나다순
+                                                        </option>
+                                                    </select>
+                                                </label>
                                             </div>
                                         </div>
-                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                        <!--                                    </div>-->
-                                        <div class="col-5" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
-                                             th:text="${myWtWebtoon.platform == 1 ? '네이버웹툰' : (myWtWebtoon.platform == 2 ? '카카오웹툰' : '')}">닉네임
-                                        </div>
-
-                                        <div class="col-3" style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD; font-family: 'Work Sans', sans-serif;" th:text="${myWtWebtoon.firstHashtag}">시간</div>
-                                    </div>
-                                    <div class="row justify-content-center">
-                                        <div class="col-12 my-3" style="">
-                                            <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                            <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                            <!-- 썸네일 이미지 있을때  -->
-                                            <img th:if="${myWtWebtoon.thumbnailUrl != null}" th:src="${myWtWebtoon.thumbnailUrl}" class="card-img-top" alt="썸네일 이미지">
-                                        </div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" th:text="${myWtWebtoon.webtoonName}">이름</div>
-                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${myWtWebtoon.author}">내용</div>
-                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                    </div>
-
-                                </div>
-                                <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
-                                <div class="col-3" th:if="${myWtWebtoons.size() == 0}"></div>
-                                <div class="col-3" th:if="${myWtWebtoons.size() == 0 || myWtWebtoons.size() == 1}"></div>
-                                <div class="col-3" th:if="${myWtWebtoons.size() == 0 || myWtWebtoons.size() == 1 || myWtWebtoons.size() == 2}"></div>
-                            </div>
-                            <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
-                                <div class="col-3 clickable-row" style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;" th:each="myWtWebtoon, iterStat : ${myWtWebtoons}" th:attr="data-href=@{/webtoon/one(
-                webtoon_id=${(myWtWebtoon.platform == 1 ? 'naver_' : myWtWebtoon.platform == 2 ? 'kakao_' : '') + myWtWebtoon.webtoonId},
-                webtoon_name=${myWtWebtoon.webtoonName},
-                author=${myWtWebtoon.author}
-                )}" th:if="${iterStat.index >= 3}">
-                                    <div class="row justify-content-center">
-                                        <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">
-                                            <div class="date-container px-3 py-2">
-                                                <div class="month"
-                                                     th:text="${myWtWebtoon.platform == 1 ? 'N' : (myWtWebtoon.platform == 2 ? 'K' : '')}"></div>
+                                    </div> <!--검색, 소팅 (토글X)-->
+                                    <div class="row justify-content-around">
+                                        <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                        <div class="col-3" style="padding: 0 1.2rem;"></div>
+                                        <div class="col-3" style="padding: 0 1.2rem;">
+                                            <div id="absdiv" class="row justify-content-end">
+                                                <!--                                        <div class="col-3">-->
+                                                <!--                                            <div class="toggle-switch">-->
+                                                <!--                                                &lt;!&ndash; 정렬 또는 토글1 &ndash;&gt;-->
+                                                <!--                                                <input type="checkbox" name="isToggled" id="isToggledCheckbox" value="Y" th:checked="${isToggled == 'Y'}" onchange="updateCheckboxValueAndSubmit()">-->
+                                                <!--                                                <label for="isToggledCheckbox" class="label">-->
+                                                <!--                                                    <div class="ball"></div>-->
+                                                <!--                                                </label>-->
+                                                <!--                                            </div>-->
+                                                <!--                                        </div>-->
+                                                <!--                                        <div class="col-8" style="text-align: right; padding: 0px; margin : 0px;">진행중인 행사</div>-->
                                             </div>
                                         </div>
-                                        <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
-                                        <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
-                                        <!--                                    </div>-->
-                                        <div class="col-5" style="color: #333333; font-size: 0.8rem; font-weight: 530;"
-                                             th:text="${myWtWebtoon.platform == 1 ? '네이버웹툰' : (myWtWebtoon.platform == 2 ? '카카오웹툰' : '')}">닉네임
-                                        </div>
-
-                                        <div class="col-3" style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD; font-family: 'Work Sans', sans-serif;" th:text="${myWtWebtoon.firstHashtag}">시간</div>
-                                    </div>
-                                    <div class="row justify-content-center">
-                                        <div class="col-12 my-3" style="">
-                                            <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                            <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
-                                            <!-- 썸네일 이미지 있을때  -->
-                                            <img th:if="${myWtWebtoon.thumbnailUrl != null}" th:src="${myWtWebtoon.thumbnailUrl}" class="card-img-top" alt="썸네일 이미지">
-                                        </div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;" th:text="${myWtWebtoon.webtoonName}">이름</div>
-                                        <div class="col-3" style="padding: 0; text-align: right;"></div>
-                                    </div>
-                                    <div class="row" style="padding: 0; margin: 0;">
-                                        <div class="col-9" style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; " th:text="${myWtWebtoon.author}">내용</div>
-                                        <div class="col-3" style="padding: 0; text-align: right;">→</div>
-                                    </div>
-
-                                </div>
-
-                                <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
-                                <div class="col-3" th:if="${myWtWebtoons.size() <= 3}"></div>
-                                <div class="col-3" th:if="${myWtWebtoons.size() <= 3 || myWtWebtoons.size() == 4}"></div>
-                                <div class="col-3" th:if="${myWtWebtoons.size() <= 3 || myWtWebtoons.size() == 4 || myWtWebtoons.size() == 5}"></div>
+                                    </div> <!--토글-->
+                                </form>
                             </div>
                         </div>
-                    </div>
-                    <div class="row justify-content-center">
-                        <!-- 페이징 -->
-                        <th:block th:if="${pages != null}">
-                            <div class="d-flex justify-content-center">
-                                <div class="btn-group">
-                                    <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/wt/webtoon(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
-                                            <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
-                                        </svg>
-                                    </button>
-                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">
-                                        <button type="button" class="btn btn-sm me-2 pages"
-                                                th:text="${p}" th:onclick="|location.href='@{/user/my/wt/webtoon(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
-                                    </th:block>
-                                    <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/wt/webtoon(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">
-                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
-                                            <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
-                                        </svg>
-                                    </button>
+                        <div class="row justify-content-around mt-4">
+                            <div class="col-12 py-4" style="background-color: #F9F9F9; border-radius: 15px;">
+                                <div class="row justify-content-around mt-5 mb-5" style="background-color:  #F9F9F9;">
+                                    <div class="col-3 clickable-row"
+                                         style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                         th:each="myWtWebtoon, iterStat : ${myWtWebtoons}" th:attr="data-href=@{/webtoon/one(
+                    webtoon_id=${(myWtWebtoon.platform == 1 ? 'naver_' : myWtWebtoon.platform == 2 ? 'kakao_' : '') + myWtWebtoon.webtoonId},
+                    webtoon_name=${myWtWebtoon.webtoonName},
+                    author=${myWtWebtoon.author}
+                    )}" th:if="${iterStat.index < 3}">
+                                        <div class="row justify-content-center">
+                                            <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                                 style="aspect-ratio: 1; border-radius: 5px;">
+                                                <div class="date-container px-3 py-2">
+                                                    <div class="month"
+                                                         th:text="${myWtWebtoon.platform == 1 ? 'N' : (myWtWebtoon.platform == 2 ? 'K' : '')}"></div>
+                                                </div>
+                                            </div>
+                                            <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                            <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                            <!--                                    </div>-->
+                                            <div class="col-5"
+                                                 style="color: #333333; font-size: 0.8rem; font-weight: 530;"
+                                                 th:text="${myWtWebtoon.platform == 1 ? '네이버웹툰' : (myWtWebtoon.platform == 2 ? '카카오웹툰' : '')}">
+                                                닉네임
+                                            </div>
+
+                                            <div class="col-3"
+                                                 style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD; font-family: 'Work Sans', sans-serif;"
+                                                 th:text="${myWtWebtoon.firstHashtag}">시간
+                                            </div>
+                                        </div>
+                                        <div class="row justify-content-center">
+                                            <div class="col-12 my-3" style="">
+                                                <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                                <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                                <!-- 썸네일 이미지 있을때  -->
+                                                <img th:if="${myWtWebtoon.thumbnailUrl != null}"
+                                                     th:src="${myWtWebtoon.thumbnailUrl}" class="card-img-top"
+                                                     alt="썸네일 이미지">
+                                            </div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                                 th:text="${myWtWebtoon.webtoonName}">이름
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                                 th:text="${myWtWebtoon.author}">내용
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                        </div>
+
+                                    </div>
+                                    <!-- 아이템 수가 0개 1개 또는 2개일 때 더미 컬럼 추가 -->
+                                    <div class="col-3" th:if="${myWtWebtoons.size() == 0}"></div>
+                                    <div class="col-3"
+                                         th:if="${myWtWebtoons.size() == 0 || myWtWebtoons.size() == 1}"></div>
+                                    <div class="col-3"
+                                         th:if="${myWtWebtoons.size() == 0 || myWtWebtoons.size() == 1 || myWtWebtoons.size() == 2}"></div>
+                                </div>
+                                <div class="row justify-content-around mt-2 mb-5" style="background-color: #F9F9F9;">
+                                    <div class="col-3 clickable-row"
+                                         style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                         th:each="myWtWebtoon, iterStat : ${myWtWebtoons}" th:attr="data-href=@{/webtoon/one(
+                    webtoon_id=${(myWtWebtoon.platform == 1 ? 'naver_' : myWtWebtoon.platform == 2 ? 'kakao_' : '') + myWtWebtoon.webtoonId},
+                    webtoon_name=${myWtWebtoon.webtoonName},
+                    author=${myWtWebtoon.author}
+                    )}" th:if="${iterStat.index >= 3}">
+                                        <div class="row justify-content-center">
+                                            <div class="col-2 p-0 d-flex align-items-center justify-content-center"
+                                                 style="aspect-ratio: 1; border-radius: 5px;">
+                                                <div class="date-container px-3 py-2">
+                                                    <div class="month"
+                                                         th:text="${myWtWebtoon.platform == 1 ? 'N' : (myWtWebtoon.platform == 2 ? 'K' : '')}"></div>
+                                                </div>
+                                            </div>
+                                            <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
+                                            <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
+                                            <!--                                    </div>-->
+                                            <div class="col-5"
+                                                 style="color: #333333; font-size: 0.8rem; font-weight: 530;"
+                                                 th:text="${myWtWebtoon.platform == 1 ? '네이버웹툰' : (myWtWebtoon.platform == 2 ? '카카오웹툰' : '')}">
+                                                닉네임
+                                            </div>
+
+                                            <div class="col-3"
+                                                 style="padding: 0; font-size: 0.7rem; text-align: right; color: #BDBDBD; font-family: 'Work Sans', sans-serif;"
+                                                 th:text="${myWtWebtoon.firstHashtag}">시간
+                                            </div>
+                                        </div>
+                                        <div class="row justify-content-center">
+                                            <div class="col-12 my-3" style="">
+                                                <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                                <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                                <!-- 썸네일 이미지 있을때  -->
+                                                <img th:if="${myWtWebtoon.thumbnailUrl != null}"
+                                                     th:src="${myWtWebtoon.thumbnailUrl}" class="card-img-top"
+                                                     alt="썸네일 이미지">
+                                            </div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; color: #333333; font-size: 1.05rem; font-weight: 530;"
+                                                 th:text="${myWtWebtoon.webtoonName}">이름
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;"></div>
+                                        </div>
+                                        <div class="row" style="padding: 0; margin: 0;">
+                                            <div class="col-9"
+                                                 style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
+                                                 th:text="${myWtWebtoon.author}">내용
+                                            </div>
+                                            <div class="col-3" style="padding: 0; text-align: right;">→</div>
+                                        </div>
+
+                                    </div>
+
+                                    <!-- 아이템 수가 3개 4개 또는 5개일 때 더미 컬럼 추가 -->
+                                    <div class="col-3" th:if="${myWtWebtoons.size() <= 3}"></div>
+                                    <div class="col-3"
+                                         th:if="${myWtWebtoons.size() <= 3 || myWtWebtoons.size() == 4}"></div>
+                                    <div class="col-3"
+                                         th:if="${myWtWebtoons.size() <= 3 || myWtWebtoons.size() == 4 || myWtWebtoons.size() == 5}"></div>
                                 </div>
                             </div>
-                        </th:block>
-                    </div>
-                </div><!--테이블 및 페이징 포함-->
+                        </div>
+                        <div class="row justify-content-center">
+                            <!-- 페이징 -->
+                            <th:block th:if="${pages != null}">
+                                <div class="d-flex justify-content-center">
+                                    <div class="btn-group">
+                                        <button type="button" class="btn btn-sm previous"
+                                                th:onclick="|location.href='@{/user/my/wt/webtoon(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|"
+                                                th:disabled="${currentPage == 1}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                                 fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">
+                                                <path fill-rule="evenodd"
+                                                      d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>
+                                            </svg>
+                                        </button>
+                                        <th:block th:each="p : ${#numbers.sequence(1, pages)}">
+                                            <button type="button" class="btn btn-sm me-2 pages"
+                                                    th:text="${p}"
+                                                    th:onclick="|location.href='@{/user/my/wt/webtoon(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>
+                                        </th:block>
+                                        <button type="button" class="btn btn-sm  next"
+                                                th:onclick="|location.href='@{/user/my/wt/webtoon(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|"
+                                                th:disabled="${currentPage == pages}">
+                                            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"
+                                                 fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">
+                                                <path fill-rule="evenodd"
+                                                      d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>
+                                            </svg>
+                                        </button>
+                                    </div>
+                                </div>
+                            </th:block>
+                        </div>
+                    </div><!--테이블 및 페이징 포함-->
+                </div> <!--본화면-->
             </div> <!--본화면-->
-        </div> <!--본화면-->
 
 
-        <!--수정전-->
-        <!--    <div class="col-md-9">-->
-        <!--        <div class="row" style="color: #828282;">-->
-        <!--            <div class="col-11">-->
-        <!--                <div class="row">-->
-        <!--                    <div class="col-12">-->
-        <!--                        <form id="sort-form" th:action="@{/user/my/wt/webtoon}" method="get">-->
-        <!--                            <div class="row">-->
-        <!--                                <div class="col-6">-->
-        <!--                                    <div class="row">-->
-        <!--                                        <div class="col-4">-->
-        <!--                                            &lt;!&ndash; 검색 조건 &ndash;&gt;-->
-        <!--                                            <label>-->
-        <!--                                                <select class="form-select px-3" name="searchBy">-->
-        <!--                                                    <option value="title" th:selected="${searchBy == 'title'}">제목</option>-->
-        <!--                                                    <option value="author" th:selected="${searchBy == 'author'}">작가</option>-->
-        <!--                                                    <option value="genre" th:selected="${searchBy == 'genre'}">장르</option>-->
-        <!--                                                    <option value="tag" th:selected="${searchBy == 'tag'}">태그</option>-->
-        <!--                                                </select>-->
-        <!--                                            </label>-->
-        <!--                                        </div>-->
-        <!--                                        <div class="col-6">-->
-        <!--                                            <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
-        <!--                                        </div>-->
-        <!--                                        <div class="col-2">-->
-        <!--                                            &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
-        <!--                                            <button type="submit">검색</button>-->
-        <!--                                        </div>-->
-        <!--                                    </div>-->
-        <!--                                </div>-->
-        <!--                                <div class="col-2" style="background-color: red;"></div>-->
-        <!--                                <div class="col-4">-->
-        <!--                                    <div class="row justify-content-end">-->
-        <!--                                        &lt;!&ndash; 정렬 조건 &ndash;&gt;-->
-        <!--                                        <label>-->
-        <!--                                            <select class="form-select px-3" name="orderBy" onchange="this.form.submit()">-->
-        <!--                                                <option value="recent" th:selected="${orderBy == 'recent'}">최근저장순</option>-->
-        <!--                                                <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
-        <!--                                                <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>-->
-        <!--                                                <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
-        <!--                                            </select>-->
-        <!--                                        </label>-->
-        <!--                                    </div>-->
-        <!--                                </div>-->
-        <!--                            </div> &lt;!&ndash;검색, 소팅 (토글X)&ndash;&gt;-->
-        <!--                        </form>-->
-        <!--                    </div>-->
-        <!--                </div>-->
-        <!--                <div class="row">-->
-        <!--                    <div class="review-list">-->
-        <!--                        <table>-->
-        <!--                            <thead>-->
-        <!--                            <tr>-->
-        <!--                                <th>저장번호</th>-->
-        <!--                                <th>웹툰 번호</th>-->
-        <!--                                <th>유저넘버</th>-->
-        <!--                                <th>웹툰아이디</th>-->
-        <!--                                <th>플렛폼</th>-->
-        <!--                                <th>제목</th>-->
-        <!--                                <th>작가</th>-->
-        <!--                                <th>이미지URL</th>-->
-        <!--                                <th>장르</th>-->
-        <!--                                <th>태그</th>-->
-        <!--                                <th>조회수</th>-->
-        <!--                            </tr>-->
-        <!--                            </thead>-->
-        <!--                            <tbody>-->
-        <!--                            <tr th:each="myWtWebtoon : ${myWtWebtoons}" class="clickable-row"-->
-        <!--                                th:attr="data-href=@{/webtoon/one(-->
-        <!--                webtoon_id=${(myWtWebtoon.platform == 1 ? 'naver_' : myWtWebtoon.platform == 2 ? 'kakao_' : '') + myWtWebtoon.webtoonId},-->
-        <!--                webtoon_name=${myWtWebtoon.webtoonName},-->
-        <!--                author=${myWtWebtoon.author}-->
-        <!--                )}">-->
-        <!--                                <td th:text="${myWtWebtoon.saveNo}">저장번호</td>-->
-        <!--                                <td th:text="${myWtWebtoon.webtoonNo}">웹툰 번호</td>-->
-        <!--                                <td th:text="${myWtWebtoon.userNo}">유저넘버</td>-->
-        <!--                                <td th:text="${myWtWebtoon.webtoonId}">웹툰아이디</td>-->
-        <!--                                <td th:text="${myWtWebtoon.platform}">플렛폼</td>-->
-        <!--                                <td th:text="${myWtWebtoon.webtoonName}">제목</td>-->
-        <!--                                <td th:text="${myWtWebtoon.author}">작가</td>-->
-        <!--                                <td th:text="${myWtWebtoon.thumbnailUrl}">이미지URL</td>-->
-        <!--                                <td th:text="${myWtWebtoon.genre}">장르</td>-->
-        <!--                                <td th:text="${myWtWebtoon.tags}">태그</td>-->
-        <!--                                <td th:text="${myWtWebtoon.count}">조회수</td>-->
-        <!--                            </tr>-->
-        <!--                            </tbody>-->
-        <!--                        </table>-->
-        <!--                        &lt;!&ndash; 페이징 &ndash;&gt;-->
-        <!--                        <th:block th:if="${pages != null}">-->
-        <!--                            <div class="d-flex justify-content-center">-->
-        <!--                                <div class="btn-group">-->
-        <!--                                    <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/wt/webtoon(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
-        <!--                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
-        <!--                                            <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
-        <!--                                        </svg>-->
-        <!--                                    </button>-->
-        <!--                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
-        <!--                                        <button type="button" class="btn btn-sm me-2 pages"-->
-        <!--                                                th:text="${p}" th:onclick="|location.href='@{/user/my/wt/webtoon(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
-        <!--                                    </th:block>-->
-        <!--                                    <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/wt/webtoon(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
-        <!--                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
-        <!--                                            <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
-        <!--                                        </svg>-->
-        <!--                                    </button>-->
-        <!--                                </div>-->
-        <!--                            </div>-->
-        <!--                        </th:block>-->
-        <!--                    </div>-->
-        <!--                </div> &lt;!&ndash;테이블과 페이징&ndash;&gt;-->
-        <!--            </div>&lt;!&ndash;테이블 및 페이징 포함&ndash;&gt;-->
-        <!--        </div>-->
+            <!--수정전-->
+            <!--    <div class="col-md-9">-->
+            <!--        <div class="row" style="color: #828282;">-->
+            <!--            <div class="col-11">-->
+            <!--                <div class="row">-->
+            <!--                    <div class="col-12">-->
+            <!--                        <form id="sort-form" th:action="@{/user/my/wt/webtoon}" method="get">-->
+            <!--                            <div class="row">-->
+            <!--                                <div class="col-6">-->
+            <!--                                    <div class="row">-->
+            <!--                                        <div class="col-4">-->
+            <!--                                            &lt;!&ndash; 검색 조건 &ndash;&gt;-->
+            <!--                                            <label>-->
+            <!--                                                <select class="form-select px-3" name="searchBy">-->
+            <!--                                                    <option value="title" th:selected="${searchBy == 'title'}">제목</option>-->
+            <!--                                                    <option value="author" th:selected="${searchBy == 'author'}">작가</option>-->
+            <!--                                                    <option value="genre" th:selected="${searchBy == 'genre'}">장르</option>-->
+            <!--                                                    <option value="tag" th:selected="${searchBy == 'tag'}">태그</option>-->
+            <!--                                                </select>-->
+            <!--                                            </label>-->
+            <!--                                        </div>-->
+            <!--                                        <div class="col-6">-->
+            <!--                                            <input class="form-control px-3" type="text" name="searchTerm" placeholder="검색어를 입력하세요" th:value="${searchTerm}" />-->
+            <!--                                        </div>-->
+            <!--                                        <div class="col-2">-->
+            <!--                                            &lt;!&ndash; 검색 버튼 &ndash;&gt;-->
+            <!--                                            <button type="submit">검색</button>-->
+            <!--                                        </div>-->
+            <!--                                    </div>-->
+            <!--                                </div>-->
+            <!--                                <div class="col-2" style="background-color: red;"></div>-->
+            <!--                                <div class="col-4">-->
+            <!--                                    <div class="row justify-content-end">-->
+            <!--                                        &lt;!&ndash; 정렬 조건 &ndash;&gt;-->
+            <!--                                        <label>-->
+            <!--                                            <select class="form-select px-3" name="orderBy" onchange="this.form.submit()">-->
+            <!--                                                <option value="recent" th:selected="${orderBy == 'recent'}">최근저장순</option>-->
+            <!--                                                <option value="oldest" th:selected="${orderBy == 'oldest'}">오래된순</option>-->
+            <!--                                                <option value="views" th:selected="${orderBy == 'views'}">조회수높은순</option>-->
+            <!--                                                <option value="title" th:selected="${orderBy == 'title'}">제목가나다순</option>-->
+            <!--                                            </select>-->
+            <!--                                        </label>-->
+            <!--                                    </div>-->
+            <!--                                </div>-->
+            <!--                            </div> &lt;!&ndash;검색, 소팅 (토글X)&ndash;&gt;-->
+            <!--                        </form>-->
+            <!--                    </div>-->
+            <!--                </div>-->
+            <!--                <div class="row">-->
+            <!--                    <div class="review-list">-->
+            <!--                        <table>-->
+            <!--                            <thead>-->
+            <!--                            <tr>-->
+            <!--                                <th>저장번호</th>-->
+            <!--                                <th>웹툰 번호</th>-->
+            <!--                                <th>유저넘버</th>-->
+            <!--                                <th>웹툰아이디</th>-->
+            <!--                                <th>플렛폼</th>-->
+            <!--                                <th>제목</th>-->
+            <!--                                <th>작가</th>-->
+            <!--                                <th>이미지URL</th>-->
+            <!--                                <th>장르</th>-->
+            <!--                                <th>태그</th>-->
+            <!--                                <th>조회수</th>-->
+            <!--                            </tr>-->
+            <!--                            </thead>-->
+            <!--                            <tbody>-->
+            <!--                            <tr th:each="myWtWebtoon : ${myWtWebtoons}" class="clickable-row"-->
+            <!--                                th:attr="data-href=@{/webtoon/one(-->
+            <!--                webtoon_id=${(myWtWebtoon.platform == 1 ? 'naver_' : myWtWebtoon.platform == 2 ? 'kakao_' : '') + myWtWebtoon.webtoonId},-->
+            <!--                webtoon_name=${myWtWebtoon.webtoonName},-->
+            <!--                author=${myWtWebtoon.author}-->
+            <!--                )}">-->
+            <!--                                <td th:text="${myWtWebtoon.saveNo}">저장번호</td>-->
+            <!--                                <td th:text="${myWtWebtoon.webtoonNo}">웹툰 번호</td>-->
+            <!--                                <td th:text="${myWtWebtoon.userNo}">유저넘버</td>-->
+            <!--                                <td th:text="${myWtWebtoon.webtoonId}">웹툰아이디</td>-->
+            <!--                                <td th:text="${myWtWebtoon.platform}">플렛폼</td>-->
+            <!--                                <td th:text="${myWtWebtoon.webtoonName}">제목</td>-->
+            <!--                                <td th:text="${myWtWebtoon.author}">작가</td>-->
+            <!--                                <td th:text="${myWtWebtoon.thumbnailUrl}">이미지URL</td>-->
+            <!--                                <td th:text="${myWtWebtoon.genre}">장르</td>-->
+            <!--                                <td th:text="${myWtWebtoon.tags}">태그</td>-->
+            <!--                                <td th:text="${myWtWebtoon.count}">조회수</td>-->
+            <!--                            </tr>-->
+            <!--                            </tbody>-->
+            <!--                        </table>-->
+            <!--                        &lt;!&ndash; 페이징 &ndash;&gt;-->
+            <!--                        <th:block th:if="${pages != null}">-->
+            <!--                            <div class="d-flex justify-content-center">-->
+            <!--                                <div class="btn-group">-->
+            <!--                                    <button type="button" class="btn btn-sm previous" th:onclick="|location.href='@{/user/my/wt/webtoon(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage - 1})}'|" th:disabled="${currentPage == 1}">-->
+            <!--                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-left" viewBox="0 0 16 16">-->
+            <!--                                            <path fill-rule="evenodd" d="M11.354 1.646a.5.5 0 0 1 0 .708L5.707 8l5.647 5.646a.5.5 0 0 1-.708.708l-6-6a.5.5 0 0 1 0-.708l6-6a.5.5 0 0 1 .708 0"/>-->
+            <!--                                        </svg>-->
+            <!--                                    </button>-->
+            <!--                                    <th:block th:each="p : ${#numbers.sequence(1, pages)}">-->
+            <!--                                        <button type="button" class="btn btn-sm me-2 pages"-->
+            <!--                                                th:text="${p}" th:onclick="|location.href='@{/user/my/wt/webtoon(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${p})}'|"></button>-->
+            <!--                                    </th:block>-->
+            <!--                                    <button type="button" class="btn btn-sm  next" th:onclick="|location.href='@{/user/my/wt/webtoon(orderBy=${orderBy}, searchBy=${searchBy}, searchTerm=${searchTerm}, page=${currentPage + 1})}'|" th:disabled="${currentPage == pages}">-->
+            <!--                                        <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-chevron-right" viewBox="0 0 16 16">-->
+            <!--                                            <path fill-rule="evenodd" d="M4.646 1.646a.5.5 0 0 1 .708 0l6 6a.5.5 0 0 1 0 .708l-6 6a.5.5 0 0 1-.708-.708L10.293 8 4.646 2.354a.5.5 0 0 1 0-.708"/>-->
+            <!--                                        </svg>-->
+            <!--                                    </button>-->
+            <!--                                </div>-->
+            <!--                            </div>-->
+            <!--                        </th:block>-->
+            <!--                    </div>-->
+            <!--                </div> &lt;!&ndash;테이블과 페이징&ndash;&gt;-->
+            <!--            </div>&lt;!&ndash;테이블 및 페이징 포함&ndash;&gt;-->
+            <!--        </div>-->
 
-        <!--    </div> &lt;!&ndash;본화면&ndash;&gt;-->
-    </div> <!--aside와 본화면-->
+            <!--    </div> &lt;!&ndash;본화면&ndash;&gt;-->
+        </div> <!--aside와 본화면-->
+    </div>
 </div>
 
 <div th:replace="common/footer.html"></div>

--- a/src/main/resources/templates/user/pwfound.html
+++ b/src/main/resources/templates/user/pwfound.html
@@ -29,118 +29,141 @@
 
 <div th:replace="~{common/menubar}"></div>
 <style>
-    .jumbotron {
-    position : relative;
-    background-color : #EEEEEE;
+    html, body {
+        height: 100%;
+        margin: 0;
     }
-    .jumbotron .row {
-    position : absolute;
-    width : 100%;
-    bottom: 0%;
+    body {
+        display: flex;
+        flex-direction: column;
     }
-
-    #loginbox {
-    border-radius : 5%;
-    border-color : #F2F2F2;
+    .content-wrapper {
+        flex: 1 0 auto;
     }
-
-    .logininput {
-    background-color : #FCFCFC;
-    border : none;
-    height : 50px;
+    footer {
+        flex-shrink: 0;
     }
-
-    .logininput::placeholder {
-    color : #BBBBBB;
-    }
-
-     .nav-link {
-            color: #828282;
-    }
-    ul {
-  list-style: none;
-  padding-left : 0px;
-  }
 
 </style>
-<div class="jumbotron">
-    <div class="container">
-        <div class="row">
-            <div class="col-9">
-                <div class="row">
-                    <div class="col-md-3 px-4">
-                        <h3>로그인</h3>
-                    </div>
-                    <div class="col-md-9">
-                        <nav class="navbar navbar-expand-md">
-                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                                <li>-</li>
-                                <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                                <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                                <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                            </ul>
-                        </nav>
+<div class="content-wrapper">
+    <style>
+        .jumbotron {
+        position : relative;
+        background-color : #EEEEEE;
+        }
+        .jumbotron .row {
+        position : absolute;
+        width : 100%;
+        bottom: 0%;
+        }
+
+        #loginbox {
+        border-radius : 5%;
+        border-color : #F2F2F2;
+        }
+
+        .logininput {
+        background-color : #FCFCFC;
+        border : none;
+        height : 50px;
+        }
+
+        .logininput::placeholder {
+        color : #BBBBBB;
+        }
+
+         .nav-link {
+                color: #828282;
+        }
+        ul {
+      list-style: none;
+      padding-left : 0px;
+      }
+
+    </style>
+    <div class="jumbotron">
+        <div class="container">
+            <div class="row">
+                <div class="col-9">
+                    <div class="row">
+                        <div class="col-md-3 px-4">
+                            <h3>로그인</h3>
+                        </div>
+                        <div class="col-md-9">
+                            <nav class="navbar navbar-expand-md">
+                                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                    <li>-</li>
+                                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                                </ul>
+                            </nav>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
-<div class="container" style="padding:0;">
-    <div class="row">
-        <aside class="col-md-3 px-4">
-            <div class="row">
-                <div class="col-1"></div>
-                <div class="col-8">
-                    <div class="panel">
-                        <ul class="list-group">
-                            <li><a th:href="@{/user/login}" class="nav-link px-2" style="color: #03C75A;">로그인</a></li>
-                            <li><a th:href="@{/user/signup}" class="nav-link px-2">회원가입</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-        </aside>
-        <div class="col-md-9">
-            <div class="row justify-content-center">
-                <div class="col-6 border" id="loginbox" style="text-align:center;">
-                    <div class="px-3 py-4" style="text-align: center; ">
-                        <h2>비밀번호 찾기</h2>
-                    </div>
-                    <div class="px-3 py-2" style="text-align:center;">
-                        <a href="/user/findid" style="color: black;">아이디 찾기</a> | <a href="/user/findpw"
-                                                                                     style="color: black;">비밀번호 찾기</a>
-                    </div>
-
-                    <div class="row px-3 py-2">
-                        <div class="col-12">
-                            <hr>
+    <div class="container" style="padding:0;">
+        <div class="row">
+            <aside class="col-md-3 px-4">
+                <div class="row">
+                    <div class="col-1"></div>
+                    <div class="col-8">
+                        <div class="panel">
+                            <ul class="list-group">
+                                <li><a th:href="@{/user/login}" class="nav-link px-2" style="color: #03C75A;">로그인</a>
+                                </li>
+                                <li><a th:href="@{/user/signup}" class="nav-link px-2">회원가입</a></li>
+                            </ul>
                         </div>
                     </div>
+                </div>
+            </aside>
+            <div class="col-md-9">
+                <div class="row justify-content-center">
+                    <div class="col-6 border" id="loginbox" style="text-align:center;">
+                        <div class="px-3 py-4" style="text-align: center; ">
+                            <h2>비밀번호 찾기</h2>
+                        </div>
+                        <div class="px-3 py-2" style="text-align:center;">
+                            <a href="/user/findid" style="color: black;">아이디 찾기</a> | <a href="/user/findpw"
+                                                                                         style="color: black;">비밀번호
+                            찾기</a>
+                        </div>
 
-                    <div th:if="${password != null}">
-                        임시 비밀번호를<br>
-                        회원정보에 등록된 이메일 주소로<br>
-                        발송하였습니다.<br>
-                        메일함을 확인해 주세요.<br>
-                    </div>
-                    <div th:if="${password != null}" class="col-12 pt-3 pb-4">
-                        <button type="submit" class="btn btn-primary btn-block" onclick="location.href='/user/login'"
-                                style="background-color:grey; height:50px;">로그인
-                        </button>
-                    </div>
+                        <div class="row px-3 py-2">
+                            <div class="col-12">
+                                <hr>
+                            </div>
+                        </div>
 
-                    <div th:if="${password == null}" style="padding: 50px 0;">
-                        비밀번호 찾기에 실패했습니다.<br>
-                        다시 시도해주세요.<br>
-                    </div>
-                    <div th:if="${password == null}" class="col-12 pt-3 pb-4">
-                        <button type="submit" class="btn btn-primary btn-block" onclick="location.href='/user/findpw'"
-                                style="background-color:grey; height:50px;">다시 시도해보기
-                        </button>
-                    </div>
+                        <div th:if="${password != null}">
+                            임시 비밀번호를<br>
+                            회원정보에 등록된 이메일 주소로<br>
+                            발송하였습니다.<br>
+                            메일함을 확인해 주세요.<br>
+                        </div>
+                        <div th:if="${password != null}" class="col-12 pt-3 pb-4">
+                            <button type="submit" class="btn btn-primary btn-block"
+                                    onclick="location.href='/user/login'"
+                                    style="background-color:grey; height:50px;">로그인
+                            </button>
+                        </div>
+
+                        <div th:if="${password == null}" style="padding: 50px 0;">
+                            비밀번호 찾기에 실패했습니다.<br>
+                            다시 시도해주세요.<br>
+                        </div>
+                        <div th:if="${password == null}" class="col-12 pt-3 pb-4">
+                            <button type="submit" class="btn btn-primary btn-block"
+                                    onclick="location.href='/user/findpw'"
+                                    style="background-color:grey; height:50px;">다시 시도해보기
+                            </button>
+                        </div>
 
 
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/user/pwfound.html
+++ b/src/main/resources/templates/user/pwfound.html
@@ -123,19 +123,20 @@
                         회원정보에 등록된 이메일 주소로<br>
                         발송하였습니다.<br>
                         메일함을 확인해 주세요.<br>
-                        <!--        (추후 수정예정)찾으시는 비밀번호는<br>-->
-                        <!--        <span th:text="${password}"></span><br>-->
-                        <!--        입니다.<br>-->
+                    </div>
+                    <div th:if="${password != null}" class="col-12 pt-3 pb-4">
+                        <button type="submit" class="btn btn-primary btn-block" onclick="location.href='/user/login'"
+                                style="background-color:grey; height:50px;">로그인
+                        </button>
                     </div>
 
-                    <div th:if="${password == null}">
+                    <div th:if="${password == null}" style="padding: 50px 0;">
                         비밀번호 찾기에 실패했습니다.<br>
                         다시 시도해주세요.<br>
                     </div>
-
-                    <div class="col-12 pt-3 pb-4">
-                        <button type="submit" class="btn btn-primary btn-block" onclick="location.href='/user/login'"
-                                style="background-color:grey; height:50px;">로그인
+                    <div th:if="${password == null}" class="col-12 pt-3 pb-4">
+                        <button type="submit" class="btn btn-primary btn-block" onclick="location.href='/user/findpw'"
+                                style="background-color:grey; height:50px;">다시 시도해보기
                         </button>
                     </div>
 

--- a/src/main/resources/templates/user/pwfound.html
+++ b/src/main/resources/templates/user/pwfound.html
@@ -90,8 +90,8 @@
     <div class="row">
         <aside class="col-md-3 px-4">
             <div class="row">
-                <div class="col-3"></div>
-                <div class="col-6">
+                <div class="col-1"></div>
+                <div class="col-8">
                     <div class="panel">
                         <ul class="list-group">
                             <li><a th:href="@{/user/login}" class="nav-link px-2" style="color: #03C75A;">로그인</a></li>

--- a/src/main/resources/templates/user/pwfound.html
+++ b/src/main/resources/templates/user/pwfound.html
@@ -66,18 +66,22 @@
 <div class="jumbotron">
     <div class="container">
         <div class="row">
-            <div class="col-md-3 px-4">
-                <h3>로그인</h3>
-            </div>
-            <div class="col-md-9">
-                <nav class="navbar navbar-expand-md">
-                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                        <li>-</li>
-                        <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                        <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                        <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                    </ul>
-                </nav>
+            <div class="col-9">
+                <div class="row">
+                    <div class="col-md-3 px-4">
+                        <h3>로그인</h3>
+                    </div>
+                    <div class="col-md-9">
+                        <nav class="navbar navbar-expand-md">
+                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                <li>-</li>
+                                <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                                <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                                <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                            </ul>
+                        </nav>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/user/pwfound.html
+++ b/src/main/resources/templates/user/pwfound.html
@@ -82,55 +82,61 @@
         </div>
     </div>
 </div>
-<div class="row">
-    <aside class="col-md-3 px-4">
-        <div class="row">
-            <div class="col-3"></div>
-            <div class="col-6">
-                <div class="panel">
-                    <ul class="list-group">
-                        <li><a th:href="@{/user/login}" class="nav-link px-2" style="color: #03C75A;">로그인</a></li>
-                        <li><a th:href="@{/user/signup}" class="nav-link px-2">회원가입</a></li>
-                    </ul>
+<div class="container" style="padding:0;">
+    <div class="row">
+        <aside class="col-md-3 px-4">
+            <div class="row">
+                <div class="col-3"></div>
+                <div class="col-6">
+                    <div class="panel">
+                        <ul class="list-group">
+                            <li><a th:href="@{/user/login}" class="nav-link px-2" style="color: #03C75A;">로그인</a></li>
+                            <li><a th:href="@{/user/signup}" class="nav-link px-2">회원가입</a></li>
+                        </ul>
+                    </div>
                 </div>
             </div>
-        </div>
-    </aside>
-    <div class="col-md-9">
-        <div class="row justify-content-center">
-            <div class="col-6 border" id="loginbox" style="text-align:center;">
-                <div class="px-3 py-4" style="text-align: center; ">
-                    <h2>비밀번호 찾기</h2>
+        </aside>
+        <div class="col-md-9">
+            <div class="row justify-content-center">
+                <div class="col-6 border" id="loginbox" style="text-align:center;">
+                    <div class="px-3 py-4" style="text-align: center; ">
+                        <h2>비밀번호 찾기</h2>
+                    </div>
+                    <div class="px-3 py-2" style="text-align:center;">
+                        <a href="/user/findid" style="color: black;">아이디 찾기</a> | <a href="/user/findpw"
+                                                                                     style="color: black;">비밀번호 찾기</a>
+                    </div>
+
+                    <div class="row px-3 py-2">
+                        <div class="col-12">
+                            <hr>
+                        </div>
+                    </div>
+
+                    <div th:if="${password != null}">
+                        임시 비밀번호를<br>
+                        회원정보에 등록된 이메일 주소로<br>
+                        발송하였습니다.<br>
+                        메일함을 확인해 주세요.<br>
+                        <!--        (추후 수정예정)찾으시는 비밀번호는<br>-->
+                        <!--        <span th:text="${password}"></span><br>-->
+                        <!--        입니다.<br>-->
+                    </div>
+
+                    <div th:if="${password == null}">
+                        비밀번호 찾기에 실패했습니다.<br>
+                        다시 시도해주세요.<br>
+                    </div>
+
+                    <div class="col-12 pt-3 pb-4">
+                        <button type="submit" class="btn btn-primary btn-block" onclick="location.href='/user/login'"
+                                style="background-color:grey; height:50px;">로그인
+                        </button>
+                    </div>
+
+
                 </div>
-                <div class="px-3 py-2" style="text-align:center;">
-                    <a href="/user/findid" style="color: black;">아이디 찾기</a> | <a href="/user/findpw" style="color: black;">비밀번호 찾기</a>
-                </div>
-
-                <div class="row px-3 py-2">
-                    <div class="col-12"><hr></div>
-                </div>
-
-                <div th:if="${password != null}">
-                    임시 비밀번호를<br>
-                    회원정보에 등록된 이메일 주소로<br>
-                    발송하였습니다.<br>
-                    메일함을 확인해 주세요.<br>
-                    <!--        (추후 수정예정)찾으시는 비밀번호는<br>-->
-                    <!--        <span th:text="${password}"></span><br>-->
-                    <!--        입니다.<br>-->
-                </div>
-
-                <div th:if="${password == null}">
-                    비밀번호 찾기에 실패했습니다.<br>
-                    다시 시도해주세요.<br>
-                </div>
-
-                <div class="col-12 pt-3 pb-4">
-                    <button type="submit" class="btn btn-primary btn-block" onclick="location.href='/user/login'" style="background-color:grey; height:50px;">로그인</button>
-                </div>
-
-
-
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/user/pwfound.html
+++ b/src/main/resources/templates/user/pwfound.html
@@ -64,19 +64,21 @@
 
 </style>
 <div class="jumbotron">
-    <div class="row">
-        <div class="col-md-3 px-4">
-            <h3>로그인</h3>
-        </div>
-        <div class="col-md-9">
-            <nav class="navbar navbar-expand-md">
-                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                    <li>-</li>
-                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                </ul>
-            </nav>
+    <div class="container">
+        <div class="row">
+            <div class="col-md-3 px-4">
+                <h3>로그인</h3>
+            </div>
+            <div class="col-md-9">
+                <nav class="navbar navbar-expand-md">
+                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                        <li>-</li>
+                        <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                        <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                        <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                    </ul>
+                </nav>
+            </div>
         </div>
     </div>
 </div>

--- a/src/main/resources/templates/user/signup.html
+++ b/src/main/resources/templates/user/signup.html
@@ -354,8 +354,8 @@ function confirmNumber() {
         <div class="row">
             <aside class="col-md-3 px-4">
                 <div class="row">
-                    <div class="col-3"></div>
-                    <div class="col-6">
+                    <div class="col-1"></div>
+                    <div class="col-8">
                         <div class="panel">
                             <ul class="list-group">
                                 <li><a th:href="@{/user/login}" class="nav-link px-2">로그인</a></li>

--- a/src/main/resources/templates/user/signup.html
+++ b/src/main/resources/templates/user/signup.html
@@ -20,6 +20,9 @@
     <!-- Latest compiled JavaScript -->
     <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
 
+    <!--KHG USER VALIDATION JS-->
+    <script src="/js/uservalidation.js"></script>
+
 
     <style>
         .navbar {
@@ -27,268 +30,8 @@
           z-index: 1000;
         }
     </style>
-    <script>
-        //VALIDATION 1) 생년월일
-            function autoFormatDate(input) {
-                // Remove all non-digit characters
-                let date = input.value.replace(/\D/g, '');
-
-                // Apply the formatting based on the length of the input
-                if (date.length > 4 && date.length <= 6) {
-                    date = date.substring(0, 4) + '-' + date.substring(4);
-                } else if (date.length > 6) {
-                    date = date.substring(0, 4) + '-' + date.substring(4, 6) + '-' + date.substring(6, 8);
-                }
-
-                // Update the input value
-                input.value = date;
-            }
-
-            // 생년월일을 검증하는 함수
-            function validateDateOfBirth(dateOfBirth) {
-                const datePattern = /^\d{4}-\d{2}-\d{2}$/; // yyyy-mm-dd 형식
-                return datePattern.test(dateOfBirth);
-            }
-
-        //VALIDATION 2) 연락처
-            function autoFormatPhoneNumber(input) {
-                let phoneNumber = input.value.replace(/\D/g, ''); // Remove all non-digit characters
-                if (phoneNumber.length > 3 && phoneNumber.length <= 7) {
-                    phoneNumber = phoneNumber.substring(0, 3) + '-' + phoneNumber.substring(3);
-                } else if (phoneNumber.length > 7) {
-                    phoneNumber = phoneNumber.substring(0, 3) + '-' + phoneNumber.substring(3, 7) + '-' + phoneNumber.substring(7, 11);
-                }
-                input.value = phoneNumber;
-            }
 
 
-            // 연락처를 검증하는 함수
-            function validatePhoneNumber(phoneNumber) {
-                const phonePattern = /^\d{3}-\d{4}-\d{4}$/; // 000-0000-0000 형식
-                return phonePattern.test(phoneNumber);
-            }
-
-        // 폼 제출 전에 모든 필드를 검증하는 함수
-
-        //VALIDATION 3) 이메일
-            // 이메일 형식을 확인하는 함수
-            function validateEmail(email) {
-                // 이메일 형식을 검증하는 정규 표현식
-                const emailPattern = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-                return emailPattern.test(email);
-            }
-
-            // 폼 제출 전 이메일 형식을 검증하는 함수
-            async function validateForm(event) {
-            event.preventDefault(); // 폼 제출 기본 동작 방지
-
-            const emailInput = document.querySelector('input[name="email"]');
-            const email = emailInput.value;
-
-            // const dateOfBirthInput = document.querySelector('input[name="dateOfBirth"]');
-            // const dateOfBirth = dateOfBirthInput.value;
-
-            const phoneNumberInput = document.querySelector('input[name="contactNumber"]');
-            const phoneNumber = phoneNumberInput.value;
-
-            const termsCheckbox = document.getElementById('termsAgreementCheckbox');
-            var verificationCheckbox = document.getElementById('verificationCheckbox');
-
-
-
-
-            // 이메일 검증
-            if (!validateEmail(email)) {
-                alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
-                event.preventDefault(); // 폼 제출을 막음
-                return;
-            }
-
-            // 생년월일 검증
-            // if (!validateDateOfBirth(dateOfBirth)) {
-            //     alert("생년월일 형식이 올바르지 않습니다. 예: yyyy-mm-dd");
-            //     event.preventDefault(); // 폼 제출을 막음
-            //     return;
-            // }
-
-            // 연락처 검증
-            if (phoneNumber.length > 0 && !validatePhoneNumber(phoneNumber)) {
-                alert("연락처 형식이 올바르지 않습니다. 예: 000-0000-0000");
-                event.preventDefault(); // 폼 제출을 막음
-                return;
-            }
-
-            // 필수 약관동의 검증
-            if (!termsCheckbox.checked) {
-                alert('필수 약관에 동의하지 않았습니다.');
-                event.preventDefault(); // 폼 제출을 막음
-                return;
-            }
-
-            // 이메일 인증 검증
-            if (!verificationCheckbox.checked) {
-                alert('이메일 인증을 완료해야 합니다.');
-                event.preventDefault(); // 폼 제출을 막음
-                return false;
-            }
-
-            // 비밀번호 일치 여부 검증
-            if (!validatePasswordMatch()) {
-            //alert('비밀번호를 다시 확인해주세요.'); // 비밀번호 불일치 시 경고
-            return; // 폼 제출을 막음
-            }
-
-
-
-            // 중복 확인 검사
-            const userId = document.getElementById('userId').value;
-            const nickname = document.getElementById('nickname').value;
-
-            // 닉네임 검증
-            if(!nickname) {
-                alert('닉네임을 입력해 주세요.');
-                return;
-            }
-
-            if (nickname.length < 4) {
-                alert('닉네임의 글자수는 최소 4자입니다.');
-                return;
-            }
-
-            // 아이디는 영문과 숫자의 조합만 가능
-            const validIdPattern = /^[a-zA-Z0-9]+$/;
-            if (!validIdPattern.test(userId)) {
-                alert('아이디는 영문과 숫자의 조합으로만 가능합니다.');
-                return;
-            }
-
-            const isDuplicate = await checkDuplicates(userId, nickname, email);
-
-            if (isDuplicate) {
-            alert('중복체크를 다시 해 주세요.');
-            return; // 폼 제출을 막음
-            }
-
-            // 모든 검증이 성공하면 폼을 제출
-            event.target.submit();
-
-        } //validateForm(event)
-
-        // 비밀번호 일치 여부를 검증하는 함수
-    function validatePasswordMatch() {
-    const password = document.querySelector('input[name="password"]').value;
-    const confirmPassword = document.querySelector('input[name="confirmPassword"]').value;
-
-    if (!password || !confirmPassword) {
-        alert('비밀번호와 비밀번호 확인란 모두 입력해 주세요.');
-        return false; // 비밀번호가 입력되지 않으면 폼 제출을 막음
-    }
-
-    if (password !== confirmPassword) {
-        alert('비밀번호를 다시 확인해주세요.');
-        return false; // 비밀번호가 일치하지 않으면 폼 제출을 막음
-    }
-
-    return true; // 비밀번호가 일치하고 둘 다 입력되었으면 폼 제출을 진행
-}
-
-
-async function checkDuplicates(userId, nickname, email) {
-    try {
-        const responses = await Promise.all([
-            fetch(`/user/checkIdDuplicate?userId=${encodeURIComponent(userId)}`),
-            fetch(`/user/checkNicknameDuplicate?nickname=${encodeURIComponent(nickname)}`),
-            fetch(`/user/checkEmailDuplicate?email=${encodeURIComponent(email)}`)
-        ]);
-
-        const [idResponse, nicknameResponse, emailResponse] = await Promise.all(responses.map(response => response.json()));
-
-        if (idResponse.isDuplicate || nicknameResponse.isDuplicate || emailResponse.isDuplicate) {
-            return true; // 중복이 발견되면 true 반환
-        }
-
-        return false; // 중복이 없으면 false 반환
-    } catch (error) {
-        console.error('Error checking duplicates:', error);
-        return true; // 에러 발생 시 중복 체크 실패로 간주
-    }
-} //checkDuplicates
-
-
-    </script>
-    <script type="text/javascript">
-        function sendNumber() {
-    checkEmailDuplicatePromise()
-        .then(() => {
-            // 이메일 중복이 확인되지 않았을 때만 AJAX 요청 실행
-            $.ajax({
-                url: "/user/mail/mailSend",
-                type: "post",
-                contentType: "application/json; charset=UTF-8",
-                dataType: "json",
-                data: JSON.stringify({ "mail": $("#email").val() }),
-                success: function(response) {
-                    if (response === true) {
-                        alert("인증번호를 발송했습니다. 메일을 확인해주세요.");
-                        // 인증하기 버튼 바꾸기
-                        $("#emailVerifyButton").text("다시 전송");
-                    } else {
-                        alert("메일 발송에 실패했습니다");
-                    }
-                },
-                error: function(xhr, status, error) {
-                    alert("요청 처리 중 오류가 발생했습니다: " + error);
-                }
-            });
-        })
-        .catch(() => {
-            // 중복된 이메일이거나, 오류가 발생했을 경우 AJAX 요청이 실행되지 않음
-        });
-}
-
-
- function confirmNumber() {
-     $.ajax({
-         url: "/user/mail/mailCheck",
-         type: "get",
-         dataType: "json",
-         data: { "userNumber": $("#mailNumber").val() },
-         success: function(response) {
-             if (response === true) {
-                 // 인증이 성공한 경우 hidden checkbox를 체크
-                 $("#verificationCheckbox").prop("checked", true);
-                 // 이메일 입력 박스를 readonly로 설정
-                 $("#email").prop("readonly", true);
-                 alert("인증되었습니다.");
-                 // 인증하기 버튼 바꾸기
-                 $("#emailVerifyButton").text("인증완료");
-                 // 인증번호란 readonly로 설정
-                 $("#mailNumber").prop("readonly", true);
-                 //버튼의 색 바꾸기 #EEEEEE
-                 $("#emailVerifyButton").css("background-color", "grey");
-                 // 인증하기 버튼 비활성화
-                 $("#emailVerifyButton").prop("disabled", true);
-                 // 인증확인 버튼 인증완료로 바꾸기
-                 $("#emailConfirmButton").text("인증완료");
-                 // 인증확인 버튼 색 바꾸기
-                 $("#emailConfirmButton").css("background-color", "grey");
-                 // 인증확인 버튼 비활성화
-                 $("#emailConfirmButton").prop("disabled", true);
-             } else {
-                 // 인증이 실패한 경우
-                 $("#verificationCheckbox").prop("checked", false);
-                 alert("인증번호가 일치하지 않습니다.");
-             }
-         },
-         error: function(jqXHR, textStatus, errorThrown) {
-             console.error("인증 요청 실패:", textStatus, errorThrown);
-             alert("인증 과정 중 오류가 발생했습니다.");
-         }
-     });
- }
-
-
-    </script>
 </head>
 <body>
 
@@ -383,7 +126,7 @@ async function checkDuplicates(userId, nickname, email) {
                         <div class="col-md-9">
                             <nav class="navbar navbar-expand-md">
                                 <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                                    <li>-</li>
+                                    <li style="color: #828282;">툰게더 회원 서비스 이용을 위해 다음 항목을 입력 또는 체크해주세요.</li>
                                     <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
                                     <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
                                     <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
@@ -413,99 +156,7 @@ async function checkDuplicates(userId, nickname, email) {
                         </div>
                     </div>
                 </aside>
-                <script>
-                    // id available check
-                    function checkIdDuplicate() {
-                        const userId = document.getElementById('userId').value;
 
-                        if(!userId) {
-                            alert('아이디를 입력해 주세요.');
-                            return;
-                        }
-
-                        if (userId.length < 4) {
-                            alert('아이디의 글자수는 최소 4자입니다.');
-                            return;
-                        }
-
-                        // 아이디는 영문과 숫자의 조합만 가능
-                        const validIdPattern = /^[a-zA-Z0-9]+$/;
-                        if (!validIdPattern.test(userId)) {
-                            alert('아이디는 영문과 숫자의 조합으로만 가능합니다.');
-                            return;
-                        }
-
-                        fetch(`/user/checkIdDuplicate?userId=${encodeURIComponent(userId)}`)
-                            .then(response => response.json())
-                            .then(data => {
-                                if (data.isDuplicate) alert('이미 존재하는 아이디입니다. ');
-                                else alert('사용 가능한 아이디입니다.');
-                            })
-                            .catch(error => {
-                                console.error('Error: ', error);
-                            });
-                    } //checkIdDuplicate()
-
-                    // nickname available check
-                    function checkNicknameDuplicate() {
-                        const nickname = document.getElementById('nickname').value;
-
-                        if(!nickname) {
-                            alert('닉네임을 입력해 주세요.');
-                            return;
-                        }
-
-                        if (nickname.length < 4) {
-                            alert('닉네임의 글자수는 최소 4자입니다.');
-                            return;
-                        }
-
-                        fetch(`/user/checkNicknameDuplicate?nickname=${encodeURIComponent(nickname)}`)
-                            .then(response => response.json())
-                            .then(data => {
-                                if (data.isDuplicate) alert('이미 사용 중인 닉네임입니다.');
-                                else alert('사용 가능한 닉네임입니다.');
-                            })
-                            .catch(error => {
-                                console.error('Error: ', error);
-                            });
-                    } //checkNicknameDuplicate()
-
-                    // email available check
-                    function checkEmailDuplicatePromise() {
-                        return new Promise((resolve, reject) => {
-                            const email = document.getElementById('email').value;
-
-                            if (!email) {
-                                alert('이메일을 입력해 주세요.');
-                                reject(); // 이메일이 없으면 Promise를 reject
-                                return;
-                            }
-
-                            // 이메일 검증
-                            if (!validateEmail(email)) {
-                                alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
-                                reject(); // 이메일 형식이 올바르지 않으면 Promise를 reject
-                                return;
-                            }
-
-                            fetch(`/user/checkEmailDuplicate?email=${encodeURIComponent(email)}`)
-                                .then(response => response.json())
-                                .then(data => {
-                                    if (data.isDuplicate) {
-                                        alert('이미 등록된 이메일입니다.');
-                                        reject(); // 중복된 이메일일 경우 Promise를 reject
-                                    } else {
-                                        resolve(); // 이메일이 중복되지 않으면 Promise를 resolve
-                                    }
-                                })
-                                .catch(error => {
-                                    console.error('Error: ', error);
-                                    reject(); // 오류 발생 시 Promise를 reject
-                                });
-                        });
-                    }
-                </script>
                 <div class="col-md-9">
                     <div class="row justify-content-start" style="color: #828282;">
                         <div class="col-8 p-3" id="loginbox">
@@ -637,7 +288,7 @@ async function checkDuplicates(userId, nickname, email) {
                                         이메일 <span class="required-star">*</span>
                                     </div>
                                     <div class="col-6">
-                                        <input id="email" class="form-control" type="text" th:field="*{email}"/>
+                                        <input id="email" class="form-control" type="text" th:field="*{email}" minlength="5" maxlength="100"/>
                                     </div>
                                     <div class="col-3">
                                         <!--                            <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;" onclick="checkEmailDuplicate()">중복확인</button>-->
@@ -652,7 +303,7 @@ async function checkDuplicates(userId, nickname, email) {
                                     </div>
                                     <div class="col-6">
                                         <input id="mailNumber" class="form-control" type="text"
-                                               th:field="*{mailNumber}"/>
+                                               th:field="*{mailNumber}" maxlength="6"/>
                                         <!-- 실제로는 보이지 않지만 폼에 포함될 hidden checkbox -->
                                         <input type="checkbox" id="verificationCheckbox" name="verificationCheckbox"
                                                style="display:none;"/>

--- a/src/main/resources/templates/user/signup.html
+++ b/src/main/resources/templates/user/signup.html
@@ -218,29 +218,33 @@ async function checkDuplicates(userId, nickname, email) {
     </script>
     <script type="text/javascript">
         function sendNumber() {
-     // 이메일 중복 체크 함수
-     checkEmailDuplicate();
-
-     $.ajax({
-         url: "/user/mail/mailSend",
-         type: "post",
-         contentType: "application/json; charset=UTF-8",
-         dataType: "json",
-         data: JSON.stringify({ "mail": $("#email").val() }),
-         success: function(response) {
-             if (response === true) {
-                 alert("인증번호를 발송했습니다. 메일을 확인해주세요.");
-                 // 인증하기 버튼 바꾸기
-                 $("#emailVerifyButton").text("다시 전송");
-             } else {
-                 alert("메일 발송에 실패했습니다");
-             }
-         },
-         error: function(xhr, status, error) {
-             alert("요청 처리 중 오류가 발생했습니다: " + error);
-         }
-     });
- }
+    checkEmailDuplicatePromise()
+        .then(() => {
+            // 이메일 중복이 확인되지 않았을 때만 AJAX 요청 실행
+            $.ajax({
+                url: "/user/mail/mailSend",
+                type: "post",
+                contentType: "application/json; charset=UTF-8",
+                dataType: "json",
+                data: JSON.stringify({ "mail": $("#email").val() }),
+                success: function(response) {
+                    if (response === true) {
+                        alert("인증번호를 발송했습니다. 메일을 확인해주세요.");
+                        // 인증하기 버튼 바꾸기
+                        $("#emailVerifyButton").text("다시 전송");
+                    } else {
+                        alert("메일 발송에 실패했습니다");
+                    }
+                },
+                error: function(xhr, status, error) {
+                    alert("요청 처리 중 오류가 발생했습니다: " + error);
+                }
+            });
+        })
+        .catch(() => {
+            // 중복된 이메일이거나, 오류가 발생했을 경우 AJAX 요청이 실행되지 않음
+        });
+}
 
 
  function confirmNumber() {
@@ -468,30 +472,39 @@ async function checkDuplicates(userId, nickname, email) {
                     } //checkNicknameDuplicate()
 
                     // email available check
-                    function checkEmailDuplicate() {
-                        const email = document.getElementById('email').value;
+                    function checkEmailDuplicatePromise() {
+                        return new Promise((resolve, reject) => {
+                            const email = document.getElementById('email').value;
 
-                        if(!email) {
-                            alert('이메일을 입력해 주세요.');
-                            return;
-                        }
+                            if (!email) {
+                                alert('이메일을 입력해 주세요.');
+                                reject(); // 이메일이 없으면 Promise를 reject
+                                return;
+                            }
 
-                        // 이메일 검증
-                        if (!validateEmail(email)) {
-                            alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
-                            return;
-                        }
+                            // 이메일 검증
+                            if (!validateEmail(email)) {
+                                alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
+                                reject(); // 이메일 형식이 올바르지 않으면 Promise를 reject
+                                return;
+                            }
 
-                        fetch(`/user/checkEmailDuplicate?email=${encodeURIComponent(email)}`)
-                            .then(response => response.json())
-                            .then(data => {
-                                if (data.isDuplicate) alert('이미 등록된 이메일입니다.');
-                                //else alert('등록 가능한 이메일입니다.');
-                            })
-                            .catch(error => {
-                                console.error('Error: ', error);
-                            });
-                    } //checkEmailDuplicate()
+                            fetch(`/user/checkEmailDuplicate?email=${encodeURIComponent(email)}`)
+                                .then(response => response.json())
+                                .then(data => {
+                                    if (data.isDuplicate) {
+                                        alert('이미 등록된 이메일입니다.');
+                                        reject(); // 중복된 이메일일 경우 Promise를 reject
+                                    } else {
+                                        resolve(); // 이메일이 중복되지 않으면 Promise를 resolve
+                                    }
+                                })
+                                .catch(error => {
+                                    console.error('Error: ', error);
+                                    reject(); // 오류 발생 시 Promise를 reject
+                                });
+                        });
+                    }
                 </script>
                 <div class="col-md-9">
                     <div class="row justify-content-start" style="color: #828282;">

--- a/src/main/resources/templates/user/signup.html
+++ b/src/main/resources/templates/user/signup.html
@@ -217,47 +217,71 @@ async function checkDuplicates(userId, nickname, email) {
 
     </script>
     <script type="text/javascript">
-        function sendNumber(){
-        //먼저 이메일 중복체크부터
-        checkEmailDuplicate();
-    $.ajax({
-        url:"/user/mail/mailSend",
-        type:"post",
-        contentType: "application/json; charset=UTF-8",
-        dataType:"json",
-        data:JSON.stringify({ "mail": $("#email").val() }),
-        success: function(data){
-            alert("인증번호를 발송했습니다. 메일을 확인해주세요.");
-        },
-        }
-    );
-}
+        function sendNumber() {
+     // 이메일 중복 체크 함수
+     checkEmailDuplicate();
 
-function confirmNumber() {
-    $.ajax({
-        url: "/user/mail/mailCheck",
-        type: "get",
-        dataType: "json",
-        data: { "userNumber": $("#mailNumber").val() },
-        success: function(response) {
-            if (response === true) {
-                // 인증이 성공한 경우 hidden checkbox를 체크
-                $("#verificationCheckbox").prop("checked", true);
-                // 이메일 입력 박스를 readonly로 설정
-                $("#email").prop("readonly", true);
-                alert("인증되었습니다.");
-            } else {
-                // 인증이 실패한 경우
-                $("#verificationCheckbox").prop("checked", false);
-                alert("인증번호가 일치하지 않습니다.");
-            }
-        },
-        error: function(jqXHR, textStatus, errorThrown) {
-            console.error("인증 요청 실패:", textStatus, errorThrown);
-            alert("인증 과정 중 오류가 발생했습니다.");
-        }
-    });
-}
+     $.ajax({
+         url: "/user/mail/mailSend",
+         type: "post",
+         contentType: "application/json; charset=UTF-8",
+         dataType: "json",
+         data: JSON.stringify({ "mail": $("#email").val() }),
+         success: function(response) {
+             if (response === true) {
+                 alert("인증번호를 발송했습니다. 메일을 확인해주세요.");
+                 // 인증하기 버튼 바꾸기
+                 $("#emailVerifyButton").text("다시 전송");
+             } else {
+                 alert("메일 발송에 실패했습니다");
+             }
+         },
+         error: function(xhr, status, error) {
+             alert("요청 처리 중 오류가 발생했습니다: " + error);
+         }
+     });
+ }
+
+
+ function confirmNumber() {
+     $.ajax({
+         url: "/user/mail/mailCheck",
+         type: "get",
+         dataType: "json",
+         data: { "userNumber": $("#mailNumber").val() },
+         success: function(response) {
+             if (response === true) {
+                 // 인증이 성공한 경우 hidden checkbox를 체크
+                 $("#verificationCheckbox").prop("checked", true);
+                 // 이메일 입력 박스를 readonly로 설정
+                 $("#email").prop("readonly", true);
+                 alert("인증되었습니다.");
+                 // 인증하기 버튼 바꾸기
+                 $("#emailVerifyButton").text("인증완료");
+                 // 인증번호란 readonly로 설정
+                 $("#mailNumber").prop("readonly", true);
+                 //버튼의 색 바꾸기 #EEEEEE
+                 $("#emailVerifyButton").css("background-color", "grey");
+                 // 인증하기 버튼 비활성화
+                 $("#emailVerifyButton").prop("disabled", true);
+                 // 인증확인 버튼 인증완료로 바꾸기
+                 $("#emailConfirmButton").text("인증완료");
+                 // 인증확인 버튼 색 바꾸기
+                 $("#emailConfirmButton").css("background-color", "grey");
+                 // 인증확인 버튼 비활성화
+                 $("#emailConfirmButton").prop("disabled", true);
+             } else {
+                 // 인증이 실패한 경우
+                 $("#verificationCheckbox").prop("checked", false);
+                 alert("인증번호가 일치하지 않습니다.");
+             }
+         },
+         error: function(jqXHR, textStatus, errorThrown) {
+             console.error("인증 요청 실패:", textStatus, errorThrown);
+             alert("인증 과정 중 오류가 발생했습니다.");
+         }
+     });
+ }
 
 
     </script>
@@ -581,7 +605,7 @@ function confirmNumber() {
                                 </div>
                                 <div class="col-3">
                                     <!--                            <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;" onclick="checkEmailDuplicate()">중복확인</button>-->
-                                    <button type="button" class="btn btn-primary btn-block"
+                                    <button id="emailVerifyButton" type="button" class="btn btn-primary btn-block"
                                             style="background-color:#03C75A;" onclick="sendNumber()">인증하기
                                     </button>
                                 </div>
@@ -597,7 +621,7 @@ function confirmNumber() {
                                            style="display:none;"/>
                                 </div>
                                 <div class="col-3">
-                                    <button type="button" class="btn btn-primary btn-block"
+                                    <button id="emailConfirmButton" type="button" class="btn btn-primary btn-block"
                                             style="background-color:#03C75A;" onclick="confirmNumber()">인증확인
                                     </button>
                                 </div>

--- a/src/main/resources/templates/user/signup.html
+++ b/src/main/resources/templates/user/signup.html
@@ -346,262 +346,289 @@ function confirmNumber() {
     </div>
 </div>
 <div class="container" style="padding:0;">
-    <div class="row">
-        <aside class="col-md-3 px-4">
-            <div class="row">
-                <div class="col-3"></div>
-                <div class="col-6">
-                    <div class="panel">
-                        <ul class="list-group">
-                            <li><a th:href="@{/user/login}" class="nav-link px-2">로그인</a></li>
-                            <li><a th:href="@{/user/signup}" class="nav-link px-2" style="color: #03C75A;">회원가입</a></li>
-                        </ul>
+    <div class="container" style="padding:0;">
+        <div class="row">
+            <aside class="col-md-3 px-4">
+                <div class="row">
+                    <div class="col-3"></div>
+                    <div class="col-6">
+                        <div class="panel">
+                            <ul class="list-group">
+                                <li><a th:href="@{/user/login}" class="nav-link px-2">로그인</a></li>
+                                <li><a th:href="@{/user/signup}" class="nav-link px-2" style="color: #03C75A;">회원가입</a>
+                                </li>
+                            </ul>
+                        </div>
                     </div>
                 </div>
-            </div>
-        </aside>
-        <script>
-            // id available check
-            function checkIdDuplicate() {
-                const userId = document.getElementById('userId').value;
+            </aside>
+            <script>
+                // id available check
+                function checkIdDuplicate() {
+                    const userId = document.getElementById('userId').value;
 
-                if(!userId) {
-                    alert('아이디를 입력해 주세요.');
-                    return;
-                }
+                    if(!userId) {
+                        alert('아이디를 입력해 주세요.');
+                        return;
+                    }
 
-                if (userId.length < 4) {
-                    alert('아이디의 글자수는 최소 4자입니다.');
-                    return;
-                }
+                    if (userId.length < 4) {
+                        alert('아이디의 글자수는 최소 4자입니다.');
+                        return;
+                    }
 
-                // 아이디는 영문과 숫자의 조합만 가능
-                const validIdPattern = /^[a-zA-Z0-9]+$/;
-                if (!validIdPattern.test(userId)) {
-                    alert('아이디는 영문과 숫자의 조합으로만 가능합니다.');
-                    return;
-                }
+                    // 아이디는 영문과 숫자의 조합만 가능
+                    const validIdPattern = /^[a-zA-Z0-9]+$/;
+                    if (!validIdPattern.test(userId)) {
+                        alert('아이디는 영문과 숫자의 조합으로만 가능합니다.');
+                        return;
+                    }
 
-                fetch(`/user/checkIdDuplicate?userId=${encodeURIComponent(userId)}`)
-                    .then(response => response.json())
-                    .then(data => {
-                        if (data.isDuplicate) alert('이미 존재하는 아이디입니다. ');
-                        else alert('사용 가능한 아이디입니다.');
-                    })
-                    .catch(error => {
-                        console.error('Error: ', error);
-                    });
-            } //checkIdDuplicate()
+                    fetch(`/user/checkIdDuplicate?userId=${encodeURIComponent(userId)}`)
+                        .then(response => response.json())
+                        .then(data => {
+                            if (data.isDuplicate) alert('이미 존재하는 아이디입니다. ');
+                            else alert('사용 가능한 아이디입니다.');
+                        })
+                        .catch(error => {
+                            console.error('Error: ', error);
+                        });
+                } //checkIdDuplicate()
 
-            // nickname available check
-            function checkNicknameDuplicate() {
-                const nickname = document.getElementById('nickname').value;
+                // nickname available check
+                function checkNicknameDuplicate() {
+                    const nickname = document.getElementById('nickname').value;
 
-                if(!nickname) {
-                    alert('닉네임을 입력해 주세요.');
-                    return;
-                }
+                    if(!nickname) {
+                        alert('닉네임을 입력해 주세요.');
+                        return;
+                    }
 
-                if (nickname.length < 4) {
-                    alert('닉네임의 글자수는 최소 4자입니다.');
-                    return;
-                }
+                    if (nickname.length < 4) {
+                        alert('닉네임의 글자수는 최소 4자입니다.');
+                        return;
+                    }
 
-                fetch(`/user/checkNicknameDuplicate?nickname=${encodeURIComponent(nickname)}`)
-                    .then(response => response.json())
-                    .then(data => {
-                        if (data.isDuplicate) alert('이미 사용 중인 닉네임입니다.');
-                        else alert('사용 가능한 닉네임입니다.');
-                    })
-                    .catch(error => {
-                        console.error('Error: ', error);
-                    });
-            } //checkNicknameDuplicate()
+                    fetch(`/user/checkNicknameDuplicate?nickname=${encodeURIComponent(nickname)}`)
+                        .then(response => response.json())
+                        .then(data => {
+                            if (data.isDuplicate) alert('이미 사용 중인 닉네임입니다.');
+                            else alert('사용 가능한 닉네임입니다.');
+                        })
+                        .catch(error => {
+                            console.error('Error: ', error);
+                        });
+                } //checkNicknameDuplicate()
 
-            // email available check
-            function checkEmailDuplicate() {
-                const email = document.getElementById('email').value;
+                // email available check
+                function checkEmailDuplicate() {
+                    const email = document.getElementById('email').value;
 
-                if(!email) {
-                    alert('이메일을 입력해 주세요.');
-                    return;
-                }
+                    if(!email) {
+                        alert('이메일을 입력해 주세요.');
+                        return;
+                    }
 
-                // 이메일 검증
-                if (!validateEmail(email)) {
-                    alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
-                    return;
-                }
+                    // 이메일 검증
+                    if (!validateEmail(email)) {
+                        alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
+                        return;
+                    }
 
-                fetch(`/user/checkEmailDuplicate?email=${encodeURIComponent(email)}`)
-                    .then(response => response.json())
-                    .then(data => {
-                        if (data.isDuplicate) alert('이미 등록된 이메일입니다.');
-                        //else alert('등록 가능한 이메일입니다.');
-                    })
-                    .catch(error => {
-                        console.error('Error: ', error);
-                    });
-            } //checkEmailDuplicate()
-        </script>
-        <div class="col-md-9">
-            <div class="row justify-content-start" style="color: #828282;">
-                <div class="col-8 p-3" id="loginbox">
-                    <form th:action="@{/user/signup}" th:object="${user}" method="post" onsubmit="validateForm(event)">
-                        <div class="row p-2">
-                            <div class="col-3">
-                                아이디 <span class="required-star">*</span>
-                            </div>
-                            <div class="col-6">
-                                <input class="form-control px-3" type="text" th:field="*{userId}" maxlength="20" minlength="4"/>
-                            </div>
-                            <div class="col-3">
-                                <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;" onclick="checkIdDuplicate()">중복확인</button>
-                            </div>
-                        </div>
-                        <div class="row p-2">
-                            <div class="col-3">
-                                비밀번호 <span class="required-star">*</span>
-                            </div>
-                            <div class="col-6">
-                                <input class="form-control px-3" type="password" th:field="*{password}" maxlength="30" minlength="8"/>
-                            </div>
-                            <div class="col-3">
-                            </div>
-                        </div>
-                        <div class="row p-2">
-                            <div class="col-3">
-                                비밀번호 확인 <span class="required-star">*</span>
-                            </div>
-                            <div class="col-6">
-                                <input class="form-control px-3" type="password" th:field="*{confirmPassword}" maxlength="30" minlength="8"/>
-                            </div>
-                            <div class="col-3">
-                            </div>
-                        </div>
-                        <div class="row p-2">
-                            <div class="col-3">
-                                닉네임 <span class="required-star">*</span>
-                            </div>
-                            <div class="col-6">
-                                <input class="form-control px-3" type="text" th:field="*{nickname}" maxlength="20" minlength="4"/>
-                            </div>
-                            <div class="col-3">
-                                <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;" onclick="checkNicknameDuplicate()">중복확인</button>
-                            </div>
-                        </div>
-                        <div class="row p-2">
-                            <div class="col-3">
-                                연락처
-                            </div>
-                            <div class="col-6">
-                                <input class="form-control px-3 logininput" type="text" th:field="*{contactNumber}" oninput="autoFormatPhoneNumber(this)" placeholder="000-0000-0000"/>
-                            </div>
-                            <div class="col-3">
-                            </div>
-                        </div>
-                        <div class="row p-2">
-                            <div class="col-3">
-                                성별
-                            </div>
-                            <div class="col-6">
-                                <select class="form-select px-3" th:field="*{gender}">
-                                    <option value="P">성별을 공개하지 않습니다</option>
-                                    <option value="F">여</option>
-                                    <option value="M">남</option>
-                                </select>
-                            </div>
-                            <div class="col-3">
-                            </div>
-                        </div>
-                        <div class="row p-2">
-                            <div class="col-3">
-                                <!-- 생년월일을 연도, 월, 일로 나누어 드롭다운 박스 형태로 입력 -->
-                                생년월일
-                            </div>
-                            <div class="col-6">
-                                <div class="row">
-                                    <div class="col-4">
-                                        <select class="form-select" id="year" name="year" th:field="*{year}" style="text-align:center;">
-                                            <option th:each="y : ${years}" th:value="${y}" th:text="${y}">연도</option>
-                                        </select>
-                                    </div>
-                                    <div class="col-4">
-                                        <select class="form-select" id="month" name="month" th:field="*{month}" style="text-align:center;">
-                                            <option th:each="m : ${months}" th:value="${m}" th:text="${m}">월</option>
-                                        </select>
-                                    </div>
-                                    <div class="col-4">
-                                        <select class="form-select" id="day" name="day" th:field="*{day}" style="text-align:center;">
-                                            <option th:each="d : ${days}" th:value="${d}" th:text="${d}">일</option>
-                                        </select>
-                                    </div>
+                    fetch(`/user/checkEmailDuplicate?email=${encodeURIComponent(email)}`)
+                        .then(response => response.json())
+                        .then(data => {
+                            if (data.isDuplicate) alert('이미 등록된 이메일입니다.');
+                            //else alert('등록 가능한 이메일입니다.');
+                        })
+                        .catch(error => {
+                            console.error('Error: ', error);
+                        });
+                } //checkEmailDuplicate()
+            </script>
+            <div class="col-md-9">
+                <div class="row justify-content-start" style="color: #828282;">
+                    <div class="col-8 p-3" id="loginbox">
+                        <form th:action="@{/user/signup}" th:object="${user}" method="post"
+                              onsubmit="validateForm(event)">
+                            <div class="row p-2">
+                                <div class="col-3">
+                                    아이디 <span class="required-star">*</span>
+                                </div>
+                                <div class="col-6">
+                                    <input class="form-control px-3" type="text" th:field="*{userId}" maxlength="20"
+                                           minlength="4"/>
+                                </div>
+                                <div class="col-3">
+                                    <button type="button" class="btn btn-primary btn-block"
+                                            style="background-color:#03C75A;" onclick="checkIdDuplicate()">중복확인
+                                    </button>
                                 </div>
                             </div>
-                            <div class="col-3">
+                            <div class="row p-2">
+                                <div class="col-3">
+                                    비밀번호 <span class="required-star">*</span>
+                                </div>
+                                <div class="col-6">
+                                    <input class="form-control px-3" type="password" th:field="*{password}"
+                                           maxlength="30" minlength="8"/>
+                                </div>
+                                <div class="col-3">
+                                </div>
                             </div>
-                        </div>
-                        <div class="row p-2">
-                            <div class="col-3">
-                                실명
+                            <div class="row p-2">
+                                <div class="col-3">
+                                    비밀번호 확인 <span class="required-star">*</span>
+                                </div>
+                                <div class="col-6">
+                                    <input class="form-control px-3" type="password" th:field="*{confirmPassword}"
+                                           maxlength="30" minlength="8"/>
+                                </div>
+                                <div class="col-3">
+                                </div>
                             </div>
-                            <div class="col-6">
-                                <input class="form-control" type="text" th:field="*{realName}" maxlength="10"/>
+                            <div class="row p-2">
+                                <div class="col-3">
+                                    닉네임 <span class="required-star">*</span>
+                                </div>
+                                <div class="col-6">
+                                    <input class="form-control px-3" type="text" th:field="*{nickname}" maxlength="20"
+                                           minlength="4"/>
+                                </div>
+                                <div class="col-3">
+                                    <button type="button" class="btn btn-primary btn-block"
+                                            style="background-color:#03C75A;" onclick="checkNicknameDuplicate()">중복확인
+                                    </button>
+                                </div>
                             </div>
-                            <div class="col-3">
+                            <div class="row p-2">
+                                <div class="col-3">
+                                    연락처
+                                </div>
+                                <div class="col-6">
+                                    <input class="form-control px-3 logininput" type="text" th:field="*{contactNumber}"
+                                           oninput="autoFormatPhoneNumber(this)" placeholder="000-0000-0000"/>
+                                </div>
+                                <div class="col-3">
+                                </div>
                             </div>
-                        </div>
-                        <div class="row p-2">
-                            <div class="col-3">
-                                이메일 <span class="required-star">*</span>
+                            <div class="row p-2">
+                                <div class="col-3">
+                                    성별
+                                </div>
+                                <div class="col-6">
+                                    <select class="form-select px-3" th:field="*{gender}">
+                                        <option value="P">성별을 공개하지 않습니다</option>
+                                        <option value="F">여</option>
+                                        <option value="M">남</option>
+                                    </select>
+                                </div>
+                                <div class="col-3">
+                                </div>
                             </div>
-                            <div class="col-6">
-                                <input id="email" class="form-control" type="text" th:field="*{email}"/>
+                            <div class="row p-2">
+                                <div class="col-3">
+                                    <!-- 생년월일을 연도, 월, 일로 나누어 드롭다운 박스 형태로 입력 -->
+                                    생년월일
+                                </div>
+                                <div class="col-6">
+                                    <div class="row">
+                                        <div class="col-4">
+                                            <select class="form-select" id="year" name="year" th:field="*{year}"
+                                                    style="text-align:center;">
+                                                <option th:each="y : ${years}" th:value="${y}" th:text="${y}">연도
+                                                </option>
+                                            </select>
+                                        </div>
+                                        <div class="col-4">
+                                            <select class="form-select" id="month" name="month" th:field="*{month}"
+                                                    style="text-align:center;">
+                                                <option th:each="m : ${months}" th:value="${m}" th:text="${m}">월
+                                                </option>
+                                            </select>
+                                        </div>
+                                        <div class="col-4">
+                                            <select class="form-select" id="day" name="day" th:field="*{day}"
+                                                    style="text-align:center;">
+                                                <option th:each="d : ${days}" th:value="${d}" th:text="${d}">일</option>
+                                            </select>
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="col-3">
+                                </div>
                             </div>
-                            <div class="col-3">
-                                <!--                            <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;" onclick="checkEmailDuplicate()">중복확인</button>-->
-                                <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;" onclick="sendNumber()">인증하기</button>
+                            <div class="row p-2">
+                                <div class="col-3">
+                                    실명
+                                </div>
+                                <div class="col-6">
+                                    <input class="form-control" type="text" th:field="*{realName}" maxlength="10"/>
+                                </div>
+                                <div class="col-3">
+                                </div>
                             </div>
-                        </div>
-                        <div class="row p-2">
-                            <div class="col-3">
-                                인증번호 입력 <span class="required-star">*</span>
+                            <div class="row p-2">
+                                <div class="col-3">
+                                    이메일 <span class="required-star">*</span>
+                                </div>
+                                <div class="col-6">
+                                    <input id="email" class="form-control" type="text" th:field="*{email}"/>
+                                </div>
+                                <div class="col-3">
+                                    <!--                            <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;" onclick="checkEmailDuplicate()">중복확인</button>-->
+                                    <button type="button" class="btn btn-primary btn-block"
+                                            style="background-color:#03C75A;" onclick="sendNumber()">인증하기
+                                    </button>
+                                </div>
                             </div>
-                            <div class="col-6">
-                                <input id="mailNumber" class="form-control" type="text" th:field="*{mailNumber}"/>
-                                <!-- 실제로는 보이지 않지만 폼에 포함될 hidden checkbox -->
-                                <input type="checkbox" id="verificationCheckbox" name="verificationCheckbox" style="display:none;"/>
+                            <div class="row p-2">
+                                <div class="col-3">
+                                    인증번호 입력 <span class="required-star">*</span>
+                                </div>
+                                <div class="col-6">
+                                    <input id="mailNumber" class="form-control" type="text" th:field="*{mailNumber}"/>
+                                    <!-- 실제로는 보이지 않지만 폼에 포함될 hidden checkbox -->
+                                    <input type="checkbox" id="verificationCheckbox" name="verificationCheckbox"
+                                           style="display:none;"/>
+                                </div>
+                                <div class="col-3">
+                                    <button type="button" class="btn btn-primary btn-block"
+                                            style="background-color:#03C75A;" onclick="confirmNumber()">인증확인
+                                    </button>
+                                </div>
                             </div>
-                            <div class="col-3">
-                                <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;" onclick="confirmNumber()">인증확인</button>
+                            <div class="row p-2">
+                                <div class="col-6">
+                                    자기소개(선택사항)
+                                </div>
+                                <div class="col-6">
+                                </div>
+                                <div class="col-12">
+                                    <textarea class="form-control logininput" rows="3" maxlength="150" th:field="*{bio}"
+                                              placeholder="본인을 자유롭게 표현해주세요.&#13;&#10;소개 내용은 소셜 페이지에 활용됩니다!"></textarea>
+                                </div>
                             </div>
-                        </div>
-                        <div class="row p-2">
-                            <div class="col-6">
-                                자기소개(선택사항)
-                            </div>
-                            <div class="col-6">
-                            </div>
-                            <div class="col-12">
-                                <textarea class="form-control logininput" rows="3" maxlength="150" th:field="*{bio}" placeholder="본인을 자유롭게 표현해주세요.&#13;&#10;소개 내용은 소셜 페이지에 활용됩니다!"></textarea>
-                            </div>
-                        </div>
 
-                        <div class="col-12 p-2">
+                            <div class="col-12 p-2">
 
 
-                        </div>
-                        <div class="form-check col-12 p-2">
-                            <label class="form-check-label">
-                                <input class="form-check-input" type="checkbox" id="termsAgreementCheckbox" th:field="*{termsAgreement}" style="color: white;"/>
-                                [필수] <span class="required-star">*</span> 본인은 툰게더 회원 약관에 동의하였으며, <br>
-                                툰게더 커뮤니티 이용 수칙에 동의하는 바입니다.
-                            </label>
-                        </div>
-                        <div class="col-12 p-2">
-                            <button type="submit" class="btn btn-primary btn-block" style="background-color:#03C75A; height:50px;">가입하기</button>
-                        </div>
-                    </form>
+                            </div>
+                            <div class="form-check col-12 p-2">
+                                <label class="form-check-label">
+                                    <input class="form-check-input" type="checkbox" id="termsAgreementCheckbox"
+                                           th:field="*{termsAgreement}" style="color: white;"/>
+                                    [필수] <span class="required-star">*</span> 본인은 툰게더 회원 약관에 동의하였으며, <br>
+                                    툰게더 커뮤니티 이용 수칙에 동의하는 바입니다.
+                                </label>
+                            </div>
+                            <div class="col-12 p-2">
+                                <button type="submit" class="btn btn-primary btn-block"
+                                        style="background-color:#03C75A; height:50px;">가입하기
+                                </button>
+                            </div>
+                        </form>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/user/signup.html
+++ b/src/main/resources/templates/user/signup.html
@@ -290,372 +290,398 @@ async function checkDuplicates(userId, nickname, email) {
 
 <div th:replace="~{common/menubar}"></div>
 <style>
-    .jumbotron {
-    position : relative;
-    background-color : #EEEEEE;
+    html, body {
+        height: 100%;
+        margin: 0;
     }
-    .jumbotron .row {
-    position : absolute;
-    width : 100%;
-    bottom: 0%;
+    body {
+        display: flex;
+        flex-direction: column;
     }
-
-    #loginbox {
-    border-radius : 5%;
-    border-color : #F2F2F2;
+    .content-wrapper {
+        flex: 1 0 auto;
     }
-
-    .form-control {
-    background-color : #FCFCFC;
-    border : none;
-    width : 100%;
-    height : 50px;
-    }
-
-    .logininput {
-    background-color : #FCFCFC;
-    border : none;
-    height : 50px;
-    }
-
-    .logininput::placeholder {
-    color : #BBBBBB;
-    }
-
-    button {
-    background-color : #03C75A;
-    }
-
-    .form-select {
-    background-color : #FCFCFC;
-    border : none;
-    width : 100%;
-    height : 50px;
-    }
-
-    .form-check-input {
-    accent-color: #03C75A;
-    }
-
-     .nav-link {
-            color: #828282;
-    }
-    ul {
-  list-style: none;
-  padding-left : 0px;
-  }
-
-    .required-star {
-        color: #03C75A;
+    footer {
+        flex-shrink: 0;
     }
 
 </style>
-<div class="jumbotron">
-    <div class="container">
-        <div class="row">
-            <div class="col-9">
-                <div class="row">
-                    <div class="col-md-3 px-4">
-                        <h3>회원 가입</h3>
-                    </div>
-                    <div class="col-md-9">
-                        <nav class="navbar navbar-expand-md">
-                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                                <li>-</li>
-                                <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                                <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                                <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                            </ul>
-                        </nav>
+<div class="content-wrapper">
+    <style>
+        .jumbotron {
+        position : relative;
+        background-color : #EEEEEE;
+        }
+        .jumbotron .row {
+        position : absolute;
+        width : 100%;
+        bottom: 0%;
+        }
+
+        #loginbox {
+        border-radius : 5%;
+        border-color : #F2F2F2;
+        }
+
+        .form-control {
+        background-color : #FCFCFC;
+        border : none;
+        width : 100%;
+        height : 50px;
+        }
+
+        .logininput {
+        background-color : #FCFCFC;
+        border : none;
+        height : 50px;
+        }
+
+        .logininput::placeholder {
+        color : #BBBBBB;
+        }
+
+        button {
+        background-color : #03C75A;
+        }
+
+        .form-select {
+        background-color : #FCFCFC;
+        border : none;
+        width : 100%;
+        height : 50px;
+        }
+
+        .form-check-input {
+        accent-color: #03C75A;
+        }
+
+         .nav-link {
+                color: #828282;
+        }
+        ul {
+      list-style: none;
+      padding-left : 0px;
+      }
+
+        .required-star {
+            color: #03C75A;
+        }
+
+    </style>
+    <div class="jumbotron">
+        <div class="container">
+            <div class="row">
+                <div class="col-9">
+                    <div class="row">
+                        <div class="col-md-3 px-4">
+                            <h3>회원 가입</h3>
+                        </div>
+                        <div class="col-md-9">
+                            <nav class="navbar navbar-expand-md">
+                                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                    <li>-</li>
+                                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                                </ul>
+                            </nav>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
-<div class="container" style="padding:0;">
     <div class="container" style="padding:0;">
-        <div class="row">
-            <aside class="col-md-3 px-4">
-                <div class="row">
-                    <div class="col-1"></div>
-                    <div class="col-8">
-                        <div class="panel">
-                            <ul class="list-group">
-                                <li><a th:href="@{/user/login}" class="nav-link px-2">로그인</a></li>
-                                <li><a th:href="@{/user/signup}" class="nav-link px-2" style="color: #03C75A;">회원가입</a>
-                                </li>
-                            </ul>
+        <div class="container" style="padding:0;">
+            <div class="row">
+                <aside class="col-md-3 px-4">
+                    <div class="row">
+                        <div class="col-1"></div>
+                        <div class="col-8">
+                            <div class="panel">
+                                <ul class="list-group">
+                                    <li><a th:href="@{/user/login}" class="nav-link px-2">로그인</a></li>
+                                    <li><a th:href="@{/user/signup}" class="nav-link px-2"
+                                           style="color: #03C75A;">회원가입</a>
+                                    </li>
+                                </ul>
+                            </div>
                         </div>
                     </div>
-                </div>
-            </aside>
-            <script>
-                // id available check
-                function checkIdDuplicate() {
-                    const userId = document.getElementById('userId').value;
+                </aside>
+                <script>
+                    // id available check
+                    function checkIdDuplicate() {
+                        const userId = document.getElementById('userId').value;
 
-                    if(!userId) {
-                        alert('아이디를 입력해 주세요.');
-                        return;
-                    }
+                        if(!userId) {
+                            alert('아이디를 입력해 주세요.');
+                            return;
+                        }
 
-                    if (userId.length < 4) {
-                        alert('아이디의 글자수는 최소 4자입니다.');
-                        return;
-                    }
+                        if (userId.length < 4) {
+                            alert('아이디의 글자수는 최소 4자입니다.');
+                            return;
+                        }
 
-                    // 아이디는 영문과 숫자의 조합만 가능
-                    const validIdPattern = /^[a-zA-Z0-9]+$/;
-                    if (!validIdPattern.test(userId)) {
-                        alert('아이디는 영문과 숫자의 조합으로만 가능합니다.');
-                        return;
-                    }
+                        // 아이디는 영문과 숫자의 조합만 가능
+                        const validIdPattern = /^[a-zA-Z0-9]+$/;
+                        if (!validIdPattern.test(userId)) {
+                            alert('아이디는 영문과 숫자의 조합으로만 가능합니다.');
+                            return;
+                        }
 
-                    fetch(`/user/checkIdDuplicate?userId=${encodeURIComponent(userId)}`)
-                        .then(response => response.json())
-                        .then(data => {
-                            if (data.isDuplicate) alert('이미 존재하는 아이디입니다. ');
-                            else alert('사용 가능한 아이디입니다.');
-                        })
-                        .catch(error => {
-                            console.error('Error: ', error);
-                        });
-                } //checkIdDuplicate()
+                        fetch(`/user/checkIdDuplicate?userId=${encodeURIComponent(userId)}`)
+                            .then(response => response.json())
+                            .then(data => {
+                                if (data.isDuplicate) alert('이미 존재하는 아이디입니다. ');
+                                else alert('사용 가능한 아이디입니다.');
+                            })
+                            .catch(error => {
+                                console.error('Error: ', error);
+                            });
+                    } //checkIdDuplicate()
 
-                // nickname available check
-                function checkNicknameDuplicate() {
-                    const nickname = document.getElementById('nickname').value;
+                    // nickname available check
+                    function checkNicknameDuplicate() {
+                        const nickname = document.getElementById('nickname').value;
 
-                    if(!nickname) {
-                        alert('닉네임을 입력해 주세요.');
-                        return;
-                    }
+                        if(!nickname) {
+                            alert('닉네임을 입력해 주세요.');
+                            return;
+                        }
 
-                    if (nickname.length < 4) {
-                        alert('닉네임의 글자수는 최소 4자입니다.');
-                        return;
-                    }
+                        if (nickname.length < 4) {
+                            alert('닉네임의 글자수는 최소 4자입니다.');
+                            return;
+                        }
 
-                    fetch(`/user/checkNicknameDuplicate?nickname=${encodeURIComponent(nickname)}`)
-                        .then(response => response.json())
-                        .then(data => {
-                            if (data.isDuplicate) alert('이미 사용 중인 닉네임입니다.');
-                            else alert('사용 가능한 닉네임입니다.');
-                        })
-                        .catch(error => {
-                            console.error('Error: ', error);
-                        });
-                } //checkNicknameDuplicate()
+                        fetch(`/user/checkNicknameDuplicate?nickname=${encodeURIComponent(nickname)}`)
+                            .then(response => response.json())
+                            .then(data => {
+                                if (data.isDuplicate) alert('이미 사용 중인 닉네임입니다.');
+                                else alert('사용 가능한 닉네임입니다.');
+                            })
+                            .catch(error => {
+                                console.error('Error: ', error);
+                            });
+                    } //checkNicknameDuplicate()
 
-                // email available check
-                function checkEmailDuplicate() {
-                    const email = document.getElementById('email').value;
+                    // email available check
+                    function checkEmailDuplicate() {
+                        const email = document.getElementById('email').value;
 
-                    if(!email) {
-                        alert('이메일을 입력해 주세요.');
-                        return;
-                    }
+                        if(!email) {
+                            alert('이메일을 입력해 주세요.');
+                            return;
+                        }
 
-                    // 이메일 검증
-                    if (!validateEmail(email)) {
-                        alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
-                        return;
-                    }
+                        // 이메일 검증
+                        if (!validateEmail(email)) {
+                            alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
+                            return;
+                        }
 
-                    fetch(`/user/checkEmailDuplicate?email=${encodeURIComponent(email)}`)
-                        .then(response => response.json())
-                        .then(data => {
-                            if (data.isDuplicate) alert('이미 등록된 이메일입니다.');
-                            //else alert('등록 가능한 이메일입니다.');
-                        })
-                        .catch(error => {
-                            console.error('Error: ', error);
-                        });
-                } //checkEmailDuplicate()
-            </script>
-            <div class="col-md-9">
-                <div class="row justify-content-start" style="color: #828282;">
-                    <div class="col-8 p-3" id="loginbox">
-                        <form th:action="@{/user/signup}" th:object="${user}" method="post"
-                              onsubmit="validateForm(event)">
-                            <div class="row p-2">
-                                <div class="col-3">
-                                    아이디 <span class="required-star">*</span>
-                                </div>
-                                <div class="col-6">
-                                    <input class="form-control px-3" type="text" th:field="*{userId}" maxlength="20"
-                                           minlength="4"/>
-                                </div>
-                                <div class="col-3">
-                                    <button type="button" class="btn btn-primary btn-block"
-                                            style="background-color:#03C75A;" onclick="checkIdDuplicate()">중복확인
-                                    </button>
-                                </div>
-                            </div>
-                            <div class="row p-2">
-                                <div class="col-3">
-                                    비밀번호 <span class="required-star">*</span>
-                                </div>
-                                <div class="col-6">
-                                    <input class="form-control px-3" type="password" th:field="*{password}"
-                                           maxlength="30" minlength="8"/>
-                                </div>
-                                <div class="col-3">
-                                </div>
-                            </div>
-                            <div class="row p-2">
-                                <div class="col-3">
-                                    비밀번호 확인 <span class="required-star">*</span>
-                                </div>
-                                <div class="col-6">
-                                    <input class="form-control px-3" type="password" th:field="*{confirmPassword}"
-                                           maxlength="30" minlength="8"/>
-                                </div>
-                                <div class="col-3">
-                                </div>
-                            </div>
-                            <div class="row p-2">
-                                <div class="col-3">
-                                    닉네임 <span class="required-star">*</span>
-                                </div>
-                                <div class="col-6">
-                                    <input class="form-control px-3" type="text" th:field="*{nickname}" maxlength="20"
-                                           minlength="4"/>
-                                </div>
-                                <div class="col-3">
-                                    <button type="button" class="btn btn-primary btn-block"
-                                            style="background-color:#03C75A;" onclick="checkNicknameDuplicate()">중복확인
-                                    </button>
-                                </div>
-                            </div>
-                            <div class="row p-2">
-                                <div class="col-3">
-                                    연락처
-                                </div>
-                                <div class="col-6">
-                                    <input class="form-control px-3 logininput" type="text" th:field="*{contactNumber}"
-                                           oninput="autoFormatPhoneNumber(this)" placeholder="000-0000-0000"/>
-                                </div>
-                                <div class="col-3">
-                                </div>
-                            </div>
-                            <div class="row p-2">
-                                <div class="col-3">
-                                    성별
-                                </div>
-                                <div class="col-6">
-                                    <select class="form-select px-3" th:field="*{gender}">
-                                        <option value="P">성별을 공개하지 않습니다</option>
-                                        <option value="F">여</option>
-                                        <option value="M">남</option>
-                                    </select>
-                                </div>
-                                <div class="col-3">
-                                </div>
-                            </div>
-                            <div class="row p-2">
-                                <div class="col-3">
-                                    <!-- 생년월일을 연도, 월, 일로 나누어 드롭다운 박스 형태로 입력 -->
-                                    생년월일
-                                </div>
-                                <div class="col-6">
-                                    <div class="row">
-                                        <div class="col-4">
-                                            <select class="form-select" id="year" name="year" th:field="*{year}"
-                                                    style="text-align:center;">
-                                                <option th:each="y : ${years}" th:value="${y}" th:text="${y}">연도
-                                                </option>
-                                            </select>
-                                        </div>
-                                        <div class="col-4">
-                                            <select class="form-select" id="month" name="month" th:field="*{month}"
-                                                    style="text-align:center;">
-                                                <option th:each="m : ${months}" th:value="${m}" th:text="${m}">월
-                                                </option>
-                                            </select>
-                                        </div>
-                                        <div class="col-4">
-                                            <select class="form-select" id="day" name="day" th:field="*{day}"
-                                                    style="text-align:center;">
-                                                <option th:each="d : ${days}" th:value="${d}" th:text="${d}">일</option>
-                                            </select>
-                                        </div>
+                        fetch(`/user/checkEmailDuplicate?email=${encodeURIComponent(email)}`)
+                            .then(response => response.json())
+                            .then(data => {
+                                if (data.isDuplicate) alert('이미 등록된 이메일입니다.');
+                                //else alert('등록 가능한 이메일입니다.');
+                            })
+                            .catch(error => {
+                                console.error('Error: ', error);
+                            });
+                    } //checkEmailDuplicate()
+                </script>
+                <div class="col-md-9">
+                    <div class="row justify-content-start" style="color: #828282;">
+                        <div class="col-8 p-3" id="loginbox">
+                            <form th:action="@{/user/signup}" th:object="${user}" method="post"
+                                  onsubmit="validateForm(event)">
+                                <div class="row p-2">
+                                    <div class="col-3">
+                                        아이디 <span class="required-star">*</span>
+                                    </div>
+                                    <div class="col-6">
+                                        <input class="form-control px-3" type="text" th:field="*{userId}" maxlength="20"
+                                               minlength="4"/>
+                                    </div>
+                                    <div class="col-3">
+                                        <button type="button" class="btn btn-primary btn-block"
+                                                style="background-color:#03C75A;" onclick="checkIdDuplicate()">중복확인
+                                        </button>
                                     </div>
                                 </div>
-                                <div class="col-3">
+                                <div class="row p-2">
+                                    <div class="col-3">
+                                        비밀번호 <span class="required-star">*</span>
+                                    </div>
+                                    <div class="col-6">
+                                        <input class="form-control px-3" type="password" th:field="*{password}"
+                                               maxlength="30" minlength="8"/>
+                                    </div>
+                                    <div class="col-3">
+                                    </div>
                                 </div>
-                            </div>
-                            <div class="row p-2">
-                                <div class="col-3">
-                                    실명
+                                <div class="row p-2">
+                                    <div class="col-3">
+                                        비밀번호 확인 <span class="required-star">*</span>
+                                    </div>
+                                    <div class="col-6">
+                                        <input class="form-control px-3" type="password" th:field="*{confirmPassword}"
+                                               maxlength="30" minlength="8"/>
+                                    </div>
+                                    <div class="col-3">
+                                    </div>
                                 </div>
-                                <div class="col-6">
-                                    <input class="form-control" type="text" th:field="*{realName}" maxlength="10"/>
+                                <div class="row p-2">
+                                    <div class="col-3">
+                                        닉네임 <span class="required-star">*</span>
+                                    </div>
+                                    <div class="col-6">
+                                        <input class="form-control px-3" type="text" th:field="*{nickname}"
+                                               maxlength="20"
+                                               minlength="4"/>
+                                    </div>
+                                    <div class="col-3">
+                                        <button type="button" class="btn btn-primary btn-block"
+                                                style="background-color:#03C75A;" onclick="checkNicknameDuplicate()">
+                                            중복확인
+                                        </button>
+                                    </div>
                                 </div>
-                                <div class="col-3">
+                                <div class="row p-2">
+                                    <div class="col-3">
+                                        연락처
+                                    </div>
+                                    <div class="col-6">
+                                        <input class="form-control px-3 logininput" type="text"
+                                               th:field="*{contactNumber}"
+                                               oninput="autoFormatPhoneNumber(this)" placeholder="000-0000-0000"/>
+                                    </div>
+                                    <div class="col-3">
+                                    </div>
                                 </div>
-                            </div>
-                            <div class="row p-2">
-                                <div class="col-3">
-                                    이메일 <span class="required-star">*</span>
+                                <div class="row p-2">
+                                    <div class="col-3">
+                                        성별
+                                    </div>
+                                    <div class="col-6">
+                                        <select class="form-select px-3" th:field="*{gender}">
+                                            <option value="P">성별을 공개하지 않습니다</option>
+                                            <option value="F">여</option>
+                                            <option value="M">남</option>
+                                        </select>
+                                    </div>
+                                    <div class="col-3">
+                                    </div>
                                 </div>
-                                <div class="col-6">
-                                    <input id="email" class="form-control" type="text" th:field="*{email}"/>
+                                <div class="row p-2">
+                                    <div class="col-3">
+                                        <!-- 생년월일을 연도, 월, 일로 나누어 드롭다운 박스 형태로 입력 -->
+                                        생년월일
+                                    </div>
+                                    <div class="col-6">
+                                        <div class="row">
+                                            <div class="col-4">
+                                                <select class="form-select" id="year" name="year" th:field="*{year}"
+                                                        style="text-align:center;">
+                                                    <option th:each="y : ${years}" th:value="${y}" th:text="${y}">연도
+                                                    </option>
+                                                </select>
+                                            </div>
+                                            <div class="col-4">
+                                                <select class="form-select" id="month" name="month" th:field="*{month}"
+                                                        style="text-align:center;">
+                                                    <option th:each="m : ${months}" th:value="${m}" th:text="${m}">월
+                                                    </option>
+                                                </select>
+                                            </div>
+                                            <div class="col-4">
+                                                <select class="form-select" id="day" name="day" th:field="*{day}"
+                                                        style="text-align:center;">
+                                                    <option th:each="d : ${days}" th:value="${d}" th:text="${d}">일
+                                                    </option>
+                                                </select>
+                                            </div>
+                                        </div>
+                                    </div>
+                                    <div class="col-3">
+                                    </div>
                                 </div>
-                                <div class="col-3">
-                                    <!--                            <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;" onclick="checkEmailDuplicate()">중복확인</button>-->
-                                    <button id="emailVerifyButton" type="button" class="btn btn-primary btn-block"
-                                            style="background-color:#03C75A;" onclick="sendNumber()">인증하기
+                                <div class="row p-2">
+                                    <div class="col-3">
+                                        실명
+                                    </div>
+                                    <div class="col-6">
+                                        <input class="form-control" type="text" th:field="*{realName}" maxlength="10"/>
+                                    </div>
+                                    <div class="col-3">
+                                    </div>
+                                </div>
+                                <div class="row p-2">
+                                    <div class="col-3">
+                                        이메일 <span class="required-star">*</span>
+                                    </div>
+                                    <div class="col-6">
+                                        <input id="email" class="form-control" type="text" th:field="*{email}"/>
+                                    </div>
+                                    <div class="col-3">
+                                        <!--                            <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;" onclick="checkEmailDuplicate()">중복확인</button>-->
+                                        <button id="emailVerifyButton" type="button" class="btn btn-primary btn-block"
+                                                style="background-color:#03C75A;" onclick="sendNumber()">인증하기
+                                        </button>
+                                    </div>
+                                </div>
+                                <div class="row p-2">
+                                    <div class="col-3">
+                                        인증번호 입력 <span class="required-star">*</span>
+                                    </div>
+                                    <div class="col-6">
+                                        <input id="mailNumber" class="form-control" type="text"
+                                               th:field="*{mailNumber}"/>
+                                        <!-- 실제로는 보이지 않지만 폼에 포함될 hidden checkbox -->
+                                        <input type="checkbox" id="verificationCheckbox" name="verificationCheckbox"
+                                               style="display:none;"/>
+                                    </div>
+                                    <div class="col-3">
+                                        <button id="emailConfirmButton" type="button" class="btn btn-primary btn-block"
+                                                style="background-color:#03C75A;" onclick="confirmNumber()">인증확인
+                                        </button>
+                                    </div>
+                                </div>
+                                <div class="row p-2">
+                                    <div class="col-6">
+                                        자기소개(선택사항)
+                                    </div>
+                                    <div class="col-6">
+                                    </div>
+                                    <div class="col-12">
+                                        <textarea class="form-control logininput" rows="3" maxlength="150"
+                                                  th:field="*{bio}"
+                                                  placeholder="본인을 자유롭게 표현해주세요.&#13;&#10;소개 내용은 소셜 페이지에 활용됩니다!"></textarea>
+                                    </div>
+                                </div>
+
+                                <div class="col-12 p-2">
+
+
+                                </div>
+                                <div class="form-check col-12 p-2">
+                                    <label class="form-check-label">
+                                        <input class="form-check-input" type="checkbox" id="termsAgreementCheckbox"
+                                               th:field="*{termsAgreement}" style="color: white;"/>
+                                        [필수] <span class="required-star">*</span> 본인은 툰게더 회원 약관에 동의하였으며, <br>
+                                        툰게더 커뮤니티 이용 수칙에 동의하는 바입니다.
+                                    </label>
+                                </div>
+                                <div class="col-12 p-2">
+                                    <button type="submit" class="btn btn-primary btn-block"
+                                            style="background-color:#03C75A; height:50px;">가입하기
                                     </button>
                                 </div>
-                            </div>
-                            <div class="row p-2">
-                                <div class="col-3">
-                                    인증번호 입력 <span class="required-star">*</span>
-                                </div>
-                                <div class="col-6">
-                                    <input id="mailNumber" class="form-control" type="text" th:field="*{mailNumber}"/>
-                                    <!-- 실제로는 보이지 않지만 폼에 포함될 hidden checkbox -->
-                                    <input type="checkbox" id="verificationCheckbox" name="verificationCheckbox"
-                                           style="display:none;"/>
-                                </div>
-                                <div class="col-3">
-                                    <button id="emailConfirmButton" type="button" class="btn btn-primary btn-block"
-                                            style="background-color:#03C75A;" onclick="confirmNumber()">인증확인
-                                    </button>
-                                </div>
-                            </div>
-                            <div class="row p-2">
-                                <div class="col-6">
-                                    자기소개(선택사항)
-                                </div>
-                                <div class="col-6">
-                                </div>
-                                <div class="col-12">
-                                    <textarea class="form-control logininput" rows="3" maxlength="150" th:field="*{bio}"
-                                              placeholder="본인을 자유롭게 표현해주세요.&#13;&#10;소개 내용은 소셜 페이지에 활용됩니다!"></textarea>
-                                </div>
-                            </div>
-
-                            <div class="col-12 p-2">
-
-
-                            </div>
-                            <div class="form-check col-12 p-2">
-                                <label class="form-check-label">
-                                    <input class="form-check-input" type="checkbox" id="termsAgreementCheckbox"
-                                           th:field="*{termsAgreement}" style="color: white;"/>
-                                    [필수] <span class="required-star">*</span> 본인은 툰게더 회원 약관에 동의하였으며, <br>
-                                    툰게더 커뮤니티 이용 수칙에 동의하는 바입니다.
-                                </label>
-                            </div>
-                            <div class="col-12 p-2">
-                                <button type="submit" class="btn btn-primary btn-block"
-                                        style="background-color:#03C75A; height:50px;">가입하기
-                                </button>
-                            </div>
-                        </form>
+                            </form>
+                        </div>
                     </div>
                 </div>
             </div>

--- a/src/main/resources/templates/user/signup.html
+++ b/src/main/resources/templates/user/signup.html
@@ -327,278 +327,282 @@ function confirmNumber() {
 
 </style>
 <div class="jumbotron">
-    <div class="row">
-        <div class="col-md-3 px-4">
-            <h3>회원 가입</h3>
-        </div>
-        <div class="col-md-9">
-            <nav class="navbar navbar-expand-md">
-                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                    <li>-</li>
-                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                </ul>
-            </nav>
+    <div class="container">
+        <div class="row">
+            <div class="col-md-3 px-4">
+                <h3>회원 가입</h3>
+            </div>
+            <div class="col-md-9">
+                <nav class="navbar navbar-expand-md">
+                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                        <li>-</li>
+                        <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                        <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                        <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                    </ul>
+                </nav>
+            </div>
         </div>
     </div>
 </div>
-<div class="row">
-    <aside class="col-md-3 px-4">
-        <div class="row">
-            <div class="col-3"></div>
-            <div class="col-6">
-                <div class="panel">
-                    <ul class="list-group">
-                        <li><a th:href="@{/user/login}" class="nav-link px-2">로그인</a></li>
-                        <li><a th:href="@{/user/signup}" class="nav-link px-2" style="color: #03C75A;">회원가입</a></li>
-                    </ul>
+<div class="container" style="padding:0;">
+    <div class="row">
+        <aside class="col-md-3 px-4">
+            <div class="row">
+                <div class="col-3"></div>
+                <div class="col-6">
+                    <div class="panel">
+                        <ul class="list-group">
+                            <li><a th:href="@{/user/login}" class="nav-link px-2">로그인</a></li>
+                            <li><a th:href="@{/user/signup}" class="nav-link px-2" style="color: #03C75A;">회원가입</a></li>
+                        </ul>
+                    </div>
                 </div>
             </div>
-        </div>
-    </aside>
-    <script>
-        // id available check
-        function checkIdDuplicate() {
-            const userId = document.getElementById('userId').value;
+        </aside>
+        <script>
+            // id available check
+            function checkIdDuplicate() {
+                const userId = document.getElementById('userId').value;
 
-            if(!userId) {
-                alert('아이디를 입력해 주세요.');
-                return;
-            }
+                if(!userId) {
+                    alert('아이디를 입력해 주세요.');
+                    return;
+                }
 
-            if (userId.length < 4) {
-                alert('아이디의 글자수는 최소 4자입니다.');
-                return;
-            }
+                if (userId.length < 4) {
+                    alert('아이디의 글자수는 최소 4자입니다.');
+                    return;
+                }
 
-            // 아이디는 영문과 숫자의 조합만 가능
-            const validIdPattern = /^[a-zA-Z0-9]+$/;
-            if (!validIdPattern.test(userId)) {
-                alert('아이디는 영문과 숫자의 조합으로만 가능합니다.');
-                return;
-            }
+                // 아이디는 영문과 숫자의 조합만 가능
+                const validIdPattern = /^[a-zA-Z0-9]+$/;
+                if (!validIdPattern.test(userId)) {
+                    alert('아이디는 영문과 숫자의 조합으로만 가능합니다.');
+                    return;
+                }
 
-            fetch(`/user/checkIdDuplicate?userId=${encodeURIComponent(userId)}`)
-                .then(response => response.json())
-                .then(data => {
-                    if (data.isDuplicate) alert('이미 존재하는 아이디입니다. ');
-                    else alert('사용 가능한 아이디입니다.');
-                })
-                .catch(error => {
-                    console.error('Error: ', error);
-                });
-        } //checkIdDuplicate()
+                fetch(`/user/checkIdDuplicate?userId=${encodeURIComponent(userId)}`)
+                    .then(response => response.json())
+                    .then(data => {
+                        if (data.isDuplicate) alert('이미 존재하는 아이디입니다. ');
+                        else alert('사용 가능한 아이디입니다.');
+                    })
+                    .catch(error => {
+                        console.error('Error: ', error);
+                    });
+            } //checkIdDuplicate()
 
-        // nickname available check
-        function checkNicknameDuplicate() {
-            const nickname = document.getElementById('nickname').value;
+            // nickname available check
+            function checkNicknameDuplicate() {
+                const nickname = document.getElementById('nickname').value;
 
-            if(!nickname) {
-                alert('닉네임을 입력해 주세요.');
-                return;
-            }
+                if(!nickname) {
+                    alert('닉네임을 입력해 주세요.');
+                    return;
+                }
 
-            if (nickname.length < 4) {
-                alert('닉네임의 글자수는 최소 4자입니다.');
-                return;
-            }
+                if (nickname.length < 4) {
+                    alert('닉네임의 글자수는 최소 4자입니다.');
+                    return;
+                }
 
-            fetch(`/user/checkNicknameDuplicate?nickname=${encodeURIComponent(nickname)}`)
-                .then(response => response.json())
-                .then(data => {
-                    if (data.isDuplicate) alert('이미 사용 중인 닉네임입니다.');
-                    else alert('사용 가능한 닉네임입니다.');
-                })
-                .catch(error => {
-                    console.error('Error: ', error);
-                });
-        } //checkNicknameDuplicate()
+                fetch(`/user/checkNicknameDuplicate?nickname=${encodeURIComponent(nickname)}`)
+                    .then(response => response.json())
+                    .then(data => {
+                        if (data.isDuplicate) alert('이미 사용 중인 닉네임입니다.');
+                        else alert('사용 가능한 닉네임입니다.');
+                    })
+                    .catch(error => {
+                        console.error('Error: ', error);
+                    });
+            } //checkNicknameDuplicate()
 
-        // email available check
-        function checkEmailDuplicate() {
-            const email = document.getElementById('email').value;
+            // email available check
+            function checkEmailDuplicate() {
+                const email = document.getElementById('email').value;
 
-            if(!email) {
-                alert('이메일을 입력해 주세요.');
-                return;
-            }
+                if(!email) {
+                    alert('이메일을 입력해 주세요.');
+                    return;
+                }
 
-            // 이메일 검증
-            if (!validateEmail(email)) {
-                alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
-                return;
-            }
+                // 이메일 검증
+                if (!validateEmail(email)) {
+                    alert("이메일 형식이 올바르지 않습니다. 예: example@example.com");
+                    return;
+                }
 
-            fetch(`/user/checkEmailDuplicate?email=${encodeURIComponent(email)}`)
-                .then(response => response.json())
-                .then(data => {
-                    if (data.isDuplicate) alert('이미 등록된 이메일입니다.');
-                    //else alert('등록 가능한 이메일입니다.');
-                })
-                .catch(error => {
-                    console.error('Error: ', error);
-                });
-        } //checkEmailDuplicate()
-    </script>
-    <div class="col-md-9">
-        <div class="row justify-content-start" style="color: #828282;">
-            <div class="col-8 p-3" id="loginbox">
-                <form th:action="@{/user/signup}" th:object="${user}" method="post" onsubmit="validateForm(event)">
-                    <div class="row p-2">
-                        <div class="col-3">
-                            아이디 <span class="required-star">*</span>
-                        </div>
-                        <div class="col-6">
-                            <input class="form-control px-3" type="text" th:field="*{userId}" maxlength="20" minlength="4"/>
-                        </div>
-                        <div class="col-3">
-                            <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;" onclick="checkIdDuplicate()">중복확인</button>
-                        </div>
-                    </div>
-                    <div class="row p-2">
-                        <div class="col-3">
-                            비밀번호 <span class="required-star">*</span>
-                        </div>
-                        <div class="col-6">
-                            <input class="form-control px-3" type="password" th:field="*{password}" maxlength="30" minlength="8"/>
-                        </div>
-                        <div class="col-3">
-                        </div>
-                    </div>
-                    <div class="row p-2">
-                        <div class="col-3">
-                            비밀번호 확인 <span class="required-star">*</span>
-                        </div>
-                        <div class="col-6">
-                            <input class="form-control px-3" type="password" th:field="*{confirmPassword}" maxlength="30" minlength="8"/>
-                        </div>
-                        <div class="col-3">
-                        </div>
-                    </div>
-                    <div class="row p-2">
-                        <div class="col-3">
-                            닉네임 <span class="required-star">*</span>
-                        </div>
-                        <div class="col-6">
-                            <input class="form-control px-3" type="text" th:field="*{nickname}" maxlength="20" minlength="4"/>
-                        </div>
-                        <div class="col-3">
-                            <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;" onclick="checkNicknameDuplicate()">중복확인</button>
-                        </div>
-                    </div>
-                    <div class="row p-2">
-                        <div class="col-3">
-                            연락처
-                        </div>
-                        <div class="col-6">
-                            <input class="form-control px-3 logininput" type="text" th:field="*{contactNumber}" oninput="autoFormatPhoneNumber(this)" placeholder="000-0000-0000"/>
-                        </div>
-                        <div class="col-3">
-                        </div>
-                    </div>
-                    <div class="row p-2">
-                        <div class="col-3">
-                            성별
-                        </div>
-                        <div class="col-6">
-                            <select class="form-select px-3" th:field="*{gender}">
-                                <option value="P">성별을 공개하지 않습니다</option>
-                                <option value="F">여</option>
-                                <option value="M">남</option>
-                            </select>
-                        </div>
-                        <div class="col-3">
-                        </div>
-                    </div>
-                    <div class="row p-2">
-                        <div class="col-3">
-                            <!-- 생년월일을 연도, 월, 일로 나누어 드롭다운 박스 형태로 입력 -->
-                            생년월일
-                        </div>
-                        <div class="col-6">
-                            <div class="row">
-                                <div class="col-4">
-                                    <select class="form-select" id="year" name="year" th:field="*{year}" style="text-align:center;">
-                                        <option th:each="y : ${years}" th:value="${y}" th:text="${y}">연도</option>
-                                    </select>
-                                </div>
-                                <div class="col-4">
-                                    <select class="form-select" id="month" name="month" th:field="*{month}" style="text-align:center;">
-                                        <option th:each="m : ${months}" th:value="${m}" th:text="${m}">월</option>
-                                    </select>
-                                </div>
-                                <div class="col-4">
-                                    <select class="form-select" id="day" name="day" th:field="*{day}" style="text-align:center;">
-                                        <option th:each="d : ${days}" th:value="${d}" th:text="${d}">일</option>
-                                    </select>
-                                </div>
+                fetch(`/user/checkEmailDuplicate?email=${encodeURIComponent(email)}`)
+                    .then(response => response.json())
+                    .then(data => {
+                        if (data.isDuplicate) alert('이미 등록된 이메일입니다.');
+                        //else alert('등록 가능한 이메일입니다.');
+                    })
+                    .catch(error => {
+                        console.error('Error: ', error);
+                    });
+            } //checkEmailDuplicate()
+        </script>
+        <div class="col-md-9">
+            <div class="row justify-content-start" style="color: #828282;">
+                <div class="col-8 p-3" id="loginbox">
+                    <form th:action="@{/user/signup}" th:object="${user}" method="post" onsubmit="validateForm(event)">
+                        <div class="row p-2">
+                            <div class="col-3">
+                                아이디 <span class="required-star">*</span>
+                            </div>
+                            <div class="col-6">
+                                <input class="form-control px-3" type="text" th:field="*{userId}" maxlength="20" minlength="4"/>
+                            </div>
+                            <div class="col-3">
+                                <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;" onclick="checkIdDuplicate()">중복확인</button>
                             </div>
                         </div>
-                        <div class="col-3">
+                        <div class="row p-2">
+                            <div class="col-3">
+                                비밀번호 <span class="required-star">*</span>
+                            </div>
+                            <div class="col-6">
+                                <input class="form-control px-3" type="password" th:field="*{password}" maxlength="30" minlength="8"/>
+                            </div>
+                            <div class="col-3">
+                            </div>
                         </div>
-                    </div>
-                    <div class="row p-2">
-                        <div class="col-3">
-                            실명
+                        <div class="row p-2">
+                            <div class="col-3">
+                                비밀번호 확인 <span class="required-star">*</span>
+                            </div>
+                            <div class="col-6">
+                                <input class="form-control px-3" type="password" th:field="*{confirmPassword}" maxlength="30" minlength="8"/>
+                            </div>
+                            <div class="col-3">
+                            </div>
                         </div>
-                        <div class="col-6">
-                            <input class="form-control" type="text" th:field="*{realName}" maxlength="10"/>
+                        <div class="row p-2">
+                            <div class="col-3">
+                                닉네임 <span class="required-star">*</span>
+                            </div>
+                            <div class="col-6">
+                                <input class="form-control px-3" type="text" th:field="*{nickname}" maxlength="20" minlength="4"/>
+                            </div>
+                            <div class="col-3">
+                                <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;" onclick="checkNicknameDuplicate()">중복확인</button>
+                            </div>
                         </div>
-                        <div class="col-3">
+                        <div class="row p-2">
+                            <div class="col-3">
+                                연락처
+                            </div>
+                            <div class="col-6">
+                                <input class="form-control px-3 logininput" type="text" th:field="*{contactNumber}" oninput="autoFormatPhoneNumber(this)" placeholder="000-0000-0000"/>
+                            </div>
+                            <div class="col-3">
+                            </div>
                         </div>
-                    </div>
-                    <div class="row p-2">
-                        <div class="col-3">
-                            이메일 <span class="required-star">*</span>
+                        <div class="row p-2">
+                            <div class="col-3">
+                                성별
+                            </div>
+                            <div class="col-6">
+                                <select class="form-select px-3" th:field="*{gender}">
+                                    <option value="P">성별을 공개하지 않습니다</option>
+                                    <option value="F">여</option>
+                                    <option value="M">남</option>
+                                </select>
+                            </div>
+                            <div class="col-3">
+                            </div>
                         </div>
-                        <div class="col-6">
-                            <input id="email" class="form-control" type="text" th:field="*{email}"/>
+                        <div class="row p-2">
+                            <div class="col-3">
+                                <!-- 생년월일을 연도, 월, 일로 나누어 드롭다운 박스 형태로 입력 -->
+                                생년월일
+                            </div>
+                            <div class="col-6">
+                                <div class="row">
+                                    <div class="col-4">
+                                        <select class="form-select" id="year" name="year" th:field="*{year}" style="text-align:center;">
+                                            <option th:each="y : ${years}" th:value="${y}" th:text="${y}">연도</option>
+                                        </select>
+                                    </div>
+                                    <div class="col-4">
+                                        <select class="form-select" id="month" name="month" th:field="*{month}" style="text-align:center;">
+                                            <option th:each="m : ${months}" th:value="${m}" th:text="${m}">월</option>
+                                        </select>
+                                    </div>
+                                    <div class="col-4">
+                                        <select class="form-select" id="day" name="day" th:field="*{day}" style="text-align:center;">
+                                            <option th:each="d : ${days}" th:value="${d}" th:text="${d}">일</option>
+                                        </select>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="col-3">
+                            </div>
                         </div>
-                        <div class="col-3">
-<!--                            <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;" onclick="checkEmailDuplicate()">중복확인</button>-->
-                            <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;" onclick="sendNumber()">인증하기</button>
+                        <div class="row p-2">
+                            <div class="col-3">
+                                실명
+                            </div>
+                            <div class="col-6">
+                                <input class="form-control" type="text" th:field="*{realName}" maxlength="10"/>
+                            </div>
+                            <div class="col-3">
+                            </div>
                         </div>
-                    </div>
-                    <div class="row p-2">
-                        <div class="col-3">
-                            인증번호 입력 <span class="required-star">*</span>
+                        <div class="row p-2">
+                            <div class="col-3">
+                                이메일 <span class="required-star">*</span>
+                            </div>
+                            <div class="col-6">
+                                <input id="email" class="form-control" type="text" th:field="*{email}"/>
+                            </div>
+                            <div class="col-3">
+                                <!--                            <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;" onclick="checkEmailDuplicate()">중복확인</button>-->
+                                <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;" onclick="sendNumber()">인증하기</button>
+                            </div>
                         </div>
-                        <div class="col-6">
-                            <input id="mailNumber" class="form-control" type="text" th:field="*{mailNumber}"/>
-                            <!-- 실제로는 보이지 않지만 폼에 포함될 hidden checkbox -->
-                            <input type="checkbox" id="verificationCheckbox" name="verificationCheckbox" style="display:none;"/>
+                        <div class="row p-2">
+                            <div class="col-3">
+                                인증번호 입력 <span class="required-star">*</span>
+                            </div>
+                            <div class="col-6">
+                                <input id="mailNumber" class="form-control" type="text" th:field="*{mailNumber}"/>
+                                <!-- 실제로는 보이지 않지만 폼에 포함될 hidden checkbox -->
+                                <input type="checkbox" id="verificationCheckbox" name="verificationCheckbox" style="display:none;"/>
+                            </div>
+                            <div class="col-3">
+                                <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;" onclick="confirmNumber()">인증확인</button>
+                            </div>
                         </div>
-                        <div class="col-3">
-                            <button type="button" class="btn btn-primary btn-block" style="background-color:#03C75A;" onclick="confirmNumber()">인증확인</button>
+                        <div class="row p-2">
+                            <div class="col-6">
+                                자기소개(선택사항)
+                            </div>
+                            <div class="col-6">
+                            </div>
+                            <div class="col-12">
+                                <textarea class="form-control logininput" rows="3" maxlength="150" th:field="*{bio}" placeholder="본인을 자유롭게 표현해주세요.&#13;&#10;소개 내용은 소셜 페이지에 활용됩니다!"></textarea>
+                            </div>
                         </div>
-                    </div>
-                    <div class="row p-2">
-                        <div class="col-6">
-                            자기소개(선택사항)
-                        </div>
-                        <div class="col-6">
-                        </div>
-                        <div class="col-12">
-                            <textarea class="form-control logininput" rows="3" maxlength="150" th:field="*{bio}" placeholder="본인을 자유롭게 표현해주세요.&#13;&#10;소개 내용은 소셜 페이지에 활용됩니다!"></textarea>
-                        </div>
-                    </div>
 
-                    <div class="col-12 p-2">
+                        <div class="col-12 p-2">
 
 
-                    </div>
-                    <div class="form-check col-12 p-2">
-                        <label class="form-check-label">
-                        <input class="form-check-input" type="checkbox" id="termsAgreementCheckbox" th:field="*{termsAgreement}" style="color: white;"/>
-                            [필수] <span class="required-star">*</span> 본인은 툰게더 회원 약관에 동의하였으며, <br>
-                            툰게더 커뮤니티 이용 수칙에 동의하는 바입니다.
-                        </label>
-                    </div>
-                    <div class="col-12 p-2">
-                        <button type="submit" class="btn btn-primary btn-block" style="background-color:#03C75A; height:50px;">가입하기</button>
-                    </div>
-                </form>
+                        </div>
+                        <div class="form-check col-12 p-2">
+                            <label class="form-check-label">
+                                <input class="form-check-input" type="checkbox" id="termsAgreementCheckbox" th:field="*{termsAgreement}" style="color: white;"/>
+                                [필수] <span class="required-star">*</span> 본인은 툰게더 회원 약관에 동의하였으며, <br>
+                                툰게더 커뮤니티 이용 수칙에 동의하는 바입니다.
+                            </label>
+                        </div>
+                        <div class="col-12 p-2">
+                            <button type="submit" class="btn btn-primary btn-block" style="background-color:#03C75A; height:50px;">가입하기</button>
+                        </div>
+                    </form>
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/user/signup.html
+++ b/src/main/resources/templates/user/signup.html
@@ -329,18 +329,22 @@ function confirmNumber() {
 <div class="jumbotron">
     <div class="container">
         <div class="row">
-            <div class="col-md-3 px-4">
-                <h3>회원 가입</h3>
-            </div>
-            <div class="col-md-9">
-                <nav class="navbar navbar-expand-md">
-                    <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                        <li>-</li>
-                        <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                        <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                        <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                    </ul>
-                </nav>
+            <div class="col-9">
+                <div class="row">
+                    <div class="col-md-3 px-4">
+                        <h3>회원 가입</h3>
+                    </div>
+                    <div class="col-md-9">
+                        <nav class="navbar navbar-expand-md">
+                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                <li>-</li>
+                                <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                                <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                                <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                            </ul>
+                        </nav>
+                    </div>
+                </div>
             </div>
         </div>
     </div>

--- a/src/main/resources/templates/user/withdrawn.html
+++ b/src/main/resources/templates/user/withdrawn.html
@@ -29,105 +29,125 @@
 
 <div th:replace="~{common/menubar}"></div>
 <style>
-    .jumbotron {
-    position : relative;
-    background-color : #EEEEEE;
+    html, body {
+        height: 100%;
+        margin: 0;
     }
-    .jumbotron .row {
-    position : absolute;
-    width : 100%;
-    bottom: 0%;
+    body {
+        display: flex;
+        flex-direction: column;
     }
-
-    #loginbox {
-    border-radius : 5%;
-    border-color : #F2F2F2;
+    .content-wrapper {
+        flex: 1 0 auto;
     }
-
-    .logininput {
-    background-color : #FCFCFC;
-    border : none;
-    height : 50px;
+    footer {
+        flex-shrink: 0;
     }
-
-    .logininput::placeholder {
-    color : #BBBBBB;
-    }
-
-     .nav-link {
-            color: #828282;
-    }
-    ul {
-  list-style: none;
-  padding-left : 0px;
-  }
 
 </style>
-<div class="jumbotron">
-    <div class="container">
-        <div class="row">
-            <div class="col-9">
-                <div class="row">
-                    <div class="col-md-3 px-4">
-                        <h3>로그인</h3>
-                    </div>
-                    <div class="col-md-9">
-                        <nav class="navbar navbar-expand-md">
-                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
-                                <li>-</li>
-                                <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
-                                <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
-                                <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
-                            </ul>
-                        </nav>
+<div class="content-wrapper">
+    <style>
+        .jumbotron {
+        position : relative;
+        background-color : #EEEEEE;
+        }
+        .jumbotron .row {
+        position : absolute;
+        width : 100%;
+        bottom: 0%;
+        }
+
+        #loginbox {
+        border-radius : 5%;
+        border-color : #F2F2F2;
+        }
+
+        .logininput {
+        background-color : #FCFCFC;
+        border : none;
+        height : 50px;
+        }
+
+        .logininput::placeholder {
+        color : #BBBBBB;
+        }
+
+         .nav-link {
+                color: #828282;
+        }
+        ul {
+      list-style: none;
+      padding-left : 0px;
+      }
+
+    </style>
+    <div class="jumbotron">
+        <div class="container">
+            <div class="row">
+                <div class="col-9">
+                    <div class="row">
+                        <div class="col-md-3 px-4">
+                            <h3>로그인</h3>
+                        </div>
+                        <div class="col-md-9">
+                            <nav class="navbar navbar-expand-md">
+                                <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                    <li>-</li>
+                                    <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                                    <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                                    <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                                </ul>
+                            </nav>
+                        </div>
                     </div>
                 </div>
             </div>
         </div>
     </div>
-</div>
-<div class="container" style="padding:0;">
-    <div class="row">
-        <aside class="col-md-3 px-4">
-            <div class="row">
-                <div class="col-1"></div>
-                <div class="col-8">
-                    <div class="panel">
-                        <ul class="list-group">
-                            <li><a th:href="@{/user/login}" class="nav-link px-2" style="color: #03C75A;">로그인</a></li>
-                            <li><a th:href="@{/user/signup}" class="nav-link px-2">회원가입</a></li>
-                        </ul>
-                    </div>
-                </div>
-            </div>
-        </aside>
-        <div class="col-md-9">
-            <div class="row justify-content-center">
-                <div class="col-6 border" id="loginbox" style="text-align:center;">
-                    <div class="px-3 py-4" style="text-align: center; ">
-                        <h2>회원탈퇴 완료</h2>
-                    </div>
-
-                    <div class="row px-3 py-2">
-                        <div class="col-12">
-                            <hr>
+    <div class="container" style="padding:0;">
+        <div class="row">
+            <aside class="col-md-3 px-4">
+                <div class="row">
+                    <div class="col-1"></div>
+                    <div class="col-8">
+                        <div class="panel">
+                            <ul class="list-group">
+                                <li><a th:href="@{/user/login}" class="nav-link px-2" style="color: #03C75A;">로그인</a>
+                                </li>
+                                <li><a th:href="@{/user/signup}" class="nav-link px-2">회원가입</a></li>
+                            </ul>
                         </div>
                     </div>
+                </div>
+            </aside>
+            <div class="col-md-9">
+                <div class="row justify-content-center">
+                    <div class="col-6 border" id="loginbox" style="text-align:center;">
+                        <div class="px-3 py-4" style="text-align: center; ">
+                            <h2>회원탈퇴 완료</h2>
+                        </div>
 
-                    <div style="padding: 50px 0;">
-                        회원 탈퇴가 완료되었습니다.<br>
-                        탈퇴한 회원의 정보는<br>
-                        개인정보보호법 및 회원정보관리약관에 의해<br>
-                        1년간 보존됨을 알려 드립니다.<br>
-                        감사합니다.
+                        <div class="row px-3 py-2">
+                            <div class="col-12">
+                                <hr>
+                            </div>
+                        </div>
+
+                        <div style="padding: 50px 0;">
+                            회원 탈퇴가 완료되었습니다.<br>
+                            탈퇴한 회원의 정보는<br>
+                            개인정보보호법 및 회원정보관리약관에 의해<br>
+                            1년간 보존됨을 알려 드립니다.<br>
+                            감사합니다.
+                        </div>
+                        <div class="col-12 pt-3 pb-4">
+                            <button type="submit" class="btn btn-primary btn-block" onclick="location.href='/'"
+                                    style="background-color:grey; height:50px;">첫페이지로 이동
+                            </button>
+                        </div>
+
+
                     </div>
-                    <div class="col-12 pt-3 pb-4">
-                        <button type="submit" class="btn btn-primary btn-block" onclick="location.href='/'"
-                                style="background-color:grey; height:50px;">첫페이지로 이동
-                        </button>
-                    </div>
-
-
                 </div>
             </div>
         </div>

--- a/src/main/resources/templates/user/withdrawn.html
+++ b/src/main/resources/templates/user/withdrawn.html
@@ -1,0 +1,138 @@
+<!DOCTYPE html>
+<html xmlns:th="http://www.thymeleaf.org" xmlns:layout="http://www.w3.org/1999/xhtml">
+<html layout:decorate="~{layout}">
+<head>
+    <title>툰게더 toonGather | 로그인</title>
+    <meta charset="UTF-8">
+
+    <!-- Latest compiled and minified CSS -->
+    <link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css">
+    <!-- 폰트: 'Noto Sans KR' 사용 -->
+    <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap">
+    <!-- 프로젝트 툰게더 전용 css 스타일 시트 -->
+    <link rel="stylesheet" th:href="@{/css/styles.css}">
+
+    <!-- jQuery library -->
+    <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js"></script>
+
+    <!-- Latest compiled JavaScript -->
+    <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.5.2/js/bootstrap.min.js"></script>
+
+    <style>
+        .navbar {
+          position: fixed;
+          z-index: 1000;
+        }
+    </style>
+</head>
+<body>
+
+<div th:replace="~{common/menubar}"></div>
+<style>
+    .jumbotron {
+    position : relative;
+    background-color : #EEEEEE;
+    }
+    .jumbotron .row {
+    position : absolute;
+    width : 100%;
+    bottom: 0%;
+    }
+
+    #loginbox {
+    border-radius : 5%;
+    border-color : #F2F2F2;
+    }
+
+    .logininput {
+    background-color : #FCFCFC;
+    border : none;
+    height : 50px;
+    }
+
+    .logininput::placeholder {
+    color : #BBBBBB;
+    }
+
+     .nav-link {
+            color: #828282;
+    }
+    ul {
+  list-style: none;
+  padding-left : 0px;
+  }
+
+</style>
+<div class="jumbotron">
+    <div class="container">
+        <div class="row">
+            <div class="col-9">
+                <div class="row">
+                    <div class="col-md-3 px-4">
+                        <h3>로그인</h3>
+                    </div>
+                    <div class="col-md-9">
+                        <nav class="navbar navbar-expand-md">
+                            <ul class="nav col-12 col-md-auto mb-4 justify-content mb-md-3">
+                                <li>-</li>
+                                <!--          <li><a th:href="@{/user/my/in/journal}" class="nav-link px-2">좋아요한 웹툰소식</a></li>-->
+                                <!--          <li><a th:href="@{/user/my/in/event}" class="nav-link px-2">좋아요한 행사</a></li>-->
+                                <!--          <li><a th:href="@{/user/my/in/merchan}" class="nav-link px-2">좋아요한 굿즈</a></li>-->
+                            </ul>
+                        </nav>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<div class="container" style="padding:0;">
+    <div class="row">
+        <aside class="col-md-3 px-4">
+            <div class="row">
+                <div class="col-1"></div>
+                <div class="col-8">
+                    <div class="panel">
+                        <ul class="list-group">
+                            <li><a th:href="@{/user/login}" class="nav-link px-2" style="color: #03C75A;">로그인</a></li>
+                            <li><a th:href="@{/user/signup}" class="nav-link px-2">회원가입</a></li>
+                        </ul>
+                    </div>
+                </div>
+            </div>
+        </aside>
+        <div class="col-md-9">
+            <div class="row justify-content-center">
+                <div class="col-6 border" id="loginbox" style="text-align:center;">
+                    <div class="px-3 py-4" style="text-align: center; ">
+                        <h2>회원탈퇴 완료</h2>
+                    </div>
+
+                    <div class="row px-3 py-2">
+                        <div class="col-12">
+                            <hr>
+                        </div>
+                    </div>
+
+                    <div style="padding: 50px 0;">
+                        회원 탈퇴가 완료되었습니다.<br>
+                        탈퇴한 회원의 정보는<br>
+                        개인정보보호법 및 회원정보관리약관에 의해<br>
+                        1년간 보존됨을 알려 드립니다.<br>
+                        감사합니다.
+                    </div>
+                    <div class="col-12 pt-3 pb-4">
+                        <button type="submit" class="btn btn-primary btn-block" onclick="location.href='/'"
+                                style="background-color:grey; height:50px;">첫페이지로 이동
+                        </button>
+                    </div>
+
+
+                </div>
+            </div>
+        </div>
+    </div>
+</div>
+<div th:replace="common/footer.html"></div>
+</body>
+</html>


### PR DESCRIPTION
**[강현구-240819] merge :: 통합테스트 대비 보완**
[강현구-240817-01] chore :: 레이아웃 수정 (1/2)
header 및 footer에 정렬되도록 레이아웃을 수정합니다.
[강현구-240817-02] chore :: 레이아웃 수정 (1/2)
header 및 footer에 정렬되도록 레이아웃을 수정합니다.
[강현구-240817-03] chore :: 나의채용 LNB수정
나의채용 [창작자 등록 현황] 페이지를 서영님이 구현하신 페이지(/recruit/creator/mypage_editCreator)로 이동 가능토록 하였습니다.
[강현구-240817-04] chore :: 나의채용 LNB수정
나의채용 LNB에서 순서 수정이 있었습니다.
[강현구-240817-05] chore :: 마이페이지 2차LNB 레이아웃 수정
[강현구-240817-06] chore :: 마이페이지 2차LNB 레이아웃 수정(2)
[강현구-240817-07] chore :: 마이페이지 1차LNB 레이아웃 수정
[강현구-240817-07] chore :: 마이페이지 1차LNB 레이아웃 수정(누락된것)
[강현구-240817-08] chore :: 관리자_회원관리 프론트 수정
[강현구-240817-09] fix :: 가입_이메일인증 수정
-- 클라이언트 사이드에서 alert창이 정상적으로 작동되지 않는 문제를 해결했습니다.
[강현구-240817-10] fix :: ID찾기 수정
-- 입력 항목을 기존 "닉네임/연락처"에서 "닉네임/이메일"로 바꾸었습니다. (필수입력항목을 반영하기 위함)
[강현구-240817-11] fix :: PW찾기 수정
-- 밸리데이션 체크 수정했습니다.
[강현구-240817-12] feat :: ID찾기
-- 소셜을 통해 가입한 경우, 닉네임만 일치해도 소셜을 통한 가입 유무를 알려주도록 로직 설정했습니다.
[강현구-240817-13] fix :: 프로필사진 업로드 후
-- 프로필사진 업로드 후, 업로드된 사진이 바로 보여질 수 있도록 자바스크립트 코드로써 구현했습니다.
[강현구-240817-14] chore :: 나의웹툰_북마크한웹툰
-- tags 중에 최초의 해시태그만 출력되도록 적용했습니다.
[강현구-240817-15] chore :: 프론트작업_검색바 수정
-- 검색바를 UI설계서에 더 가깝게 수정했습니다.
[강현구-240817-16] chore :: 프론트작업_나의웹툰_내가남긴코멘트
-- 사소한 수정(jumbotron 세로길이 다른것)
[강현구-240817-17] chore :: 프론트작업_프로필수정
-- 사소한 수정(jumbotron 세로길이 다른것)
[강현구-240818-01] chore :: 프론트작업_관리자_회원관리
-- 검색바 수정
[강현구-240818-02] fix :: 소셜가입시 이메일설정
-- 이메일이 DB에서 UK로 관리되므로, 이에 맞게 설정
[강현구-240818-03] fix :: 프로필수정-회원탈퇴
-- 회원탈퇴는 기본적으로 users.withdrawn의 값을 'Y'로 바꾸는 작업입니다.
-- 탈퇴후 재가입 (1) 소셜회원의 경우 재가입시 이전 정보를 복원합니다.(비활성화 해제 개념)
-- 탈퇴후 재가입 (2) 일반회원의 경우 같은 아이디로 재가입이 불가능합니다.(비활성화 해제 불가)
[강현구-240818-04] fix :: 프로필수정
-- 프로필 수정 성공/실패시 이에 맞는 alert창을 띄우도록 하였습니다.
[강현구-240818-05] fix :: 프로필수정
-- 밸리데이션체크 사소한 수정('회원정보 수정을 위해' 비밀번호 입력해주세요)
[강현구-240818-06] chore :: 프론트_대시보드
-- 사소한 수정('창작자 등록' -> '창작자 정보 수정', 링크도 수정)
[강현구-240818-07] fix :: 관리자_회원상세
-- 관리자가 회원정보 수정완료/실패시 alert창 띄우도록 하였습니다.
[강현구-240818-08] fix :: 관리자_회원목록/상세 강제탈퇴와 재활성화
-- 관리자 회원 강제탈퇴 수정
-- 재활성화 기능 추가 : 관리자만 사용할 수 있는 기능으로, 탈퇴된 회원의 탈퇴를 취소할 수 있습니다.
-- 회원상세 : "강제탈퇴" 버튼을 클릭시 "강제탈퇴 취소"로, 그 반대의 경우도 되게끔 동기식으로 구현했습니다.
-- 회원목록 : 토글 OFF시 (탈퇴X) 회원만, 토글 ON시 탈퇴한 회원을 출력합니다. (다른 토글들과는 다르게 상호배타적으로 구현함)
[강현구-240818-09] chore :: 프론트작업_프로필수정(회원/관리자)
-- UI 배치에 사소한 변화를 주었습니다.
[강현구-240818-10] chore :: 프론트작업_검색버튼
-- 사소한 변화 (색상 변화)
[강현구-240818-11] chore :: 프론트작업_푸터붙박이
-- 푸터 페이지하단에 붙도록 설정했습니다
[강현구-240818-12] fix :: 회원가입_이메일인증
-- 이메일 밸리데이션을 통과한 경우에만 ajax 요청이 실행되도록 구현했습니다.
[강현구-240818-13] fix :: 소셜로그인유저의 탈퇴후재가입시 재가입이 안되는 현상
-- 잘못된 로직을 수정했습니다.
[강현구-240818-15] fix :: 회원 밸리데이션 js로 정리
-- 회원 CRUD의 밸리데이션 로직을 static/js 폴더에 js파일로 정리하였습니다.
-- uservalidation.js : signup.html
-- uservalidation2.js : mypage_editprofile.html
-- uservalidation3.js : /admin/userdetails.html
과 각각 연결시켰습니다. 각 파일별로 차이점이 있어 각각으로 나눕니다.
[강현구-240818-15] fix :: 관리자_회원목록 소팅기준 추가
-- 소팅기준 '최근수정순' 추가하였습니다.
[강현구-240818-16] fix :: 회원가입_이메일인증
-- 이메일인증시 alert창을 상황에 맞게 수정했습니다.
[강현구-240818-17] fix :: ID찾기
-- 로직에 결함이 있어 논리적으로 수정했습니다.
[강현구-240818-19] fix :: ID찾기/PW찾기
-- ID찾기 : 닉네임/이메일 밸리데이션 버그수정
-- PW찾기 : 아이디/이메일 밸리데이션 버그수정