### PR TITLE
[강현구-240820] merge :: 통합테스트 FAIL 해결

### DIFF
--- a/src/main/java/com/multi/toonGather/config/SecurityConfig.java
+++ b/src/main/java/com/multi/toonGather/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.multi.toonGather.config;
 
+import com.multi.toonGather.security.CustomAuthenticationFailureHandler;
 import com.multi.toonGather.security.CustomUserDetailsService;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -10,6 +11,7 @@ import org.springframework.security.config.annotation.web.configuration.WebSecur
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 import org.springframework.security.web.util.matcher.AntPathRequestMatcher;
 
 @Configuration
@@ -35,6 +37,11 @@ public class SecurityConfig {
         authProvider.setUserDetailsService(customUserDetailsService);
         authProvider.setPasswordEncoder(passwordEncoder());
         return authProvider;
+    }
+
+    @Bean
+    public AuthenticationFailureHandler authenticationFailureHandler() {
+        return new CustomAuthenticationFailureHandler();
     }
 
 //    @Bean
@@ -84,7 +91,8 @@ public class SecurityConfig {
 //                );
         http    //Form 로그인 설정 : 커스텀로그인 페이지와 로그인처리URL을 설정함
                 .formLogin((auth) -> auth.loginPage("/user/login")
-                        .loginProcessingUrl("/user/login").permitAll());
+                        .loginProcessingUrl("/user/login").permitAll()
+                        .failureHandler(authenticationFailureHandler()));
 
         http    //로그아웃 설정
                 .logout(logout -> logout

--- a/src/main/java/com/multi/toonGather/security/CustomAuthenticationFailureHandler.java
+++ b/src/main/java/com/multi/toonGather/security/CustomAuthenticationFailureHandler.java
@@ -1,0 +1,39 @@
+package com.multi.toonGather.security;
+
+import com.multi.toonGather.user.service.UserService;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.web.authentication.AuthenticationFailureHandler;
+
+import java.io.IOException;
+
+public class CustomAuthenticationFailureHandler implements AuthenticationFailureHandler {
+    @Autowired
+    private UserService userService;
+    @Autowired
+    private CustomUserDetailsService customUserDetailsService;
+
+    @Override
+    public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response, AuthenticationException exception) throws IOException, ServletException {
+        String msg = "";
+        String ID = request.getParameter("username");
+        String PW = request.getParameter("password");
+        BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
+        CustomUserDetails customUserDetails = (CustomUserDetails) customUserDetailsService.loadUserByUsername(ID);
+        String password = customUserDetails.getPassword();
+        if(password == null || password.equals("")) {
+            msg = "NotFound";
+        }
+        boolean result = encoder.matches(PW, password);
+        if(result == false) {
+            msg = "NotFound";
+        }
+
+        //msg = URLEncoder.encode(msg, "UTF-8");
+        response.sendRedirect("/user/login?msg=" + msg);
+    }
+}

--- a/src/main/java/com/multi/toonGather/security/CustomAuthenticationFailureHandler.java
+++ b/src/main/java/com/multi/toonGather/security/CustomAuthenticationFailureHandler.java
@@ -6,6 +6,7 @@ import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.authentication.AuthenticationFailureHandler;
 
@@ -22,16 +23,24 @@ public class CustomAuthenticationFailureHandler implements AuthenticationFailure
         String msg = "";
         String ID = request.getParameter("username");
         String PW = request.getParameter("password");
+
         BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
-        CustomUserDetails customUserDetails = (CustomUserDetails) customUserDetailsService.loadUserByUsername(ID);
-        String password = customUserDetails.getPassword();
-        if(password == null || password.equals("")) {
-            msg = "NotFound";
+        try {
+            CustomUserDetails customUserDetails = (CustomUserDetails) customUserDetailsService.loadUserByUsername(ID);
+            String password = customUserDetails.getPassword();
+            if(password == null || password.equals("")) {
+                msg = "notFound";
+            }
+            boolean result = encoder.matches(PW, password);
+            if(result == false) {
+                msg = "notFound";
+            }
+        } catch(UsernameNotFoundException e) {
+            msg ="notFound";
         }
-        boolean result = encoder.matches(PW, password);
-        if(result == false) {
-            msg = "NotFound";
-        }
+
+
+
 
         //msg = URLEncoder.encode(msg, "UTF-8");
         response.sendRedirect("/user/login?msg=" + msg);

--- a/src/main/java/com/multi/toonGather/user/model/dto/MyInEventDTO.java
+++ b/src/main/java/com/multi/toonGather/user/model/dto/MyInEventDTO.java
@@ -42,11 +42,21 @@ public class MyInEventDTO {
     public String getFormattedEventDuration() {
         LocalDate today = LocalDate.now();
 
-        // NOW > 시작날짜 return "시작"+"전";
-        if(today.isBefore(startDate)){
-            return "시작 "+ TimeAgoUtils.formatTimeAgo(startDate.atStartOfDay());
+        // endDate가 NULL인 경우
+        if (endDate == null) {
+            if (today.isBefore(startDate)) {
+                return "시작 " + TimeAgoUtils.formatTimeAgo(startDate.atStartOfDay());
+            } else if (today.isEqual(startDate)) {
+                return "오늘 진행";
+            } else {
+                return "종료됨";
+            }
         }
-        else if (!today.isAfter(endDate)) {
+
+        // endDate가 NULL이 아닌 경우
+        if (today.isBefore(startDate)) {
+            return "시작 " + TimeAgoUtils.formatTimeAgo(startDate.atStartOfDay());
+        } else if (!today.isAfter(endDate)) {
             // 시작날짜 <= NOW <= 종료날짜
             if (today.equals(endDate)) {
                 return "오늘 종료";
@@ -57,6 +67,6 @@ public class MyInEventDTO {
             // NOW > 종료날짜
             return "종료됨";
         }
-
     }
+
 }

--- a/src/main/java/com/multi/toonGather/user/model/dto/MyInMerchanDTO.java
+++ b/src/main/java/com/multi/toonGather/user/model/dto/MyInMerchanDTO.java
@@ -5,6 +5,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.text.NumberFormat;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -32,5 +33,9 @@ public class MyInMerchanDTO {
     //시간 view에 뿌려줄 때
     public String getFormattedPostingDate() {
         return TimeAgoUtils.formatTimeAgo(postingDate);
+    }
+
+    public String getFormattedDiscountPrice() {
+        return NumberFormat.getInstance().format(this.discountPrice);
     }
 }

--- a/src/main/java/com/multi/toonGather/user/model/dto/MyRctApplicationDTO.java
+++ b/src/main/java/com/multi/toonGather/user/model/dto/MyRctApplicationDTO.java
@@ -30,6 +30,9 @@ public class MyRctApplicationDTO {
     private LocalDateTime jobModifiedDate;
     private LocalDateTime jobDeadLine;
 
+    //조인2하여 가져올 것 (from users)
+    private String applyUserId;//
+
     //시간 view에 뿌려줄 때
     public String getFormattedApplyCreatedDate() {
         if(applyCreatedDate == null) return "미정";

--- a/src/main/resources/mappers/user/MyMapper.xml
+++ b/src/main/resources/mappers/user/MyMapper.xml
@@ -339,10 +339,10 @@
                 ORDER BY srl.like_no ASC
             </when>
             <when test="orderBy == 'recentadded'">
-                ORDER BY sr.created_date DESC
+                ORDER BY srl.review_no DESC
             </when>
             <when test="orderBy == 'oldestadded'">
-                ORDER BY sr.created_date ASC
+                ORDER BY srl.review_no ASC
             </when>
             <when test="orderBy == 'highrated'">
                 ORDER BY sr.star_rating DESC

--- a/src/main/resources/mappers/user/MyMapper.xml
+++ b/src/main/resources/mappers/user/MyMapper.xml
@@ -1572,7 +1572,7 @@
             </choose>
         </if>
         <if test="toggleValue == 'Y'">
-            AND im.discount_price > 1000
+            AND im.regular_price IS NOT NULL
         </if>
         <choose>
             <when test="orderBy == 'recentliked'">
@@ -1588,10 +1588,10 @@
                 ORDER BY iml.merchan_no ASC
             </when>
             <when test="orderBy == 'expensive'">
-                ORDER BY im.regular_price DESC
+                ORDER BY im.discount_price DESC
             </when>
             <when test="orderBy == 'cheap'">
-                ORDER BY im.regular_price ASC
+                ORDER BY im.discount_price ASC
             </when>
             <when test="orderBy == 'title'">
                 ORDER BY im.title ASC

--- a/src/main/resources/mappers/user/MyMapper.xml
+++ b/src/main/resources/mappers/user/MyMapper.xml
@@ -234,7 +234,12 @@
                 ORDER BY board_no ASC
             </when>
             <when test="orderBy == 'dueSoon'">
-                ORDER BY dead_line ASC
+                ORDER BY
+                CASE
+                WHEN dead_line IS NULL THEN 1
+                ELSE 0
+                END ASC,
+                dead_line ASC
             </when>
             <when test="orderBy == 'title'">
                 ORDER BY title ASC
@@ -1058,7 +1063,12 @@
                 ORDER BY rja.board_no ASC
             </when>
             <when test="orderBy == 'dueSoon'">
-                ORDER BY rj.dead_line ASC
+                ORDER BY
+                CASE
+                WHEN rj.dead_line IS NULL THEN 1
+                ELSE 0
+                END ASC,
+                dead_line ASC
             </when>
             <when test="orderBy == 'title'">
                 ORDER BY rj.title ASC

--- a/src/main/resources/mappers/user/MyMapper.xml
+++ b/src/main/resources/mappers/user/MyMapper.xml
@@ -982,6 +982,8 @@
         <result property="jobCreatedDate" column="created_date"/>
         <result property="jobModifiedDate" column="modified_date"/>
         <result property="jobDeadLine" column="dead_line"/>
+
+        <result property="applyUserId" column="user_id"/>
     </resultMap>
     <sql id="MyRctApplicationQueryA">
         SELECT
@@ -1001,7 +1003,9 @@
         rj.img AS jobImg,
         rj.created_date AS jobCreatedDate,
         rj.modified_date AS jobModifiedDate,
-        rj.dead_line AS jobDeadLine
+        rj.dead_line AS jobDeadLine,
+
+        u.user_id AS applyUserId
     </sql>
     <sql id="MyRctApplicationQueryB">
         FROM
@@ -1010,6 +1014,9 @@
         rct_job_apply rja
         ON
         rj.board_no = rja.board_no
+        INNER JOIN
+        users u
+        ON rja.writer = u.user_no  <!-- 추가된 부분 -->
         WHERE
         rja.writer = #{userNo}
         <if test="searchBy != null and searchTerm != null and searchTerm != ''">
@@ -1089,7 +1096,9 @@
         rj.img AS jobImg,
         rj.created_date AS jobCreatedDate,
         rj.modified_date AS jobModifiedDate,
-        rj.dead_line AS jobDeadLine
+        rj.dead_line AS jobDeadLine,
+
+        u.user_id AS applyUserId
     </sql>
     <sql id="MyRctJobApplicationQueryB">
         FROM
@@ -1098,6 +1107,9 @@
         rct_job_apply rja
         ON
         rj.board_no = rja.board_no
+        INNER JOIN
+        users u
+        ON rja.writer = u.user_no  <!-- 추가된 부분 -->
         WHERE
         rja.board_no = #{boardNo}
         <if test="searchBy != null and searchTerm != null and searchTerm != ''">

--- a/src/main/resources/mappers/user/MyMapper.xml
+++ b/src/main/resources/mappers/user/MyMapper.xml
@@ -759,10 +759,10 @@
                 ORDER BY iel.liked_no ASC
             </when>
             <when test="orderBy == 'recent'">
-                ORDER BY ie.event_no DESC
+                ORDER BY ie.start_date DESC
             </when>
             <when test="orderBy == 'oldest'">
-                ORDER BY ie.event_no ASC
+                ORDER BY ie.start_date ASC
             </when>
             <when test="orderBy == 'title'">
                 ORDER BY ie.title ASC

--- a/src/main/resources/static/js/uservalidation.js
+++ b/src/main/resources/static/js/uservalidation.js
@@ -56,6 +56,7 @@
         return emailPattern.test(email);
     }
 
+
     // 폼 제출 전에 모든 필드를 검증하는 함수
     async function validateForm(event) {
         event.preventDefault(); // 폼 제출 기본 동작 방지
@@ -92,6 +93,7 @@
             // (B5) 약관동의
             const termsCheckbox = document.getElementById('termsAgreementCheckbox');
             var verificationCheckbox = document.getElementById('verificationCheckbox');
+
 
 
         // (B0) 아이디 검증 (공란O/형식O/자수O)
@@ -160,6 +162,24 @@
         // (B5) 필수 약관동의 검증 (공란O/형식-/자수-)
         if (!termsCheckbox.checked) {
             alert('필수 약관에 동의하지 않았습니다.');
+            event.preventDefault(); // 폼 제출을 막음
+            return;
+        }
+
+        // (B6) 생년월일의 유효성 (공란-/형식O/자수-)
+        const yearSelect = document.getElementById('year');
+        const monthSelect = document.getElementById('month');
+        const daySelect = document.getElementById('day');
+
+        const year = parseInt(yearSelect.value);
+        const month = parseInt(monthSelect.value) - 1; // JS에서 월은 0부터 시작
+        const day = parseInt(daySelect.value);
+
+        const selectedDate = new Date(year, month, day);
+        const today = new Date();
+
+        if (selectedDate > today) {
+            alert("생년월일을 정확히 입력해주세요.");
             event.preventDefault(); // 폼 제출을 막음
             return;
         }

--- a/src/main/resources/static/js/uservalidation2.js
+++ b/src/main/resources/static/js/uservalidation2.js
@@ -173,6 +173,24 @@
         //     return;
         // }
 
+        // (B6) 생년월일의 유효성 (공란-/형식O/자수-)
+        const yearSelect = document.getElementById('year');
+        const monthSelect = document.getElementById('month');
+        const daySelect = document.getElementById('day');
+
+        const year = parseInt(yearSelect.value);
+        const month = parseInt(monthSelect.value) - 1; // JS에서 월은 0부터 시작
+        const day = parseInt(daySelect.value);
+
+        const selectedDate = new Date(year, month, day);
+        const today = new Date();
+
+        if (selectedDate > today) {
+            alert("생년월일을 정확히 입력해주세요.");
+            event.preventDefault(); // 폼 제출을 막음
+            return;
+        }
+
         // (C1~C3) 중복체크 3종(아이디/닉네임/이메일)의 더블체크
         const isDuplicate = await checkDuplicates(/*userId,*/ nickname, email);
 

--- a/src/main/resources/static/js/uservalidation3.js
+++ b/src/main/resources/static/js/uservalidation3.js
@@ -176,6 +176,24 @@
         //     return;
         // }
 
+        // (B6) 생년월일의 유효성 (공란-/형식O/자수-)
+        const yearSelect = document.getElementById('year');
+        const monthSelect = document.getElementById('month');
+        const daySelect = document.getElementById('day');
+
+        const year = parseInt(yearSelect.value);
+        const month = parseInt(monthSelect.value) - 1; // JS에서 월은 0부터 시작
+        const day = parseInt(daySelect.value);
+
+        const selectedDate = new Date(year, month, day);
+        const today = new Date();
+
+        if (selectedDate > today) {
+            alert("생년월일을 정확히 입력해주세요.");
+            event.preventDefault(); // 폼 제출을 막음
+            return;
+        }
+
         // (C1~C3) 중복체크 3종(아이디/닉네임/이메일)의 더블체크
         const isDuplicate = await checkDuplicates(/*userId,*/ nickname, email);
 

--- a/src/main/resources/templates/user/admin/userdetails.html
+++ b/src/main/resources/templates/user/admin/userdetails.html
@@ -109,7 +109,7 @@
 
         .profile-image {
         width: 100px;
-        height: auto;
+        height: 100px;
         border-radius: 50%;
         object-fit: cover;
         margin-right: 15px;
@@ -192,10 +192,10 @@
                                     <div id="imagePreview">
                                         <img th:if="${user.profileImagePath == null}"
                                              src="/images/defaultprofileimage.png"
-                                             style="width: 100px; height: auto;" class="profile-image"/>
+                                             style="width: 100px; height: 100px;" class="profile-image"/>
                                         <img th:if="${user.profileImagePath != null}"
                                              th:src="@{/uploadFiles/{fileName}(fileName=${user.profileImagePath})}"
-                                             style="width: 100px; height: auto;" class="profile-image"/>
+                                             style="width: 100px; height: 100px;" class="profile-image"/>
                                     </div>
                                     <div id="profileuploadbutton">
                                         <label for="image">
@@ -469,7 +469,7 @@
 
               // 스타일과 클래스 추가
               imgElement.style.width = '100px';
-              imgElement.style.height = 'auto';
+              imgElement.style.height = '100px';
               imgElement.className = 'profile-image';
 
               imagePreview.appendChild(imgElement);

--- a/src/main/resources/templates/user/login.html
+++ b/src/main/resources/templates/user/login.html
@@ -184,5 +184,15 @@
 </div>
 
 <div th:replace="common/footer.html"></div>
+<script>
+    //로그인 실패시 알림
+      window.onload = function() {
+            const urlParams = new URLSearchParams(window.location.search);
+            const msg = urlParams.get('msg');
+            if (msg === 'NotFound') {
+                alert("로그인에 실패했습니다. 다시 시도해주세요.");
+            }
+        }
+</script>
 </body>
 </html>

--- a/src/main/resources/templates/user/login.html
+++ b/src/main/resources/templates/user/login.html
@@ -189,7 +189,7 @@
       window.onload = function() {
             const urlParams = new URLSearchParams(window.location.search);
             const msg = urlParams.get('msg');
-            if (msg === 'NotFound') {
+            if (msg === 'notFound') {
                 alert("로그인에 실패했습니다. 다시 시도해주세요.");
             }
         }

--- a/src/main/resources/templates/user/mypage_dashboard.html
+++ b/src/main/resources/templates/user/mypage_dashboard.html
@@ -577,11 +577,11 @@
                                 <h3>나의 채용</h3>
                             </div>
                             <div class="col-12 clickable-row my-4"
-                                 style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                 style="background-color: rgba(255,255,255,0.9); border-radius: 15px; padding: 1.5rem 1.2rem;"
                                  th:attr="data-href=@{/user/my/rct/job}">
                                 <div class="row justify-content-center">
                                     <div class="col-2 p-0 d-flex align-items-center justify-content-center"
-                                         style="aspect-ratio: 1; border-radius: 5px;">
+                                         style="opacity:0; aspect-ratio: 1; border-radius: 5px;">
                                         <div class="date-container px-2 py-1">
                                             <div class="month">8</div>
                                             <div class="year">2024</div>
@@ -627,11 +627,11 @@
 
                             </div>
                             <div class="col-12 clickable-row"
-                                 style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                 style="background-color: rgba(255,255,255,0.9); border-radius: 15px; padding: 1.5rem 1.2rem;"
                                  th:attr="data-href=@{/user/my/rct/free}">
                                 <div class="row justify-content-center">
                                     <div class="col-2 p-0 d-flex align-items-center justify-content-center"
-                                         style="aspect-ratio: 1; border-radius: 5px;">
+                                         style="opacity:0; aspect-ratio: 1; border-radius: 5px;">
                                         <div class="date-container px-2 py-1">
                                             <div class="month">8</div>
                                             <div class="year">2024</div>
@@ -684,11 +684,11 @@
                                 <h3>나의 지원서</h3>
                             </div>
                             <div class="col-12 clickable-row my-4"
-                                 style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                 style="background-color: rgba(255,255,255,0.9); border-radius: 15px; padding: 1.5rem 1.2rem;"
                                  th:attr="data-href=@{/user/my/rct/apply}">
                                 <div class="row justify-content-center">
                                     <div class="col-2 p-0 d-flex align-items-center justify-content-center"
-                                         style="aspect-ratio: 1; border-radius: 5px;">
+                                         style="opacity:0; aspect-ratio: 1; border-radius: 5px;">
                                         <div class="date-container px-2 py-1">
                                             <div class="month">8</div>
                                             <div class="year">2024</div>
@@ -734,11 +734,11 @@
 
                             </div>
                             <div class="col-12 clickable-row"
-                                 style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                 style="background-color: rgba(255,255,255,0.9); border-radius: 15px; padding: 1.5rem 1.2rem;"
                                  th:attr="data-href=@{/user/my/rct/order}">
                                 <div class="row justify-content-center">
                                     <div class="col-2 p-0 d-flex align-items-center justify-content-center"
-                                         style="aspect-ratio: 1; border-radius: 5px;">
+                                         style="opacity:0; aspect-ratio: 1; border-radius: 5px;">
                                         <div class="date-container px-2 py-1">
                                             <div class="month">8</div>
                                             <div class="year">2024</div>
@@ -790,11 +790,11 @@
                                 <h3>나의 소식</h3>
                             </div>
                             <div class="col-12 clickable-row my-4"
-                                 style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                 style="background-color: rgba(255,255,255,0.9); border-radius: 15px; padding: 1.5rem 1.2rem;"
                                  th:attr="data-href=@{/user/my/in/journal}">
                                 <div class="row justify-content-center">
                                     <div class="col-2 p-0 d-flex align-items-center justify-content-center"
-                                         style="aspect-ratio: 1; border-radius: 5px;">
+                                         style="opacity:0; aspect-ratio: 1; border-radius: 5px;">
                                         <div class="date-container px-2 py-1">
                                             <div class="month">8</div>
                                             <div class="year">2024</div>
@@ -840,11 +840,11 @@
 
                             </div>
                             <div class="col-12 clickable-row"
-                                 style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
+                                 style="background-color: rgba(255,255,255,0.9); border-radius: 15px; padding: 1.5rem 1.2rem;"
                                  th:attr="data-href=@{/user/my/in/event}">
                                 <div class="row justify-content-center">
                                     <div class="col-2 p-0 d-flex align-items-center justify-content-center"
-                                         style="aspect-ratio: 1; border-radius: 5px;">
+                                         style="opacity:0; aspect-ratio: 1; border-radius: 5px;">
                                         <div class="date-container px-2 py-1">
                                             <div class="month">8</div>
                                             <div class="year">2024</div>

--- a/src/main/resources/templates/user/mypage_dashboard.html
+++ b/src/main/resources/templates/user/mypage_dashboard.html
@@ -143,7 +143,7 @@
 
         .profile-image {
         width: 100px;
-        height: auto;
+        height: 100px;
         border-radius: 50%;
         object-fit: cover;
         margin-right: 15px;
@@ -337,10 +337,10 @@
                                         <div class="col-4 m-0 p-0" id="profileimagebox">
                                             <img th:if="${user.profileImagePath == null}"
                                                  th:src="@{/images/defaultprofileimage.png}"
-                                                 style="width: 100px; height: auto;" class="profile-image"/>
+                                                 style="width: 100px; height: 100px;" class="profile-image"/>
                                             <img th:if="${user.profileImagePath != null}"
                                                  th:src="@{/uploadFiles/{fileName}(fileName=${user.profileImagePath})}"
-                                                 style="width: 100px; height: auto;" class="profile-image"/>
+                                                 style="width: 100px; height: 100px;" class="profile-image"/>
                                         </div>
                                         <div class="col-8">
                                             <div class="row">

--- a/src/main/resources/templates/user/mypage_editprofile.html
+++ b/src/main/resources/templates/user/mypage_editprofile.html
@@ -118,7 +118,7 @@
 
       .profile-image {
       width: 100px;
-      height: auto;
+      height: 100px;
       border-radius: 50%;
       object-fit: cover;
       margin-right: 15px;
@@ -198,10 +198,10 @@
                 <div class="col-3 m-0 p-0" id="profileimagebox">
                   <div id="imagePreview">
                     <img th:if="${user.profileImagePath == null}" src="/images/defaultprofileimage.png"
-                         style="width: 100px; height: auto;" class="profile-image"/>
+                         style="width: 100px; height: 100px;" class="profile-image"/>
                     <img th:if="${user.profileImagePath != null}"
                          th:src="@{/uploadFiles/{fileName}(fileName=${user.profileImagePath})}"
-                         style="width: 100px; height: auto;" class="profile-image"/>
+                         style="width: 100px; height: 100px;" class="profile-image"/>
                   </div>
                   <div id="profileuploadbutton">
                     <label for="image">
@@ -436,7 +436,7 @@
 
             // 스타일과 클래스 추가
             imgElement.style.width = '100px';
-            imgElement.style.height = 'auto';
+            imgElement.style.height = '100px';
             imgElement.className = 'profile-image';
 
             imagePreview.appendChild(imgElement);

--- a/src/main/resources/templates/user/mypage_in_event.html
+++ b/src/main/resources/templates/user/mypage_in_event.html
@@ -502,7 +502,7 @@
                                         <div class="row justify-content-center">
                                             <div class="col-12 my-3" style="">
                                                 <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                                <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                                <img th:unless="${#lists.size(myInEvent.eventFiles) > 0}" src="/images/user/mypage_bg01.jpg" class="card-img-top" alt="기본 썸네일 이미지" style="filter: brightness(1.2);" >
                                                 <!-- 썸네일 이미지 있을때  -->
                                                 <img th:if="${#lists.size(myInEvent.eventFiles) > 0}"
                                                      th:src="@{/uploadFiles/{fileName}(fileName=${myInEvent.eventFiles.get(0).fileName})}"

--- a/src/main/resources/templates/user/mypage_in_event.html
+++ b/src/main/resources/templates/user/mypage_in_event.html
@@ -488,9 +488,14 @@
                                             <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
                                             <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
                                             <!--                                    </div>-->
-                                            <div class="col-5"
+                                            <div th:if="${myInEvent.endDate != null}" class="col-5"
                                                  style="color: #333333; font-size: 0.8rem; font-weight: 530;"
                                                  th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M월 d일').format(myInEvent.startDate)} + ' ~ ' + ${T(java.time.format.DateTimeFormatter).ofPattern('M월 d일').format(myInEvent.endDate)}">
+                                                닉네임
+                                            </div>
+                                            <div th:if="${myInEvent.endDate == null}" class="col-5"
+                                                 style="color: #333333; font-size: 0.8rem; font-weight: 530;"
+                                                 th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M월 d일').format(myInEvent.startDate)}">
                                                 닉네임
                                             </div>
 
@@ -558,9 +563,14 @@
                                             <!--                                    <div class="col-2 p-0 d-flex align-items-center justify-content-center" style="aspect-ratio: 1; border-radius: 5px;">-->
                                             <!--                                        <div th:text="${T(java.time.format.DateTimeFormatter).ofPattern('MM월 yyyy').format(myRctJob.createdDate)}" style="background-color: #8E4B6E; color: white; border-radius: 5px; font-size: 0.8rem; text-align: center;"></div>-->
                                             <!--                                    </div>-->
-                                            <div class="col-4"
+                                            <div th:if="${myInEvent.endDate != null}" class="col-5"
                                                  style="color: #333333; font-size: 0.8rem; font-weight: 530;"
                                                  th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M월 d일').format(myInEvent.startDate)} + ' ~ ' + ${T(java.time.format.DateTimeFormatter).ofPattern('M월 d일').format(myInEvent.endDate)}">
+                                                닉네임
+                                            </div>
+                                            <div th:if="${myInEvent.endDate == null}" class="col-5"
+                                                 style="color: #333333; font-size: 0.8rem; font-weight: 530;"
+                                                 th:text="${T(java.time.format.DateTimeFormatter).ofPattern('M월 d일').format(myInEvent.startDate)}">
                                                 닉네임
                                             </div>
 
@@ -570,7 +580,13 @@
                                             </div>
                                         </div>
                                         <div class="row justify-content-center">
-                                            <div class="col-10" style="color: white;" th:text="${myInEvent.eventNo}">사진
+                                            <div class="col-12 my-3" style="">
+                                                <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
+                                                <img th:unless="${#lists.size(myInEvent.eventFiles) > 0}" src="/images/user/mypage_bg01.jpg" class="card-img-top" alt="기본 썸네일 이미지" style="filter: brightness(1.2);" >
+                                                <!-- 썸네일 이미지 있을때  -->
+                                                <img th:if="${#lists.size(myInEvent.eventFiles) > 0}"
+                                                     th:src="@{/uploadFiles/{fileName}(fileName=${myInEvent.eventFiles.get(0).fileName})}"
+                                                     class="card-img-top" alt="썸네일 이미지">
                                             </div>
                                         </div>
                                         <div class="row" style="padding: 0; margin: 0;">

--- a/src/main/resources/templates/user/mypage_in_journal.html
+++ b/src/main/resources/templates/user/mypage_in_journal.html
@@ -529,7 +529,7 @@
                                         <div class="row justify-content-center">
                                             <div class="col-12 my-3" style="">
                                                 <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                                <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                                <img th:unless="${#lists.size(myInJournal.journalFiles) > 0}" src="/images/user/mypage_bg01.jpg" class="card-img-top" alt="기본 썸네일 이미지" style="filter: brightness(1.2);" >
                                                 <!-- 썸네일 이미지 있을때  -->
                                                 <img th:if="${#lists.size(myInJournal.journalFiles) > 0}"
                                                      th:src="@{/uploadFiles/{fileName}(fileName=${myInJournal.journalFiles.get(0).fileName})}"

--- a/src/main/resources/templates/user/mypage_in_journal.html
+++ b/src/main/resources/templates/user/mypage_in_journal.html
@@ -467,7 +467,7 @@
                                         <div class="row justify-content-center">
                                             <div class="col-12 my-3" style="">
                                                 <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                                <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                                <img th:unless="${#lists.size(myInJournal.journalFiles) > 0}" src="/images/user/mypage_bg01.jpg" class="card-img-top" alt="기본 썸네일 이미지" style="filter: brightness(1.2);" >
                                                 <!-- 썸네일 이미지 있을때  -->
                                                 <img th:if="${#lists.size(myInJournal.journalFiles) > 0}"
                                                      th:src="@{/uploadFiles/{fileName}(fileName=${myInJournal.journalFiles.get(0).fileName})}"

--- a/src/main/resources/templates/user/mypage_in_merchan.html
+++ b/src/main/resources/templates/user/mypage_in_merchan.html
@@ -468,7 +468,7 @@
                                     <div class="col-3 clickable-row"
                                          style="background-color: #FFFFFF; border-radius: 15px; padding: 1.5rem 1.2rem;"
                                          th:each="myInMerchan, iterStat : ${myInMerchans}"
-                                         th:attr="data-href=@{/introduction/merchanDetail(no=${myInMerchan.merchanNo})}"
+                                         th:attr="data-href=@{/introduction/merchan/merchanDetail(merchanNo=${myInMerchan.merchanNo})}"
                                          th:if="${iterStat.index < 3}">
                                         <div class="row justify-content-center">
                                             <div class="col-2 p-0 d-flex align-items-center justify-content-center"

--- a/src/main/resources/templates/user/mypage_in_merchan.html
+++ b/src/main/resources/templates/user/mypage_in_merchan.html
@@ -513,7 +513,7 @@
                                         <div class="row" style="padding: 0; margin: 0;">
                                             <div class="col-9"
                                                  style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
-                                                 th:text="${myInMerchan.discountPrice+'원'}">내용
+                                                 th:text="${myInMerchan.formattedDiscountPrice+'원'}">내용
                                             </div>
                                             <div class="col-3" style="padding: 0; text-align: right;"></div>
                                         </div>
@@ -575,7 +575,7 @@
                                         <div class="row" style="padding: 0; margin: 0;">
                                             <div class="col-9"
                                                  style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
-                                                 th:text="${myInMerchan.discountPrice+'원'}">내용
+                                                 th:text="${myInMerchan.formattedDiscountPrice+'원'}">내용
                                             </div>
                                             <div class="col-3" style="padding: 0; text-align: right;"></div>
                                         </div>

--- a/src/main/resources/templates/user/mypage_in_merchan.html
+++ b/src/main/resources/templates/user/mypage_in_merchan.html
@@ -454,7 +454,7 @@
                                                 </div>
                                                 <div class="col-8"
                                                      style="text-align: right; padding: 0px; margin : 0px;">
-                                                    품절됨
+                                                    할인중
                                                 </div>
                                             </div>
                                         </div>
@@ -513,7 +513,7 @@
                                         <div class="row" style="padding: 0; margin: 0;">
                                             <div class="col-9"
                                                  style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
-                                                 th:text="${myInMerchan.merchanInfo}">내용
+                                                 th:text="${myInMerchan.discountPrice+'원'}">내용
                                             </div>
                                             <div class="col-3" style="padding: 0; text-align: right;"></div>
                                         </div>
@@ -575,7 +575,7 @@
                                         <div class="row" style="padding: 0; margin: 0;">
                                             <div class="col-9"
                                                  style="padding: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis;   color:#BDBDBD; font-size: 0.8rem; "
-                                                 th:text="${myInMerchan.merchanInfo}">내용
+                                                 th:text="${myInMerchan.discountPrice+'원'}">내용
                                             </div>
                                             <div class="col-3" style="padding: 0; text-align: right;"></div>
                                         </div>

--- a/src/main/resources/templates/user/mypage_in_merchan.html
+++ b/src/main/resources/templates/user/mypage_in_merchan.html
@@ -496,7 +496,7 @@
                                         <div class="row justify-content-center">
                                             <div class="col-12 my-3" style="">
                                                 <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                                <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                                <img th:unless="${#lists.size(myInMerchan.merchanFiles) > 0}" src="/images/user/mypage_bg01.jpg" class="card-img-top" alt="기본 썸네일 이미지" style="filter: brightness(1.2);" >
                                                 <!-- 썸네일 이미지 있을때  -->
                                                 <img th:if="${#lists.size(myInMerchan.merchanFiles) > 0}"
                                                      th:src="@{/uploadFiles/{fileName}(fileName=${myInMerchan.merchanFiles.get(0).fileName})}"

--- a/src/main/resources/templates/user/mypage_in_merchan.html
+++ b/src/main/resources/templates/user/mypage_in_merchan.html
@@ -558,7 +558,7 @@
                                         <div class="row justify-content-center">
                                             <div class="col-12 my-3" style="">
                                                 <!-- 썸네일 이미지 없을때 : 기본 썸네일 이미지 -->
-                                                <!--                                        <img th:unless="${#lists.size(event.eventFiles) > 0}" src="/images/introduction/default-thumbnail.png" class="card-img-top" alt="기본 썸네일 이미지">-->
+                                                <img th:unless="${#lists.size(myInMerchan.merchanFiles) > 0}" src="/images/user/mypage_bg01.jpg" class="card-img-top" alt="기본 썸네일 이미지" style="filter: brightness(1.2);" >
                                                 <!-- 썸네일 이미지 있을때  -->
                                                 <img th:if="${#lists.size(myInMerchan.merchanFiles) > 0}"
                                                      th:src="@{/uploadFiles/{fileName}(fileName=${myInMerchan.merchanFiles.get(0).fileName})}"

--- a/src/main/resources/templates/user/mypage_rct_application.html
+++ b/src/main/resources/templates/user/mypage_rct_application.html
@@ -428,9 +428,7 @@
                                                                 th:selected="${orderBy == 'oldestApplication'}">오래된순
                                                         </option>
 
-                                                        <option value="recentedited"
-                                                                th:selected="${orderBy == 'recentedited'}">공고최근수정순
-                                                        </option>
+
                                                         <option value="recent" th:selected="${orderBy == 'recent'}">
                                                             공고최근작성순
                                                         </option>

--- a/src/main/resources/templates/user/mypage_rct_free_orderlist.html
+++ b/src/main/resources/templates/user/mypage_rct_free_orderlist.html
@@ -522,7 +522,7 @@
                                                         class="clickable-row"
                                                         th:attr="data-href=@{/recruit/free/view(no=${myRctFreeOrder.boardNo})}">
                                                         <td th:text="${myRctFreeOrder.orderNo}">주문 번호</td>
-                                                        <td th:text="${myRctFreeOrder.memberNo}">구매자</td>
+                                                        <td th:text="${myRctFreeOrder.nickname}">구매자</td>
                                                         <td th:text="${myRctFreeOrder.boardNo}">구매상품</td>
                                                         <td th:text="${myRctFreeOrder.quantity}">구매 갯수</td>
                                                         <td th:text="${myRctFreeOrder.price}">결제 금액</td>

--- a/src/main/resources/templates/user/mypage_rct_job.html
+++ b/src/main/resources/templates/user/mypage_rct_job.html
@@ -414,9 +414,6 @@
                                                 <label>
                                                     <select class="form-select px-3" name="orderBy"
                                                             onchange="submitForm()">
-                                                        <option value="recentedited"
-                                                                th:selected="${orderBy == 'recentedited'}">최근수정순
-                                                        </option>
                                                         <option value="recent" th:selected="${orderBy == 'recent'}">
                                                             최근작성순
                                                         </option>

--- a/src/main/resources/templates/user/mypage_rct_job_applicationlist.html
+++ b/src/main/resources/templates/user/mypage_rct_job_applicationlist.html
@@ -516,7 +516,7 @@
                                                         class="clickable-row"
                                                         th:attr="data-href=@{/recruit/job/applyView(no=${myRctJobApplication.applyNo})}">
                                                         <td th:text="${myRctJobApplication.applyNo}">지원글 번호</td>
-                                                        <td th:text="${myRctJobApplication.writer}">지원자</td>
+                                                        <td th:text="${myRctJobApplication.applyUserId}">지원자</td>
                                                         <td th:text="${myRctJobApplication.applyTitle}">제목</td>
                                                         <td th:text="${myRctJobApplication.applyCreatedDate}">작성 일자</td>
                                                         <td th:text="${myRctJobApplication.applyCheckStatus}">조회 여부</td>


### PR DESCRIPTION
**[강현구-240820] merge :: 통합테스트 FAIL 해결**
[강현구-240819-02] feat :: 로그인 실패시 알림 메시지 출력
-- 선생님 피드백사항을 반영했습니다.
[강현구-240819-03] fix :: 로그인 실패시 알림 메시지 출력
-- ID-비밀번호 불일치
-- 없는 ID(탈퇴회원 포함)
모두 똑같은 메시지를 출력하도록 설정했습니다.
[강현구-240819-04] feat :: 밸리데이션 체크 추가(생년월일)
-- 생년월일을 오늘 다음날 이후로 지정하는 경우 제출을 막음
[강현구-240819-05] fix :: 프론트작업_프로필사진 타원형으로 나오는 문제 수정
[강현구-240819-06] fix :: 나의소식_좋아요한굿즈
-- 상세페이지 이동 경로 수정했습니다.
[강현구-240819-07] fix :: 나의소셜_좋아요한리뷰
-- 정렬기준 수정했습니다. (createdDate -> reviewNo)
[강현구-240819-08] fix :: 나의소식_좋아요한행사
-- 정렬기준(최신행사순/오래된행사순) 수정했습니다. (eventNo -> startDate)
[강현구-240819-09] fix :: 나의채용_공고지원서/프리랜서주문
-- 공고의 지원서 목록 : 구매자 아이디를 출력하도록 하였습니다.
-- 프리랜서의 주문 목록 : 구매자 닉네임을 출력하도록 하였습니다.
[강현구-240819-10] fix :: 나의채용_내가올린공고/나의지원서
-- 내가올린공고/나의지원서 : 마감임박순 '미정'에 해당되는 아이템을 맨 뒤쪽에 정렬되도록 하였습니다.
-- 최근수정순/공고최근수정순 : 정렬기준에서 제외하였습니다.
[강현구-240819-11] fix ::
나의소식_좋아요한굿즈
-- 토글 필터의 기준을 '할인중'인 품목으로 바꾸었습니다.
-- 상품 내용 대신 '판매가'를 표시했습니다.
[강현구-240819-12] fix ::
나의소식_좋아요한굿즈
-- 상품 내용 대신 '판매가'를 표시했습니다. (금액표시로 바꿈)
[강현구-240819-13] chore :: 프론트 수정
-- 마이페이지_나의소식 3개페이지 : 썸네일이미지 만들어서 구조 통일감 갖췄습니다.
-- 마이페이지_대시보드 : 날짜부분 제거했습니다.
[강현구-240819-14] fix :: 마이페이지_나의소식 수정
-- 좋아요한 행사 : endDate가 null일 때 문제 해결
-- 기본 썸네일이미지 누락된 부분 수정